### PR TITLE
Update GitHub Actions workflow to use PAT_GITHUB_TOKEN for authentication

### DIFF
--- a/.github/workflows/create_develop_to_main.yml
+++ b/.github/workflows/create_develop_to_main.yml
@@ -26,7 +26,7 @@ jobs:
         id: check_pr
         uses: actions/github-script@v6
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.PAT_GITHUB_TOKEN }}
           result-encoding: string
           script: |
             const { data: pulls } = await github.rest.pulls.list({
@@ -48,7 +48,7 @@ jobs:
         if: steps.check_pr.outputs.result == 'false'
         uses: actions/github-script@v6
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.PAT_GITHUB_TOKEN }}
           script: |
             const { data: pull } = await github.rest.pulls.create({
               owner: context.repo.owner,


### PR DESCRIPTION
# 事前確認(共通)

- [x] PR 前に動作確認をしたか
- [x] 機密情報を含んでいないか

# やったこと<!-- このプルリクエストでやったことを書く -->

This pull request updates the GitHub Actions workflow to enhance security by replacing the default `GITHUB_TOKEN` with a personal access token (`PAT_GITHUB_TOKEN`) for authentication in API calls.

Security improvements in GitHub Actions workflow:

* [`.github/workflows/create_develop_to_main.yml`](diffhunk://#diff-984e03cbd82640f75c2299a273576646c2097ce374a44c4ff5a6afd95e761fa9L29-R29): Replaced `github-token: ${{ secrets.GITHUB_TOKEN }}` with `github-token: ${{ secrets.PAT_GITHUB_TOKEN }}` in two steps (`check_pr` and pull request creation) to use a personal access token for API authentication. [[1]](diffhunk://#diff-984e03cbd82640f75c2299a273576646c2097ce374a44c4ff5a6afd95e761fa9L29-R29) [[2]](diffhunk://#diff-984e03cbd82640f75c2299a273576646c2097ce374a44c4ff5a6afd95e761fa9L51-R51)

# やらないこと<!-- このプルリクエストでやってもおかしくないけどやらなかったことを書く -->

特になし

# 懸念点や注意点<!-- このプルリクエストにおける懸念点や注意点を書く -->

特になし

# その他<!-- このプルリクエストで上記の項目以外に伝えるべきことを書く -->

特になし
