### PR TITLE
Add GitHub Actions workflow to automate PR creation from develop to main branch

### DIFF
--- a/.github/workflows/create_develop_to_main.yml
+++ b/.github/workflows/create_develop_to_main.yml
@@ -4,9 +4,17 @@ on:
   push:
     branches:
       - develop
+  workflow_dispatch: # Allow manual triggering for maintenance and debugging
+
+permissions:
+  contents: read
+  pull-requests: write
 
 jobs:
   create_pr:
+    concurrency:
+      group: 'create-develop-to-main'
+      cancel-in-progress: true
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -14,13 +22,13 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Check for existing PR
+      - name: Check if PR exists
         id: check_pr
         uses: actions/github-script@v6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          result-encoding: string
           script: |
-            // develop → main のオープンPRを取得
             const { data: pulls } = await github.rest.pulls.list({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -28,11 +36,16 @@ jobs:
               head: `${context.repo.owner}:develop`,
               base: 'main'
             });
-            // true／false を return すると、steps.check_pr.outputs.result に格納される
-            return pulls.length > 0;
+            
+            if (pulls.length > 0) {
+              console.log('PR already exists. Skipping PR creation.');
+              return 'true';
+            }
+            
+            return 'false';
 
       - name: Create Pull Request
-        if: ${{ steps.check_pr.outputs.result == 'false' }}
+        if: steps.check_pr.outputs.result == 'false'
         uses: actions/github-script@v6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -45,4 +58,5 @@ jobs:
               head: 'develop',
               base: 'main'
             });
+            
             console.log(`Pull request created: ${pull.html_url}`);

--- a/.github/workflows/create_develop_to_main.yml
+++ b/.github/workflows/create_develop_to_main.yml
@@ -1,0 +1,48 @@
+name: Create Develop to Main PR
+
+on:
+  push:
+    branches:
+      - develop
+
+jobs:
+  create_pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Check for existing PR
+        id: check_pr
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            // develop → main のオープンPRを取得
+            const { data: pulls } = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              head: `${context.repo.owner}:develop`,
+              base: 'main'
+            });
+            // true／false を return すると、steps.check_pr.outputs.result に格納される
+            return pulls.length > 0;
+
+      - name: Create Pull Request
+        if: ${{ steps.check_pr.outputs.result == 'false' }}
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { data: pull } = await github.rest.pulls.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: 'Develop to Main',
+              body: 'Automatically created PR from develop to main branch',
+              head: 'develop',
+              base: 'main'
+            });
+            console.log(`Pull request created: ${pull.html_url}`);


### PR DESCRIPTION
# 事前確認(共通)

- [x] PR 前に動作確認をしたか
- [x] 機密情報を含んでいないか

# やったこと<!-- このプルリクエストでやったことを書く -->

This pull request introduces a new GitHub Actions workflow to automate the creation of pull requests from the `develop` branch to the `main` branch whenever changes are pushed to `develop`.

### New GitHub Actions Workflow:

* [`.github/workflows/create_develop_to_main.yml`](diffhunk://#diff-984e03cbd82640f75c2299a273576646c2097ce374a44c4ff5a6afd95e761fa9R1-R48): Added a workflow named "Create Develop to Main PR" that triggers on pushes to the `develop` branch. It checks for an existing open pull request from `develop` to `main` and creates one if none exists.

# やらないこと<!-- このプルリクエストでやってもおかしくないけどやらなかったことを書く -->

特になし

# 懸念点や注意点<!-- このプルリクエストにおける懸念点や注意点を書く -->

特になし

# その他<!-- このプルリクエストで上記の項目以外に伝えるべきことを書く -->

特になし


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - `develop`ブランチから`main`ブランチへのプルリクエストを自動作成するワークフローを追加しました。同時に1件のみオープンするよう管理されます。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->