### PR TITLE
Fix prototype duplication and improve UI

### DIFF
--- a/backend/src/routes/prototype.ts
+++ b/backend/src/routes/prototype.ts
@@ -696,12 +696,23 @@ router.post(
         return;
       }
 
+      // 複製元のプロトタイプの最初のバージョンを取得
+      const sourceVersion = await PrototypeVersionModel.findOne({
+        where: { prototypeId },
+        order: [['createdAt', 'ASC']],
+      });
+
+      if (!sourceVersion) {
+        res.status(404).json({ error: 'バージョンが見つかりません' });
+        return;
+      }
+
       await createPrototype({
         userId: prototype.userId,
         name: `${prototype.name} - 複製版`,
         type: 'EDIT',
         groupId: null,
-        editPrototypeDefaultVersionId: null,
+        editPrototypeDefaultVersionId: sourceVersion.id,
         minPlayers: prototype.minPlayers,
         maxPlayers: prototype.maxPlayers,
         transaction,

--- a/frontend/src/features/prototype/components/organisms/GroupPrototypeList.tsx
+++ b/frontend/src/features/prototype/components/organisms/GroupPrototypeList.tsx
@@ -4,7 +4,13 @@ import Link from 'next/link';
 import { useParams, useRouter } from 'next/navigation';
 import React, { useState, useEffect, useCallback } from 'react';
 import { BsDoorOpenFill } from 'react-icons/bs';
-import { FaCheck, FaPenToSquare, FaUserPlus, FaEye } from 'react-icons/fa6';
+import {
+  FaCheck,
+  FaPenToSquare,
+  FaUserPlus,
+  FaEye,
+  FaCopy,
+} from 'react-icons/fa6';
 import { HiOutlinePencilAlt } from 'react-icons/hi';
 import { IoAdd, IoArrowBack, IoTrash } from 'react-icons/io5';
 import { TbVersions } from 'react-icons/tb';
@@ -26,6 +32,7 @@ const GroupPrototypeList: React.FC = () => {
     deleteVersion,
     updatePrototype,
     getAccessUsersByGroup,
+    duplicatePrototype,
   } = usePrototypes();
 
   // グループID
@@ -245,6 +252,19 @@ const GroupPrototypeList: React.FC = () => {
     }
   };
 
+  /**
+   * プロトタイプを複製する
+   * @param prototypeId プロトタイプID
+   */
+  const handleDuplicate = async (prototypeId: string) => {
+    try {
+      await duplicatePrototype(prototypeId);
+      router.push('/prototypes'); // 複製後はプロトタイプ一覧へ
+    } catch (error) {
+      console.error('Error duplicating prototype:', error);
+    }
+  };
+
   // プロトタイプが存在しない場合
   if (!prototype || !prototype.edit) return null;
 
@@ -306,9 +326,34 @@ const GroupPrototypeList: React.FC = () => {
         )}
       </div>
 
-      {/* 他のユーザーを招待するボタン */}
-      <div className="flex justify-end mb-4">
-        {/* 既存のボタンを削除し、参加ユーザーエリア内に移動 */}
+      {/* 複製・招待ボタン */}
+      <div className="flex justify-end mb-4 gap-2">
+        {prototype.edit && user?.id === prototype.edit.prototype.userId ? (
+          <button
+            onClick={() =>
+              prototype.edit && handleDuplicate(prototype.edit.prototype.id)
+            }
+            className="flex items-center gap-1 px-3 py-1.5 text-sm text-wood hover:text-header rounded-md hover:bg-wood-lightest/20 transition-colors border border-wood-light/20"
+            title="プロトタイプを複製"
+          >
+            <FaCopy className="w-4 h-4" />
+            <span>複製</span>
+          </button>
+        ) : (
+          <div className="relative group">
+            <button
+              disabled
+              className="flex items-center gap-1 px-3 py-1.5 text-sm text-wood-light/50 cursor-not-allowed rounded-md border border-wood-light/20"
+              title="プロトタイプを複製"
+            >
+              <FaCopy className="w-4 h-4" />
+              <span>複製</span>
+            </button>
+            <div className="absolute bottom-full mb-2 right-0 w-48 bg-gray-800 text-white text-xs rounded py-1 px-2 opacity-0 group-hover:opacity-100 transition-opacity duration-300 pointer-events-none z-50">
+              プロトタイプのオーナーのみが複製できます
+            </div>
+          </div>
+        )}
       </div>
 
       {/* プロトタイプの基本情報 */}

--- a/frontend/src/features/prototype/components/organisms/GroupPrototypeList.tsx
+++ b/frontend/src/features/prototype/components/organisms/GroupPrototypeList.tsx
@@ -505,13 +505,9 @@ const GroupPrototypeList: React.FC = () => {
               </p>
             </div>
           </div>
-        </div>
-      </div>
 
-      <div className="mb-8">
-        <div className="grid grid-cols-1 gap-4">
           {/* プロトタイプ編集ボタン */}
-          <div className="flex flex-col gap-4">
+          <div className="flex flex-col gap-4 mt-6">
             <button
               onClick={() => {
                 if (!prototype.edit) return;

--- a/frontend/src/features/prototype/components/organisms/GroupPrototypeList.tsx
+++ b/frontend/src/features/prototype/components/organisms/GroupPrototypeList.tsx
@@ -359,6 +359,9 @@ const GroupPrototypeList: React.FC = () => {
       {/* プロトタイプの基本情報 */}
       <div className="mb-6 overflow-hidden rounded-xl bg-gradient-to-r from-content via-content to-content-secondary shadow-lg border border-wood-lightest/30">
         <div className="p-6">
+          <h2 className="text-xl font-bold text-wood-darkest mb-4 border-b border-wood-light/30 pb-2">
+            基本情報
+          </h2>
           <div className="flex flex-col md:flex-row gap-6">
             <div className="flex-1 bg-white/80 rounded-xl p-5 shadow-inner border border-wood-lightest/40">
               <h3 className="text-sm uppercase tracking-wide text-wood-dark/70 mb-2 font-medium">
@@ -536,7 +539,10 @@ const GroupPrototypeList: React.FC = () => {
       {/* プレイルーム */}
       <div className="mt-12">
         <div className="bg-wood-lightest/30 rounded-xl p-5 mb-6 border border-wood-light/30 shadow-md">
-          <div className="flex justify-start mb-6 border-b border-wood-light/30 pb-6 w-full">
+          <h2 className="text-xl font-bold text-wood-darkest mb-4 border-b border-wood-light/30 pb-2">
+            プレイルーム
+          </h2>
+          <div className="flex justify-start w-full">
             <button
               onClick={() => {
                 if (!prototype.edit) return;

--- a/frontend/src/features/prototype/components/organisms/GroupPrototypeList.tsx
+++ b/frontend/src/features/prototype/components/organisms/GroupPrototypeList.tsx
@@ -334,7 +334,7 @@ const GroupPrototypeList: React.FC = () => {
               prototype.edit && handleDuplicate(prototype.edit.prototype.id)
             }
             className="flex items-center gap-1 px-3 py-1.5 text-sm text-wood hover:text-header rounded-md hover:bg-wood-lightest/20 transition-colors border border-wood-light/20"
-            title="プロトタイプを複製"
+            title="プロトタイプ複製"
           >
             <FaCopy className="w-4 h-4" />
             <span>複製</span>
@@ -344,7 +344,7 @@ const GroupPrototypeList: React.FC = () => {
             <button
               disabled
               className="flex items-center gap-1 px-3 py-1.5 text-sm text-wood-light/50 cursor-not-allowed rounded-md border border-wood-light/20"
-              title="プロトタイプを複製"
+              title="プロトタイプ複製"
             >
               <FaCopy className="w-4 h-4" />
               <span>複製</span>
@@ -356,11 +356,11 @@ const GroupPrototypeList: React.FC = () => {
         )}
       </div>
 
-      {/* プロトタイプの基本情報 */}
+      {/* このプロトタイプについて */}
       <div className="mb-6 overflow-hidden rounded-xl bg-gradient-to-r from-content via-content to-content-secondary shadow-lg border border-wood-lightest/30">
         <div className="p-6">
           <h2 className="text-xl font-bold text-wood-darkest mb-4 border-b border-wood-light/30 pb-2">
-            基本情報
+            このプロトタイプについて
           </h2>
           <div className="flex flex-col md:flex-row gap-6">
             <div className="flex-1 bg-white/80 rounded-xl p-5 shadow-inner border border-wood-lightest/40">
@@ -542,7 +542,7 @@ const GroupPrototypeList: React.FC = () => {
           <h2 className="text-xl font-bold text-wood-darkest mb-4 border-b border-wood-light/30 pb-2">
             プレイルーム
           </h2>
-          <div className="flex justify-start w-full">
+          <div className="flex justify-start w-full mb-6">
             <button
               onClick={() => {
                 if (!prototype.edit) return;
@@ -561,8 +561,12 @@ const GroupPrototypeList: React.FC = () => {
                       新しいバージョン
                     </span>
                     <span className="font-medium text-wood-dark group-hover:text-header transition-colors">
-                      プロトタイプバージョン作成
+                      今のプロトタイプを保存
                     </span>
+                    <p className="text-xs mt-1 max-w-md text-wood-dark/70 group-hover:text-header/70 transition-colors">
+                      <span className="inline-block mr-1">💡</span>
+                      プレイルームを作成するには、まず今のプロトタイプを保存します
+                    </p>
                   </div>
                 </div>
               </div>
@@ -571,12 +575,7 @@ const GroupPrototypeList: React.FC = () => {
 
           {prototype.preview.length === 0 ? (
             <div className="text-center py-8 text-wood-dark">
-              <p className="mb-2">プレイルームがありません</p>
-              <p className="text-xs text-wood-dark/70 italic max-w-md mx-auto">
-                編集したプロトタイプをプレイできるようにするには
-                <br />
-                「プロトタイプバージョン作成」ボタンを押してください
-              </p>
+              <p className="mb-2">バージョン・プレイルームがありません</p>
             </div>
           ) : (
             [...prototype.preview]

--- a/frontend/src/features/prototype/components/organisms/PrototypeList.tsx
+++ b/frontend/src/features/prototype/components/organisms/PrototypeList.tsx
@@ -452,14 +452,30 @@ const PrototypeList: React.FC = () => {
                         <FaBoxOpen className="w-4 h-4" />
                         <span>開く</span>
                       </Link>
-                      <button
-                        onClick={(e) => handleDuplicate(id, e)}
-                        className="flex items-center gap-1 px-3 py-1.5 text-sm text-wood hover:text-header rounded-md hover:bg-wood-lightest/20 transition-colors border border-wood-light/20"
-                        title="プロトタイプを複製"
-                      >
-                        <FaCopy className="w-4 h-4" />
-                        <span>複製</span>
-                      </button>
+                      {userContext?.user?.id === userId ? (
+                        <button
+                          onClick={(e) => handleDuplicate(id, e)}
+                          className="flex items-center gap-1 px-3 py-1.5 text-sm text-wood hover:text-header rounded-md hover:bg-wood-lightest/20 transition-colors border border-wood-light/20"
+                          title="プロトタイプを複製"
+                        >
+                          <FaCopy className="w-4 h-4" />
+                          <span>複製</span>
+                        </button>
+                      ) : (
+                        <div className="relative group">
+                          <button
+                            disabled
+                            className="flex items-center gap-1 px-3 py-1.5 text-sm text-wood-light/50 cursor-not-allowed rounded-md border border-wood-light/20"
+                            title="プロトタイプを複製"
+                          >
+                            <FaCopy className="w-4 h-4" />
+                            <span>複製</span>
+                          </button>
+                          <div className="absolute bottom-full mb-2 right-0 w-48 bg-gray-800 text-white text-xs rounded py-1 px-2 opacity-0 group-hover:opacity-100 transition-opacity duration-300 pointer-events-none z-50">
+                            プロトタイプのオーナーのみが複製できます
+                          </div>
+                        </div>
+                      )}
                     </td>
                   </tr>
                 );

--- a/frontend/src/features/prototype/components/organisms/PrototypeList.tsx
+++ b/frontend/src/features/prototype/components/organisms/PrototypeList.tsx
@@ -8,7 +8,7 @@ import React, {
   useMemo,
   useContext,
 } from 'react';
-import { FaCheck, FaCopy } from 'react-icons/fa';
+import { FaCheck } from 'react-icons/fa';
 import { FaSort, FaSortDown, FaSortUp } from 'react-icons/fa';
 import { FaBoxOpen, FaPenToSquare, FaPlus } from 'react-icons/fa6';
 
@@ -35,8 +35,7 @@ type SortOrder = 'asc' | 'desc';
  * @state isLoading - データ取得中のローディング状態を管理するState。
  */
 const PrototypeList: React.FC = () => {
-  const { getPrototypes, duplicatePrototype, updatePrototype } =
-    usePrototypes();
+  const { getPrototypes, updatePrototype } = usePrototypes();
   // UserContextからユーザー情報を取得
   const userContext = useContext(UserContext);
   // ローディング状態を管理するState
@@ -263,17 +262,6 @@ const PrototypeList: React.FC = () => {
     );
   };
 
-  // プロトタイプを複製する
-  const handleDuplicate = async (prototypeId: string, e: React.MouseEvent) => {
-    e.preventDefault(); // リンククリックのイベントバブリングを防止
-    try {
-      await duplicatePrototype(prototypeId);
-      fetchPrototypes(); // 一覧を更新
-    } catch (error) {
-      console.error('Error duplicating prototype:', error);
-    }
-  };
-
   // ソートアイコン
   const getSortIcon = (key: SortKey) => {
     if (sort.key !== key) return <FaSort className="w-4 h-4" />;
@@ -315,7 +303,7 @@ const PrototypeList: React.FC = () => {
                 </button>
               </th>
               <th className="text-left p-4 w-32">作成者</th>
-              <th className="text-center p-4 w-48">アクション</th>
+              <th className="text-center p-4 w-30"></th>
             </tr>
           </thead>
           <tbody className="divide-y divide-wood-lightest/20">
@@ -452,30 +440,6 @@ const PrototypeList: React.FC = () => {
                         <FaBoxOpen className="w-4 h-4" />
                         <span>開く</span>
                       </Link>
-                      {userContext?.user?.id === userId ? (
-                        <button
-                          onClick={(e) => handleDuplicate(id, e)}
-                          className="flex items-center gap-1 px-3 py-1.5 text-sm text-wood hover:text-header rounded-md hover:bg-wood-lightest/20 transition-colors border border-wood-light/20"
-                          title="プロトタイプを複製"
-                        >
-                          <FaCopy className="w-4 h-4" />
-                          <span>複製</span>
-                        </button>
-                      ) : (
-                        <div className="relative group">
-                          <button
-                            disabled
-                            className="flex items-center gap-1 px-3 py-1.5 text-sm text-wood-light/50 cursor-not-allowed rounded-md border border-wood-light/20"
-                            title="プロトタイプを複製"
-                          >
-                            <FaCopy className="w-4 h-4" />
-                            <span>複製</span>
-                          </button>
-                          <div className="absolute bottom-full mb-2 right-0 w-48 bg-gray-800 text-white text-xs rounded py-1 px-2 opacity-0 group-hover:opacity-100 transition-opacity duration-300 pointer-events-none z-50">
-                            プロトタイプのオーナーのみが複製できます
-                          </div>
-                        </div>
-                      )}
                     </td>
                   </tr>
                 );


### PR DESCRIPTION
# 事前確認(共通)

- [x] PR 前に動作確認をしたか
- [x] 機密情報を含んでいないか

# やったこと<!-- このプルリクエストでやったことを書く -->

This pull request introduces a new feature for duplicating prototypes and refines the user interface in several areas. The most significant changes include the backend implementation for retrieving the source version of a prototype, the addition of a "Duplicate" button in the frontend, and updates to the user interface for better clarity and usability.

### Backend Changes:
* **Prototype duplication logic**: Added functionality in `backend/src/routes/prototype.ts` to retrieve the first version of the source prototype and set it as the default version for the duplicated prototype. If no source version is found, a 404 error is returned.

### Frontend Changes:
#### New Feature: Prototype Duplication
* **"Duplicate" button**: Added a "Duplicate" button to the `GroupPrototypeList` component, allowing users to duplicate prototypes if they are the owner. The button includes a tooltip for non-owners explaining the restriction.
* **Duplication handler**: Introduced a `handleDuplicate` function in `GroupPrototypeList` to manage the duplication process and navigate to the prototypes list upon success.
* **Icon update**: Imported the `FaCopy` icon for use in the duplication button.

#### UI/UX Enhancements
* **Section headers**: Added clear section headers (e.g., "このプロトタイプについて" and "プレイルーム") for better visual organization in `GroupPrototypeList`. [[1]](diffhunk://#diff-313784a9f8118d01366865907201d6a565a8002a9184ad8346261558537ede24L498-R545) [[2]](diffhunk://#diff-313784a9f8118d01366865907201d6a565a8002a9184ad8346261558537ede24L463-R513)
* **Improved tooltips and instructions**: Updated button tooltips and added explanatory text to guide users, such as clarifying the process for saving prototypes before creating playrooms. [[1]](diffhunk://#diff-313784a9f8118d01366865907201d6a565a8002a9184ad8346261558537ede24L517-R569) [[2]](diffhunk://#diff-313784a9f8118d01366865907201d6a565a8002a9184ad8346261558537ede24L527-R578)

#### Code Cleanup
* **Removed duplication logic from `PrototypeList`**: Removed the `handleDuplicate` function and associated button from the `PrototypeList` component, consolidating duplication functionality into `GroupPrototypeList`. [[1]](diffhunk://#diff-4da77a990f75260b60a88921266b77adf7ae3a218e84778aa9707c61818a865dL266-L276) [[2]](diffhunk://#diff-4da77a990f75260b60a88921266b77adf7ae3a218e84778aa9707c61818a865dL455-L462)
* **Unused imports**: Removed the unused `FaCopy` import from `PrototypeList`.

# やらないこと<!-- このプルリクエストでやってもおかしくないけどやらなかったことを書く -->

特になし

# 懸念点や注意点<!-- このプルリクエストにおける懸念点や注意点を書く -->

特になし

# その他<!-- このプルリクエストで上記の項目以外に伝えるべきことを書く -->

特になし


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - プロトタイプ詳細画面に「複製」ボタンを追加しました。オーナーのみが利用可能で、ツールチップで権限について説明されます。
  - 「このプロトタイプについて」や「プレイルーム」セクションの見出しやボタンのラベル・説明文がより分かりやすく改善されました。

- **変更・改善**
  - プロトタイプ一覧画面から「複製」機能を削除しました。
  - UIのレイアウトや文言を一部調整しました。

- **バグ修正**
  - プロトタイプ複製時、元プロトタイプの最初のバージョンが存在しない場合にエラーが表示されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->