### PR TITLE
feat: add GitHub Actions workflow for issue notifications to Discord

### DIFF
--- a/.github/workflows/issue_notifications.yml
+++ b/.github/workflows/issue_notifications.yml
@@ -16,10 +16,11 @@ jobs:
           NUMBER: ${{ github.event.issue.number }}
           TITLE: ${{ github.event.issue.title }}
           URL: ${{ github.event.issue.html_url }}
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             const axios = require('axios');
+            const core = require('@actions/core');
             
             try {
               // 通知タイプに応じて文言と色を切り替え
@@ -49,5 +50,5 @@ jobs:
               console.log('Discord notification sent successfully');
             } catch (error) {
               console.error('Failed to send Discord notification:', error);
-              process.exit(1);
+              core.setFailed(error.message);
             }

--- a/.github/workflows/issue_notifications.yml
+++ b/.github/workflows/issue_notifications.yml
@@ -1,0 +1,53 @@
+# .github/workflows/issue_notifications.yml
+name: Issue Notifications
+
+on:
+  issues:
+    types: [opened, closed]
+
+jobs:
+  notify-discord:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send notification to Discord
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          ACTION: ${{ github.event.action }}
+          NUMBER: ${{ github.event.issue.number }}
+          TITLE: ${{ github.event.issue.title }}
+          URL: ${{ github.event.issue.html_url }}
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const axios = require('axios');
+            
+            try {
+              // 通知タイプに応じて文言と色を切り替え
+              const content = process.env.ACTION === 'opened' 
+                ? ':sparkles: New issue created'
+                : ':lock: Issue closed';
+              
+              const color = process.env.ACTION === 'opened'
+                ? 3066993  // 緑
+                : 15158332; // 赤
+              
+              // Discord 向けペイロードを作成
+              const payload = {
+                content: content,
+                embeds: [{
+                  title: `#${process.env.NUMBER} ${process.env.TITLE}`,
+                  url: process.env.URL,
+                  color: color
+                }]
+              };
+              
+              // Discord webhook に POST リクエストを送信
+              await axios.post(process.env.DISCORD_WEBHOOK_URL, payload, {
+                headers: { 'Content-Type': 'application/json' }
+              });
+              
+              console.log('Discord notification sent successfully');
+            } catch (error) {
+              console.error('Failed to send Discord notification:', error);
+              process.exit(1);
+            }

--- a/.github/workflows/issue_notifications.yml
+++ b/.github/workflows/issue_notifications.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const axios = require('axios');
+            const { HttpClient } = require('@actions/http-client');
             const core = require('@actions/core');
             
             try {
@@ -43,9 +43,8 @@ jobs:
               };
               
               // Discord webhook に POST リクエストを送信
-              await axios.post(process.env.DISCORD_WEBHOOK_URL, payload, {
-                headers: { 'Content-Type': 'application/json' }
-              });
+              const http = new HttpClient();
+              await http.postJson(process.env.DISCORD_WEBHOOK_URL, payload);
               
               console.log('Discord notification sent successfully');
             } catch (error) {


### PR DESCRIPTION
# 事前確認(共通)

- [x] PR 前に動作確認をしたか
- [x] 機密情報を含んでいないか

# やったこと<!-- このプルリクエストでやったことを書く -->

This pull request introduces a new GitHub Actions workflow to send notifications to a Discord channel when issues are opened or closed in the repository.

### New GitHub Actions Workflow:
* [`.github/workflows/issue_notifications.yml`](diffhunk://#diff-945e7f1b5af8a1763c9b68be3def2b63cfbf0fa9551229ea16975eb222cf50b3R1-R48): Added a workflow named "Issue Notifications" that triggers on issue events (`opened` and `closed`). It sends a notification to a Discord channel using a webhook, with the message content and embed color dynamically adjusted based on the issue action.

# やらないこと<!-- このプルリクエストでやってもおかしくないけどやらなかったことを書く -->

特になし

# 懸念点や注意点<!-- このプルリクエストにおける懸念点や注意点を書く -->

特になし

# その他<!-- このプルリクエストで上記の項目以外に伝えるべきことを書く -->

特になし


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - Issueが作成またはクローズされた際に、Discordチャンネルへリアルタイム通知が送信されるようになりました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->