### PR TITLE
Remove players update feature from prototype list

### DIFF
--- a/frontend/src/features/prototype/components/organisms/PrototypeList.tsx
+++ b/frontend/src/features/prototype/components/organisms/PrototypeList.tsx
@@ -85,8 +85,6 @@ const PrototypeList: React.FC = () => {
       // 名前だけを更新
       await updatePrototype(nameEditingId, {
         name: editedName,
-        minPlayers: prototype.minPlayers,
-        maxPlayers: prototype.maxPlayers,
       });
 
       // ローカルの状態を更新

--- a/frontend/src/features/prototype/components/organisms/PrototypeList.tsx
+++ b/frontend/src/features/prototype/components/organisms/PrototypeList.tsx
@@ -15,7 +15,6 @@ import { FaBoxOpen, FaPenToSquare, FaPlus } from 'react-icons/fa6';
 import { usePrototypes } from '@/api/hooks/usePrototypes';
 import { Prototype } from '@/api/types';
 import { UserContext } from '@/contexts/UserContext';
-import { PLAYERS_MIN, PLAYERS_MAX } from '@/features/prototype/const';
 import formatDate from '@/utils/dateFormat';
 
 import EmptyPrototypeList from '../molecules/EmptyPrototypeList';
@@ -27,10 +26,7 @@ type SortOrder = 'asc' | 'desc';
  * PrototypeListコンポーネントで使用される各種Stateの説明:
  *
  * @state nameEditingId - 現在プロトタイプ名を編集中のIDを管理するState。
- * @state playersEditingId - 現在プレイヤー人数を編集中のIDを管理するState。
  * @state editedName - 編集中のプロトタイプの名前を保持するState。
- * @state editedMinPlayers - 編集中のプロトタイプの最小プレイヤー数を保持するState。
- * @state editedMaxPlayers - 編集中のプロトタイプの最大プレイヤー数を保持するState。
  * @state editPrototypes - 編集可能なプロトタイプのリストを保持するState。
  * @state sort - プロトタイプのソート条件（キーと順序）を管理するState。
  * @state isLoading - データ取得中のローディング状態を管理するState。
@@ -43,13 +39,8 @@ const PrototypeList: React.FC = () => {
   const [isLoading, setIsLoading] = useState<boolean>(true);
   // 編集中のプロトタイプのIDを管理するState
   const [nameEditingId, setNameEditingId] = useState<string>('');
-  const [playersEditingId, setPlayersEditingId] = useState<string>('');
   // 編集中のプロトタイプの名前を保持するState
   const [editedName, setEditedName] = useState<string>('');
-  // 編集中のプロトタイプの最小プレイヤー数を保持するState
-  const [editedMinPlayers, setEditedMinPlayers] = useState<number>(0);
-  // 編集中のプロトタイプの最大プレイヤー数を保持するState
-  const [editedMaxPlayers, setEditedMaxPlayers] = useState<number>(0);
   // 編集用プロトタイプ
   const [editPrototypes, setEditPrototypes] = useState<Prototype[]>([]);
   // ソート
@@ -74,28 +65,6 @@ const PrototypeList: React.FC = () => {
       // 編集モードにする
       setNameEditingId(id);
       setEditedName(name);
-    }
-  };
-
-  /**
-   * プレイヤー人数の編集モードを切り替える関数
-   * @param id プロトタイプID
-   * @param minPlayers 最小プレイヤー数
-   * @param maxPlayers 最大プレイヤー数
-   */
-  const handlePlayersEditToggle = (
-    id: string,
-    minPlayers: number,
-    maxPlayers: number
-  ) => {
-    if (playersEditingId === id) {
-      // 同じ項目を再度押した場合は編集モードを解除
-      setPlayersEditingId('');
-    } else {
-      // 編集モードにする
-      setPlayersEditingId(id);
-      setEditedMinPlayers(minPlayers);
-      setEditedMaxPlayers(maxPlayers);
     }
   };
 
@@ -131,55 +100,6 @@ const PrototypeList: React.FC = () => {
     } finally {
       // 編集モードを解除
       setNameEditingId('');
-    }
-  };
-
-  /**
-   * プレイヤー人数の編集を完了する処理
-   */
-  const handlePlayersEditComplete = async () => {
-    // プレイヤー人数のバリデーション
-    if (editedMinPlayers < PLAYERS_MIN || editedMinPlayers > PLAYERS_MAX) {
-      alert(
-        `最小プレイヤー数は${PLAYERS_MIN}人以上、${PLAYERS_MAX}人以下に設定してください`
-      );
-      return;
-    }
-    if (editedMaxPlayers < editedMinPlayers || editedMaxPlayers > PLAYERS_MAX) {
-      alert(
-        `最大プレイヤー数は最小プレイヤー数以上、${PLAYERS_MAX}人以下に設定してください`
-      );
-      return;
-    }
-
-    try {
-      const prototype = editPrototypes.find((p) => p.id === playersEditingId);
-      if (!prototype) return;
-
-      // プレイヤー人数だけを更新
-      await updatePrototype(playersEditingId, {
-        name: prototype.name,
-        minPlayers: editedMinPlayers,
-        maxPlayers: editedMaxPlayers,
-      });
-
-      // ローカルの状態を更新
-      setEditPrototypes((currentPrototypes) =>
-        currentPrototypes.map((p) =>
-          p.id === playersEditingId
-            ? {
-                ...p,
-                minPlayers: editedMinPlayers,
-                maxPlayers: editedMaxPlayers,
-              }
-            : p
-        )
-      );
-    } catch (error) {
-      console.error('Error updating player count:', error);
-    } finally {
-      // 編集モードを解除
-      setPlayersEditingId('');
     }
   };
 
@@ -323,7 +243,6 @@ const PrototypeList: React.FC = () => {
                 userId,
               }) => {
                 const isNameEditing = nameEditingId === id; // 現在の項目が編集中かどうかを判定
-                const isPlayersEditing = playersEditingId === id; // 現在の項目が編集中かどうかを判定
                 return (
                   <tr key={id}>
                     <td className="p-4">
@@ -369,80 +288,14 @@ const PrototypeList: React.FC = () => {
                       )}
                     </td>
                     <td className="p-4">
-                      {isPlayersEditing ? (
-                        <form
-                          className="flex items-center gap-2"
-                          onSubmit={(e) => {
-                            e.preventDefault();
-                            handlePlayersEditComplete();
-                          }}
-                        >
-                          <input
-                            type="number"
-                            value={
-                              editedMinPlayers === 0 ? '' : editedMinPlayers
-                            }
-                            onChange={(e) =>
-                              setEditedMinPlayers(
-                                e.target.value === ''
-                                  ? 0
-                                  : Number(e.target.value)
-                              )
-                            }
-                            className="w-16 p-1 border border-wood-light rounded"
-                            autoFocus
-                            min={PLAYERS_MIN}
-                            max={PLAYERS_MAX}
-                          />
-                          <span>~</span>
-                          <input
-                            type="number"
-                            value={
-                              editedMaxPlayers === 0 ? '' : editedMaxPlayers
-                            }
-                            onChange={(e) =>
-                              setEditedMaxPlayers(
-                                e.target.value === ''
-                                  ? 0
-                                  : Number(e.target.value)
-                              )
-                            }
-                            className="w-16 p-1 border border-wood-light rounded"
-                            min={PLAYERS_MIN}
-                            max={PLAYERS_MAX}
-                          />
-                          <span className="text-wood-dark">人</span>
-                          <button
-                            type="submit"
-                            className="ml-2 p-1.5 text-green-600 hover:text-green-700 rounded-md border border-green-500 hover:bg-green-50 transition-colors"
-                            title="編集完了"
-                          >
-                            <FaCheck className="w-3.5 h-3.5" />
-                          </button>
-                        </form>
-                      ) : (
-                        <div className="flex items-center">
-                          <span className="text-wood-dark">
-                            {minPlayers !== maxPlayers
-                              ? `${minPlayers} ~ ${maxPlayers}`
-                              : `${minPlayers}`}
-                          </span>
-                          <span className="text-wood-dark">人</span>
-                          <button
-                            onClick={() =>
-                              handlePlayersEditToggle(
-                                id,
-                                minPlayers,
-                                maxPlayers
-                              )
-                            }
-                            className="ml-2 p-1 text-wood hover:text-header rounded-md hover:bg-wood-lightest/20 transition-colors"
-                            title="プレイヤー人数を編集"
-                          >
-                            <FaPenToSquare className="w-4 h-4" />
-                          </button>
-                        </div>
-                      )}
+                      <div className="flex items-center">
+                        <span className="text-wood-dark">
+                          {minPlayers !== maxPlayers
+                            ? `${minPlayers} ~ ${maxPlayers}`
+                            : `${minPlayers}`}
+                        </span>
+                        <span className="text-wood-dark">人</span>
+                      </div>
                     </td>
                     <td className="p-4 text-sm text-wood">
                       {formatDate(createdAt)}


### PR DESCRIPTION
# 事前確認(共通)

- [x] PR 前に動作確認をしたか
- [x] 機密情報を含んでいないか

# やったこと<!-- このプルリクエストでやったことを書く -->

This pull request removes functionality related to editing the player count (minimum and maximum players) in the `PrototypeList` component. The changes simplify the component by eliminating unused states, functions, and UI elements associated with player count editing.

### Removal of Player Count Editing Functionality:

* Removed state variables `playersEditingId`, `editedMinPlayers`, and `editedMaxPlayers`, which were used to manage the editing of player counts. [[1]](diffhunk://#diff-4da77a990f75260b60a88921266b77adf7ae3a218e84778aa9707c61818a865dL30-L33) [[2]](diffhunk://#diff-4da77a990f75260b60a88921266b77adf7ae3a218e84778aa9707c61818a865dL46-L52)
* Deleted the `handlePlayersEditToggle` and `handlePlayersEditComplete` functions, which handled toggling and completing the player count editing process. [[1]](diffhunk://#diff-4da77a990f75260b60a88921266b77adf7ae3a218e84778aa9707c61818a865dL80-L101) [[2]](diffhunk://#diff-4da77a990f75260b60a88921266b77adf7ae3a218e84778aa9707c61818a865dL137-L185)
* Removed the conditional rendering logic and form elements for editing player counts in the table rows. The player count is now displayed as static text.
* Deleted the `isPlayersEditing` variable, which was used to determine if a specific prototype's player count was being edited.

### Code Cleanup:

* Removed the `PLAYERS_MIN` and `PLAYERS_MAX` constants, as they are no longer needed after the removal of player count editing functionality.

# やらないこと<!-- このプルリクエストでやってもおかしくないけどやらなかったことを書く -->

特になし

# 懸念点や注意点<!-- このプルリクエストにおける懸念点や注意点を書く -->

特になし

# その他<!-- このプルリクエストで上記の項目以外に伝えるべきことを書く -->

特になし


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **機能変更**
  - プロトタイプ一覧でプレイヤー人数（最小・最大）の編集機能を削除し、人数は編集不可の静的テキスト表示となりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->