### PR TITLE
refactor: remove HttpClient usage and replace with fetch API for Discord notifications

### DIFF
--- a/.github/workflows/issue_notifications.yml
+++ b/.github/workflows/issue_notifications.yml
@@ -19,8 +19,6 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const { HttpClient } = require('@actions/http-client');
-            
             try {
               // 通知タイプに応じて文言と色を切り替え
               const content = process.env.ACTION === 'opened' 
@@ -41,9 +39,18 @@ jobs:
                 }]
               };
               
-              // Discord webhook に POST リクエストを送信
-              const http = new HttpClient();
-              await http.postJson(process.env.DISCORD_WEBHOOK_URL, payload);
+              // Discord webhook に fetch API を使用してリクエストを送信
+              const response = await fetch(process.env.DISCORD_WEBHOOK_URL, {
+                method: 'POST',
+                headers: {
+                  'Content-Type': 'application/json'
+                },
+                body: JSON.stringify(payload)
+              });
+              
+              if (!response.ok) {
+                throw new Error(`Discord API responded with status: ${response.status}`);
+              }
               
               console.log('Discord notification sent successfully');
             } catch (error) {


### PR DESCRIPTION
# 事前確認(共通)

- [x] PR 前に動作確認をしたか
- [x] 機密情報を含んでいないか

# やったこと<!-- このプルリクエストでやったことを書く -->

This pull request updates the Discord webhook notification logic in the GitHub Actions workflow to use the `fetch` API instead of the `@actions/http-client` library. This change simplifies the dependencies and improves error handling.

### Changes to Discord webhook logic:

* [`.github/workflows/issue_notifications.yml`](diffhunk://#diff-945e7f1b5af8a1763c9b68be3def2b63cfbf0fa9551229ea16975eb222cf50b3L22-L23): Removed the `@actions/http-client` dependency and replaced it with the `fetch` API for sending POST requests to the Discord webhook. Added error handling to throw an exception if the response status is not OK. [[1]](diffhunk://#diff-945e7f1b5af8a1763c9b68be3def2b63cfbf0fa9551229ea16975eb222cf50b3L22-L23) [[2]](diffhunk://#diff-945e7f1b5af8a1763c9b68be3def2b63cfbf0fa9551229ea16975eb222cf50b3L44-R53)

# やらないこと<!-- このプルリクエストでやってもおかしくないけどやらなかったことを書く -->

特になし

# 懸念点や注意点<!-- このプルリクエストにおける懸念点や注意点を書く -->

特になし

# その他<!-- このプルリクエストで上記の項目以外に伝えるべきことを書く -->

特になし
