### PR TITLE
エリアパーツを追加

### DIFF
--- a/backend/src/const.ts
+++ b/backend/src/const.ts
@@ -3,6 +3,7 @@ export const PART_TYPE = {
   CARD: 'card',
   HAND: 'hand',
   DECK: 'deck',
+  AREA: 'area',
 };
 
 export const PROTOTYPE_TYPE = {

--- a/frontend/src/features/prototype/components/atoms/Part.tsx
+++ b/frontend/src/features/prototype/components/atoms/Part.tsx
@@ -97,8 +97,10 @@ const Part = forwardRef<PartHandle, PartProps>(
           onTransitionEnd={() => setIsReversing(false)}
           style={{
             stroke: 'gray',
+            strokeDasharray: part.type === PART_TYPE.AREA ? '4' : 'none',
             fill: part.color || 'white',
             // fill: `url(#bgPattern)`, // 画像設定その2
+            opacity: part.type === PART_TYPE.AREA ? 0.6 : 1,
             transform: `
             translate(${part.position.x}px, ${part.position.y}px)
             translate(${part.width / 2}px, ${part.height / 2}px)

--- a/frontend/src/features/prototype/components/molecules/PartCreateSidebar.tsx
+++ b/frontend/src/features/prototype/components/molecules/PartCreateSidebar.tsx
@@ -2,6 +2,7 @@
 
 import { useRouter } from 'next/navigation';
 import { useState } from 'react';
+import { BiArea } from 'react-icons/bi';
 import {
   Gi3dMeeple,
   GiCard10Clubs,
@@ -10,7 +11,6 @@ import {
 } from 'react-icons/gi';
 import { IoArrowBack } from 'react-icons/io5';
 import { PiSidebarSimpleThin } from 'react-icons/pi';
-import { BiArea } from 'react-icons/bi';
 
 import TextIconButton from '@/components/atoms/TextIconButton';
 import { PART_DEFAULT_CONFIG, PART_TYPE } from '@/features/prototype/const';

--- a/frontend/src/features/prototype/components/molecules/PartCreateSidebar.tsx
+++ b/frontend/src/features/prototype/components/molecules/PartCreateSidebar.tsx
@@ -10,6 +10,7 @@ import {
 } from 'react-icons/gi';
 import { IoArrowBack } from 'react-icons/io5';
 import { PiSidebarSimpleThin } from 'react-icons/pi';
+import { BiArea } from 'react-icons/bi';
 
 import TextIconButton from '@/components/atoms/TextIconButton';
 import { PART_DEFAULT_CONFIG, PART_TYPE } from '@/features/prototype/const';
@@ -129,6 +130,8 @@ export default function PartCreateSidebar({
                   <GiPokerHand className="h-4 w-4 text-gray-500" />
                 ) : part.id === 'deck' ? (
                   <GiStoneBlock className="h-4 w-4 text-gray-500" />
+                ) : part.id === 'area' ? (
+                  <BiArea className="h-4 w-4 text-gray-500" />
                 ) : null;
 
               return (

--- a/frontend/src/features/prototype/const.ts
+++ b/frontend/src/features/prototype/const.ts
@@ -3,6 +3,7 @@ export const PART_TYPE = {
   CARD: 'card',
   HAND: 'hand',
   DECK: 'deck',
+  AREA: 'area',
 };
 
 export const PROTOTYPE_TYPE = {
@@ -52,6 +53,15 @@ export const PART_DEFAULT_CONFIG = {
     color: '#FFFFFF',
     configurableTypeAsChild: ['card'],
     canReverseCardOnDeck: false,
+  },
+  AREA: {
+    id: 'area',
+    name: 'エリア',
+    width: 300,
+    height: 200,
+    description: '',
+    color: '#FFFFFF',
+    configurableTypeAsChild: ['card', 'token', 'hand', 'deck'],
   },
 };
 

--- a/frontend/src/features/prototype/helpers/partHelper.ts
+++ b/frontend/src/features/prototype/helpers/partHelper.ts
@@ -45,8 +45,8 @@ export const needsParentUpdate = (
   newPosition: { x: number; y: number }
 ) => {
   // ドロップ位置の真下にある親になりえるパーツを探す
-  const parentParts = parts.filter((part) =>
-    part.configurableTypeAsChild.includes(PART_TYPE.CARD)
+  const parentParts = parts.filter((part) => 
+    part.configurableTypeAsChild.includes(draggingPart.type)
   );
   const targetParentPart = parentParts.find((parentPart) => {
     const parentPartPosition = {

--- a/frontend/src/features/prototype/helpers/partHelper.ts
+++ b/frontend/src/features/prototype/helpers/partHelper.ts
@@ -1,7 +1,5 @@
 import { Part } from '@/types/models';
 
-import { PART_TYPE } from '../const';
-
 /**
  * パーツが他のパーツの上にあるかどうかを判定
  * @param partPosition - パーツの位置


### PR DESCRIPTION
# 事前確認(共通)

- [x] PR 前に動作確認をしたか
- [x] 機密情報を含んでいないか

# やったこと<!-- このプルリクエストでやったことを書く -->
- エリアパーツを追加

# やらないこと<!-- このプルリクエストでやってもおかしくないけどやらなかったことを書く -->
- opacity やdashed のパラメータを画面から設定できるようにすること　
　[起票済み](https://github.com/orgs/habitat-hub/projects/1/views/1?pane=issue&itemId=96426312&issue=habitat-hub%7Cboard-game-prototype%7C76)

# 懸念点や注意点<!-- このプルリクエストにおける懸念点や注意点を書く -->
-   「ドロップ位置の真下にある親になりえるパーツを探す」実装箇所で気になる場所があったので修正に含めました。

# その他<!-- このプルリクエストで上記の項目以外に伝えるべきことを書く -->

特になし


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - 新しいパートタイプ「エリア」を追加し、幅300、高さ200、白色などの初期設定が適用されるようになりました。
  - サイドバーに「エリア」用アイコンを導入し、視認性・識別性が向上しました。
  - 「エリア」パートは対象の場合、独自のストロークパターンと不透明度が適用され、視覚表現が改善されました。
- **リファクタ**
  - ドラッグ時の親パート選択ロジックを動的に改善し、操作体験が向上しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->