### PR TITLE
feat: add player count display to PlayRoomCard and GroupPrototypeList components

### DIFF
--- a/frontend/src/features/prototype/components/molecules/PlayRoomCard.tsx
+++ b/frontend/src/features/prototype/components/molecules/PlayRoomCard.tsx
@@ -3,17 +3,23 @@
 import Link from 'next/link';
 import React from 'react';
 import { BsDoorOpenFill } from 'react-icons/bs';
+import { FaUsers } from 'react-icons/fa';
 import { IoTrash } from 'react-icons/io5';
 
-import { PrototypeVersion } from '@/api/types';
+import { Prototype, PrototypeVersion } from '@/api/types';
 import formatDate from '@/utils/dateFormat';
 
 interface PlayRoomCardProps {
   version: PrototypeVersion;
-  onDelete: (prototypeId: string, versionId: string) => Promise<void>;
+  onDelete: (prototypeId: string, prototypeVersionId: string) => Promise<void>;
+  prototype?: Prototype; // プロトタイプ情報（プレイヤー数を表示するため）
 }
 
-const PlayRoomCard: React.FC<PlayRoomCardProps> = ({ version, onDelete }) => {
+const PlayRoomCard: React.FC<PlayRoomCardProps> = ({
+  version,
+  onDelete,
+  prototype,
+}) => {
   return (
     <Link
       href={`/prototypes/${version.prototypeId}/versions/${version.id}/play`}
@@ -48,6 +54,18 @@ const PlayRoomCard: React.FC<PlayRoomCardProps> = ({ version, onDelete }) => {
               {formatDate(version.createdAt, true)}
             </div>
           </div>
+
+          {/* プレイヤー人数情報 */}
+          {prototype && (
+            <div className="flex items-center gap-1 mt-2 text-xs text-wood-dark">
+              <FaUsers className="h-3 w-3" />
+              <span>
+                {prototype.minPlayers === prototype.maxPlayers
+                  ? `${prototype.minPlayers}人`
+                  : `${prototype.minPlayers}〜${prototype.maxPlayers}人`}
+              </span>
+            </div>
+          )}
         </div>
       </div>
     </Link>

--- a/frontend/src/features/prototype/components/organisms/GroupPrototypeList.tsx
+++ b/frontend/src/features/prototype/components/organisms/GroupPrototypeList.tsx
@@ -3,7 +3,13 @@
 import Link from 'next/link';
 import { useParams, useRouter } from 'next/navigation';
 import React, { useState, useEffect, useCallback } from 'react';
-import { FaCheck, FaPenToSquare, FaEye, FaCopy } from 'react-icons/fa6';
+import {
+  FaCheck,
+  FaPenToSquare,
+  FaEye,
+  FaCopy,
+  FaUsers,
+} from 'react-icons/fa6';
 import { HiOutlinePencilAlt } from 'react-icons/hi';
 import { IoAdd, IoArrowBack, IoTrash } from 'react-icons/io5';
 
@@ -436,6 +442,7 @@ const GroupPrototypeList: React.FC = () => {
               </form>
             ) : (
               <div className="flex items-center">
+                <FaUsers className="h-4 w-4 mr-2 text-wood-dark" />
                 <span className="text-2xl font-semibold text-wood-darkest">
                   {prototype.edit.prototype.minPlayers ===
                   prototype.edit.prototype.maxPlayers
@@ -571,7 +578,16 @@ const GroupPrototypeList: React.FC = () => {
                           </button>
                         </h3>
                       )}
-                      <div className="flex gap-2">
+                      <div className="flex gap-2 items-center">
+                        {/* プレイヤー人数表示 */}
+                        <div className="text-sm text-wood-dark bg-wood-lightest/70 px-2 py-0.5 rounded-md border border-wood-light/20 flex items-center">
+                          <FaUsers className="h-3 w-3 mr-1" />
+                          <span>
+                            {prototype.minPlayers === prototype.maxPlayers
+                              ? `${prototype.minPlayers}人`
+                              : `${prototype.minPlayers}〜${prototype.maxPlayers}人`}
+                          </span>
+                        </div>
                         {versions.some(
                           (v) => v.versionNumber === VERSION_NUMBER.MASTER
                         ) && (
@@ -622,6 +638,7 @@ const GroupPrototypeList: React.FC = () => {
                               key={version.id}
                               version={version}
                               onDelete={handleDeleteRoom}
+                              prototype={prototype}
                             />
                           );
                         })}


### PR DESCRIPTION
# 事前確認(共通)

- [x] PR 前に動作確認をしたか
- [x] 機密情報を含んでいないか

# やったこと<!-- このプルリクエストでやったことを書く -->

This pull request enhances the display of player information in the `PlayRoomCard` and `GroupPrototypeList` components by incorporating player count details and updating their respective props and layouts. Additionally, new icons are introduced to visually represent player-related data.

### Enhancements to `PlayRoomCard`:

* Added a new optional `prototype` prop to the `PlayRoomCard` component to provide prototype details, including player count information. (`frontend/src/features/prototype/components/molecules/PlayRoomCard.tsx`, [frontend/src/features/prototype/components/molecules/PlayRoomCard.tsxR6-R22](diffhunk://#diff-2be92ffc19bbca9e179a1cf3171b7af54a08a146e22a6aec3cfb97f6f1d44516R6-R22))
* Updated the component layout to display player count details using the `FaUsers` icon, showing either a fixed player count or a range (e.g., "2人" or "2〜4人"). (`frontend/src/features/prototype/components/molecules/PlayRoomCard.tsx`, [frontend/src/features/prototype/components/molecules/PlayRoomCard.tsxR57-R68](diffhunk://#diff-2be92ffc19bbca9e179a1cf3171b7af54a08a146e22a6aec3cfb97f6f1d44516R57-R68))

### Enhancements to `GroupPrototypeList`:

* Imported the `FaUsers` icon to represent player-related information. (`frontend/src/features/prototype/components/organisms/GroupPrototypeList.tsx`, [frontend/src/features/prototype/components/organisms/GroupPrototypeList.tsxL6-R12](diffhunk://#diff-313784a9f8118d01366865907201d6a565a8002a9184ad8346261558537ede24L6-R12))
* Updated the `GroupPrototypeList` layout to include player count details in multiple locations:
  - Added the `FaUsers` icon and player count display in the prototype editing section. (`frontend/src/features/prototype/components/organisms/GroupPrototypeList.tsx`, [frontend/src/features/prototype/components/organisms/GroupPrototypeList.tsxR445](diffhunk://#diff-313784a9f8118d01366865907201d6a565a8002a9184ad8346261558537ede24R445))
  - Displayed player count details in the prototype list, using a styled badge with the `FaUsers` icon. (`frontend/src/features/prototype/components/organisms/GroupPrototypeList.tsx`, [frontend/src/features/prototype/components/organisms/GroupPrototypeList.tsxL574-R590](diffhunk://#diff-313784a9f8118d01366865907201d6a565a8002a9184ad8346261558537ede24L574-R590))
* Passed the `prototype` prop to the `PlayRoomCard` component to enable the display of player count information. (`frontend/src/features/prototype/components/organisms/GroupPrototypeList.tsx`, [frontend/src/features/prototype/components/organisms/GroupPrototypeList.tsxR641](diffhunk://#diff-313784a9f8118d01366865907201d6a565a8002a9184ad8346261558537ede24R641))

# やらないこと<!-- このプルリクエストでやってもおかしくないけどやらなかったことを書く -->

特になし

# 懸念点や注意点<!-- このプルリクエストにおける懸念点や注意点を書く -->

特になし

# その他<!-- このプルリクエストで上記の項目以外に伝えるべきことを書く -->

特になし


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - プレイルームカードにプレイヤー人数（最小～最大）を表示するUIを追加しました。人数はアイコン付きで表示されます。
- **スタイル**
  - プレイヤー人数表示にユーザーアイコン（FaUsers）を導入し、視認性を向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->