### PR TITLE
fix: remove unnecessary prototype properties from updatePrototype call

### DIFF
--- a/frontend/src/features/prototype/components/organisms/GroupPrototypeList.tsx
+++ b/frontend/src/features/prototype/components/organisms/GroupPrototypeList.tsx
@@ -173,13 +173,9 @@ const GroupPrototypeList: React.FC = () => {
         return;
       }
 
-      const prototypeToEdit = prototype.edit.prototype;
-
       // プロトタイプ名を更新
       await updatePrototype(nameEditingId, {
         name: editedName,
-        minPlayers: prototypeToEdit.minPlayers,
-        maxPlayers: prototypeToEdit.maxPlayers,
       });
 
       // 一覧を更新


### PR DESCRIPTION
# 事前確認(共通)

- [x] PR 前に動作確認をしたか
- [x] 機密情報を含んでいないか

# やったこと<!-- このプルリクエストでやったことを書く -->

This pull request makes a minor update to the `GroupPrototypeList` component by removing unused variables and properties related to editing prototypes. This simplifies the code and reduces potential confusion.

Code cleanup:

* [`frontend/src/features/prototype/components/organisms/GroupPrototypeList.tsx`](diffhunk://#diff-313784a9f8118d01366865907201d6a565a8002a9184ad8346261558537ede24L176-L182): Removed the `prototypeToEdit` variable and associated properties (`minPlayers` and `maxPlayers`) since they were unused in the `updatePrototype` function.

# やらないこと<!-- このプルリクエストでやってもおかしくないけどやらなかったことを書く -->

特になし

# 懸念点や注意点<!-- このプルリクエストにおける懸念点や注意点を書く -->

特になし

# その他<!-- このプルリクエストで上記の項目以外に伝えるべきことを書く -->

特になし


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **バグ修正**
  - プロトタイプ名の編集時に、最小・最大プレイヤー数が意図せず変更される問題を修正しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->