### PR TITLE
fix: standardize PR title casing from 'Develop to Main' to 'develop to main'

### DIFF
--- a/.github/workflows/create_develop_to_main.yml
+++ b/.github/workflows/create_develop_to_main.yml
@@ -1,4 +1,4 @@
-name: Create Develop to Main PR
+name: Create develop to main PR
 
 on:
   push:
@@ -53,7 +53,7 @@ jobs:
             const { data: pull } = await github.rest.pulls.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              title: 'Develop to Main',
+              title: 'develop to main',
               body: 'Automatically created PR from develop to main branch',
               head: 'develop',
               base: 'main'


### PR DESCRIPTION


# 事前確認(共通)

- [x] PR 前に動作確認をしたか
- [x] 機密情報を含んでいないか

# やったこと<!-- このプルリクエストでやったことを書く -->

This pull request makes minor updates to the `.github/workflows/create_develop_to_main.yml` file to standardize capitalization in the workflow name and pull request title.

Changes include:

* Standardized the capitalization of the workflow name from "Create Develop to Main PR" to "Create develop to main PR." (`[.github/workflows/create_develop_to_main.ymlL1-R1](diffhunk://#diff-984e03cbd82640f75c2299a273576646c2097ce374a44c4ff5a6afd95e761fa9L1-R1)`)
* Updated the pull request title in the workflow script from "Develop to Main" to "develop to main" to match the new capitalization style. (`[.github/workflows/create_develop_to_main.ymlL56-R56](diffhunk://#diff-984e03cbd82640f75c2299a273576646c2097ce374a44c4ff5a6afd95e761fa9L56-R56)`)

# やらないこと<!-- このプルリクエストでやってもおかしくないけどやらなかったことを書く -->

特になし

# 懸念点や注意点<!-- このプルリクエストにおける懸念点や注意点を書く -->

特になし

# その他<!-- このプルリクエストで上記の項目以外に伝えるべきことを書く -->

特になし
