### PR TITLE
#129 数量セレクタのエラー

### DIFF
--- a/frontend/src/features/prototype/components/molecules/PartPropertySidebar.tsx
+++ b/frontend/src/features/prototype/components/molecules/PartPropertySidebar.tsx
@@ -187,7 +187,7 @@ export default function PartPropertySidebar({
                       type: 'UPDATE_PART',
                       payload: {
                         partId: selectedPart.id,
-                        updatePart: { position: { x: number } },
+                        updatePart: { position: { x: number, y: selectedPart.position.y} },
                       },
                     });
                   }}
@@ -201,7 +201,7 @@ export default function PartPropertySidebar({
                       type: 'UPDATE_PART',
                       payload: {
                         partId: selectedPart.id,
-                        updatePart: { position: { y: number } },
+                        updatePart: { position: { x: selectedPart.position.x, y: number } },
                       },
                     });
                   }}


### PR DESCRIPTION
# 事前確認(共通)

- [x] PR 前に動作確認をしたか
- [x] 機密情報を含んでいないか

# やったこと<!-- このプルリクエストでやったことを書く -->
座標の数量セレクタを手動で操作すると座標がバグってしまう現象を修正

# やらないこと<!-- このプルリクエストでやってもおかしくないけどやらなかったことを書く -->
特になし

# 懸念点や注意点<!-- このプルリクエストにおける懸念点や注意点を書く -->
特になし

# その他<!-- このプルリクエストで上記の項目以外に伝えるべきことを書く -->
特になし


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **バグ修正**
  - パーツの位置をサイドバーで更新する際、x座標またはy座標を変更した場合でも両方の座標が常に正しく更新されるようになりました。これにより、位置情報の一部が欠落する問題が解消されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->