### PR TITLE
feat: implement KonvaPartContextMenu for part context menu functionality in GameBoard and Part2 components

### DIFF
--- a/frontend/src/features/prototype/components/atoms/KonvaPartContextMenu.tsx
+++ b/frontend/src/features/prototype/components/atoms/KonvaPartContextMenu.tsx
@@ -1,0 +1,131 @@
+import React, { useState } from 'react';
+import { Group, Rect, Text } from 'react-konva';
+
+/**
+ * Konvaパーツ用コンテキストメニューのProps
+ */
+export interface KonvaPartContextMenuProps {
+  /**
+   * メニューの表示状態
+   */
+  visible: boolean;
+  /**
+   * メニューの位置
+   */
+  position: {
+    x: number;
+    y: number;
+  };
+  /**
+   * 順序変更のコールバック
+   */
+  onChangeOrder: (type: 'front' | 'back' | 'frontmost' | 'backmost') => void;
+  /**
+   * メニューを閉じるコールバック
+   */
+  onClose: () => void;
+}
+
+/**
+ * Konvaパーツで使用するコンテキストメニューコンポーネント
+ * Part2.tsxの外部に定義された独立したコンポーネント
+ */
+export const KonvaPartContextMenu: React.FC<KonvaPartContextMenuProps> = ({
+  visible,
+  position,
+  onChangeOrder,
+  onClose,
+}) => {
+  const [hoveredMenuItem, setHoveredMenuItem] = useState<number | null>(null);
+
+  if (!visible) {
+    return null;
+  }
+
+  // メニュー項目の定義
+  const menuItems = [
+    {
+      id: 0,
+      text: '最前面に移動',
+      action: () => onChangeOrder('frontmost'),
+    },
+    {
+      id: 1,
+      text: '前面に移動',
+      action: () => onChangeOrder('front'),
+    },
+    {
+      id: 2,
+      text: '背面に移動',
+      action: () => onChangeOrder('back'),
+    },
+    {
+      id: 3,
+      text: '最背面に移動',
+      action: () => onChangeOrder('backmost'),
+    },
+  ];
+
+  const menuHeight = menuItems.length * 25;
+
+  return (
+    <Group
+      x={position.x}
+      y={position.y}
+      name="context-menu-component"
+      onClick={(e) => {
+        // クリックイベントの伝播を停止
+        e.cancelBubble = true;
+      }}
+    >
+      {/* メニュー背景 */}
+      <Rect
+        width={120}
+        height={menuHeight}
+        fill="rgba(255, 255, 255, 0.9)"
+        stroke="grey"
+        strokeWidth={1}
+        cornerRadius={4}
+        shadowColor="rgba(0, 0, 0, 0.2)"
+        shadowBlur={5}
+        shadowOffsetX={1}
+        shadowOffsetY={1}
+        name="context-menu-component"
+      />
+
+      {/* メニュー項目 */}
+      <Group name="context-menu-component">
+        {menuItems.map((item) => (
+          <React.Fragment key={item.id}>
+            <Rect
+              width={120}
+              height={25}
+              fill={
+                hoveredMenuItem === item.id
+                  ? 'rgba(200, 200, 255, 0.5)'
+                  : 'transparent'
+              }
+              y={item.id * 25}
+              name="context-menu-component"
+            />
+            <Text
+              text={item.text}
+              fontSize={12}
+              fill="black"
+              padding={8}
+              y={item.id * 25}
+              width={120}
+              name="context-menu-component"
+              onMouseEnter={() => setHoveredMenuItem(item.id)}
+              onMouseLeave={() => setHoveredMenuItem(null)}
+              onClick={() => {
+                item.action();
+                onClose();
+              }}
+            />
+          </React.Fragment>
+        ))}
+      </Group>
+    </Group>
+  );
+};

--- a/frontend/src/features/prototype/components/atoms/Part2.tsx
+++ b/frontend/src/features/prototype/components/atoms/Part2.tsx
@@ -25,6 +25,10 @@ interface Part2Props {
   onDragEnd?: (e: Konva.KonvaEventObject<DragEvent>, partId: number) => void;
   onClick?: (e: Konva.KonvaEventObject<MouseEvent>) => void;
   onDblClick?: (partId: number) => void;
+  onContextMenu?: (
+    e: Konva.KonvaEventObject<PointerEvent>,
+    partId: number
+  ) => void;
   isActive: boolean;
 }
 
@@ -42,6 +46,7 @@ const Part2 = forwardRef<PartHandle, Part2Props>(
       onDragEnd,
       onClick,
       onDblClick,
+      onContextMenu,
       isActive = false,
     },
     ref
@@ -59,15 +64,17 @@ const Part2 = forwardRef<PartHandle, Part2Props>(
     useEffect(() => {
       if (!groupRef.current || prototypeType !== 'PREVIEW') return;
 
+      const currentGroup = groupRef.current;
+
       // ドラッグ開始時のハンドラーを追加（PREVIEWモードのみ）
-      groupRef.current.on('dragstart', () => {
+      currentGroup.on('dragstart', () => {
         // ドラッグ中のノードを最前面に移動
-        groupRef.current?.moveToTop();
+        currentGroup.moveToTop();
       });
 
       return () => {
         // クリーンアップ
-        groupRef.current?.off('dragstart');
+        currentGroup.off('dragstart');
       };
     }, [prototypeType]);
 
@@ -170,6 +177,14 @@ const Part2 = forwardRef<PartHandle, Part2Props>(
     // 中央を軸にして反転させるための設定
     const offsetX = part.width / 2;
 
+    // コンテキストメニュー用ハンドラー
+    const handleContextMenu = (e: Konva.KonvaEventObject<PointerEvent>) => {
+      e.evt.preventDefault();
+      if (onContextMenu) {
+        onContextMenu(e, part.id);
+      }
+    };
+
     return (
       <Group
         ref={groupRef}
@@ -186,6 +201,7 @@ const Part2 = forwardRef<PartHandle, Part2Props>(
         onDragEnd={(e) => onDragEnd && onDragEnd(e, part.id)}
         onClick={(e) => onClick && onClick(e)}
         onDblClick={handleDoubleClick}
+        onContextMenu={handleContextMenu}
       >
         {/* パーツの背景 */}
         <Rect
@@ -294,7 +310,6 @@ const Part2 = forwardRef<PartHandle, Part2Props>(
     );
   }
 );
-
 Part2.displayName = 'Part2';
 
 export default Part2;


### PR DESCRIPTION
# 事前確認(共通)

- [x] PR 前に動作確認をしたか
- [x] 機密情報を含んでいないか

# やったこと<!-- このプルリクエストでやったことを書く -->

This pull request introduces a context menu feature for Konva parts in the `GameBoard` component, enabling users to perform actions such as changing the order of parts. The changes include the addition of a new `KonvaPartContextMenu` component, updates to the `Part2` component to support context menu events, and modifications to `GameBoard` to manage context menu state and interactions.

### Context Menu Feature Implementation:

#### New Component:
* [`frontend/src/features/prototype/components/atoms/KonvaPartContextMenu.tsx`](diffhunk://#diff-339bd92c43d8fa893044c85e091d3151418c46b2c2ffcaef8e64bbd64475f59bR1-R132): Added a reusable context menu component for Konva parts, allowing actions like moving parts to the front, back, frontmost, or backmost positions.

#### Updates to Part2:
* `frontend/src/features/prototype/components/atoms/Part2.tsx`: 
  - Added `onContextMenu` prop and handler to support right-click context menu events. [[1]](diffhunk://#diff-b3e44d7db85ffd8d1659582e97ca3efa4ada55e8897ea2d3d7dadded6061512dR36-R39) [[2]](diffhunk://#diff-b3e44d7db85ffd8d1659582e97ca3efa4ada55e8897ea2d3d7dadded6061512dR187-R194) [[3]](diffhunk://#diff-b3e44d7db85ffd8d1659582e97ca3efa4ada55e8897ea2d3d7dadded6061512dR211)
  - Integrated `usePartReducer` for dispatching actions related to part order changes.

#### Integration with GameBoard:
* `frontend/src/features/prototype/components/organisms/GameBoard.tsx`:
  - Imported `KonvaPartContextMenu` and added state management for context menu visibility, position, and associated part ID. [[1]](diffhunk://#diff-c744a3a422bf8c68f3e3d51476160645ffd164a9fcc857182f844ff58c1def51R22) [[2]](diffhunk://#diff-c744a3a422bf8c68f3e3d51476160645ffd164a9fcc857182f844ff58c1def51R67-R73)
  - Implemented handlers for opening, closing, and interacting with the context menu, including dispatching actions to change part order. [[1]](diffhunk://#diff-c744a3a422bf8c68f3e3d51476160645ffd164a9fcc857182f844ff58c1def51R220-R274) [[2]](diffhunk://#diff-c744a3a422bf8c68f3e3d51476160645ffd164a9fcc857182f844ff58c1def51R669-R691)
  - Rendered `KonvaPartContextMenu` dynamically based on context menu state and part interactions.

# やらないこと<!-- このプルリクエストでやってもおかしくないけどやらなかったことを書く -->

特になし

# 懸念点や注意点<!-- このプルリクエストにおける懸念点や注意点を書く -->

特になし

# その他<!-- このプルリクエストで上記の項目以外に伝えるべきことを書く -->

特になし


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - ゲームボード上のパーツを右クリックすると、パーツの描画順序を変更できるコンテキストメニューが表示されるようになりました。
  - コンテキストメニューはクリックで閉じることができます。

- **改善**
  - パーツの右クリック操作に対応し、より直感的な操作が可能になりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->