### PR TITLE
feat: add old prototype edit and play components with socket integration

### DIFF
--- a/frontend/src/app/prototypes/[prototypeId]/versions/[versionId]/edit/old/page.tsx
+++ b/frontend/src/app/prototypes/[prototypeId]/versions/[versionId]/edit/old/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 
-import PrototypeEdit2 from '@/features/prototype/components/organisms/PrototypeEdit2';
+import PrototypeEditOld from '@/features/prototype/components/organisms/PrototypeEditOld';
 
 export const metadata: Metadata = {
   title: 'プロトタイプ編集',
@@ -8,5 +8,5 @@ export const metadata: Metadata = {
 
 export const runtime = 'edge';
 export default function Page() {
-  return <PrototypeEdit2 />;
+  return <PrototypeEditOld />;
 }

--- a/frontend/src/app/prototypes/[prototypeId]/versions/[versionId]/play/old/page.tsx
+++ b/frontend/src/app/prototypes/[prototypeId]/versions/[versionId]/play/old/page.tsx
@@ -1,0 +1,15 @@
+import { Metadata } from 'next';
+import React from 'react';
+
+import PrototypePlayOld from '@/features/prototype/components/organisms/PrototypePlayOld';
+
+export const metadata: Metadata = {
+  title: 'プレイ',
+};
+
+export const runtime = 'edge';
+const PrototypesPreviewPage: React.FC = () => {
+  return <PrototypePlayOld />;
+};
+
+export default PrototypesPreviewPage;

--- a/frontend/src/features/prototype/components/organisms/PrototypeEdit.tsx
+++ b/frontend/src/features/prototype/components/organisms/PrototypeEdit.tsx
@@ -12,7 +12,7 @@ import {
   Prototype,
   PrototypeVersion,
 } from '@/api/types';
-import Canvas from '@/features/prototype/components/organisms/Canvas';
+import GameBoard from '@/features/prototype/components/organisms/GameBoard';
 import { PrototypeVersionIdProvider } from '@/features/prototype/contexts/PrototypeVersionIdContext';
 import { SocketProvider } from '@/features/prototype/contexts/SocketContext';
 import { CursorInfo } from '@/features/prototype/types/cursor';
@@ -20,7 +20,7 @@ import { useUser } from '@/hooks/useUser';
 
 const socket = io(process.env.NEXT_PUBLIC_API_URL);
 
-const PrototypeEdit: React.FC = () => {
+export default function PrototypeEdit() {
   const router = useRouter();
   const { getPrototypeVersions } = usePrototypes();
   const { user } = useUser();
@@ -107,7 +107,7 @@ const PrototypeEdit: React.FC = () => {
   return (
     <SocketProvider socket={socket}>
       <PrototypeVersionIdProvider prototypeVersionId={versionId}>
-        <Canvas
+        <GameBoard
           prototypeName={prototype.name}
           parts={parts}
           properties={properties}
@@ -120,6 +120,4 @@ const PrototypeEdit: React.FC = () => {
       </PrototypeVersionIdProvider>
     </SocketProvider>
   );
-};
-
-export default PrototypeEdit;
+}

--- a/frontend/src/features/prototype/components/organisms/PrototypeEditOld.tsx
+++ b/frontend/src/features/prototype/components/organisms/PrototypeEditOld.tsx
@@ -12,7 +12,7 @@ import {
   Prototype,
   PrototypeVersion,
 } from '@/api/types';
-import GameBoard from '@/features/prototype/components/organisms/GameBoard';
+import Canvas from '@/features/prototype/components/organisms/Canvas';
 import { PrototypeVersionIdProvider } from '@/features/prototype/contexts/PrototypeVersionIdContext';
 import { SocketProvider } from '@/features/prototype/contexts/SocketContext';
 import { CursorInfo } from '@/features/prototype/types/cursor';
@@ -20,7 +20,7 @@ import { useUser } from '@/hooks/useUser';
 
 const socket = io(process.env.NEXT_PUBLIC_API_URL);
 
-const PrototypePlay: React.FC = () => {
+export default function PrototypeEditOld() {
   const router = useRouter();
   const { getPrototypeVersions } = usePrototypes();
   const { user } = useUser();
@@ -47,7 +47,7 @@ const PrototypePlay: React.FC = () => {
   // カーソル
   const [cursors, setCursors] = useState<Record<string, CursorInfo>>({});
 
-  // socket通信
+  // socket通信の設定
   useEffect(() => {
     // サーバーに接続した後、特定のプロトタイプに参加
     socket.emit('JOIN_PROTOTYPE', {
@@ -55,18 +55,18 @@ const PrototypePlay: React.FC = () => {
       userId: user?.id || '',
     });
 
-    // 更新パーツの受信
+    // 更新されたパーツを受信
     socket.on('UPDATE_PARTS', ({ parts, properties }) => {
       setParts(parts);
       setProperties(properties);
     });
 
-    // 更新プレイヤーの受信
+    // 更新されたプレイヤーを受信
     socket.on('UPDATE_PLAYERS', (players: Player[]) => {
       setPlayers(players.sort((a, b) => a.id - b.id));
     });
 
-    // 更新カーソルの受信
+    // 更新されたカーソルを受信
     socket.on('UPDATE_CURSORS', ({ cursors }) => {
       setCursors(cursors);
     });
@@ -84,8 +84,8 @@ const PrototypePlay: React.FC = () => {
       .then((response) => {
         const { prototype, versions } = response;
 
-        // プレビュー版でない場合
-        if (prototype.type !== 'PREVIEW') {
+        // プロトタイプのタイプが編集版でない場合
+        if (prototype.type !== 'EDIT') {
           router.replace(`/prototypes/groups/${prototype.groupId}`);
           return;
         }
@@ -95,7 +95,7 @@ const PrototypePlay: React.FC = () => {
       .catch((error) => console.error('Error fetching prototypes:', error));
   }, [getPrototypeVersions, prototypeId, router]);
 
-  // プロトタイプバージョン番号
+  // バージョン番号
   const versionNumber = useMemo(() => {
     return prototype?.versions.find((version) => version.id === versionId)
       ?.versionNumber;
@@ -107,7 +107,7 @@ const PrototypePlay: React.FC = () => {
   return (
     <SocketProvider socket={socket}>
       <PrototypeVersionIdProvider prototypeVersionId={versionId}>
-        <GameBoard
+        <Canvas
           prototypeName={prototype.name}
           parts={parts}
           properties={properties}
@@ -115,11 +115,9 @@ const PrototypePlay: React.FC = () => {
           cursors={cursors}
           prototypeVersionNumber={versionNumber}
           groupId={prototype.groupId}
-          prototypeType="PREVIEW"
+          prototypeType="EDIT"
         />
       </PrototypeVersionIdProvider>
     </SocketProvider>
   );
-};
-
-export default PrototypePlay;
+}

--- a/frontend/src/features/prototype/components/organisms/PrototypePlayOld.tsx
+++ b/frontend/src/features/prototype/components/organisms/PrototypePlayOld.tsx
@@ -12,7 +12,7 @@ import {
   Prototype,
   PrototypeVersion,
 } from '@/api/types';
-import GameBoard from '@/features/prototype/components/organisms/GameBoard';
+import Canvas from '@/features/prototype/components/organisms/Canvas';
 import { PrototypeVersionIdProvider } from '@/features/prototype/contexts/PrototypeVersionIdContext';
 import { SocketProvider } from '@/features/prototype/contexts/SocketContext';
 import { CursorInfo } from '@/features/prototype/types/cursor';
@@ -20,7 +20,7 @@ import { useUser } from '@/hooks/useUser';
 
 const socket = io(process.env.NEXT_PUBLIC_API_URL);
 
-export default function PrototypeEdit2() {
+const PrototypePlayOld: React.FC = () => {
   const router = useRouter();
   const { getPrototypeVersions } = usePrototypes();
   const { user } = useUser();
@@ -47,7 +47,7 @@ export default function PrototypeEdit2() {
   // カーソル
   const [cursors, setCursors] = useState<Record<string, CursorInfo>>({});
 
-  // socket通信の設定
+  // socket通信
   useEffect(() => {
     // サーバーに接続した後、特定のプロトタイプに参加
     socket.emit('JOIN_PROTOTYPE', {
@@ -55,18 +55,18 @@ export default function PrototypeEdit2() {
       userId: user?.id || '',
     });
 
-    // 更新されたパーツを受信
+    // 更新パーツの受信
     socket.on('UPDATE_PARTS', ({ parts, properties }) => {
       setParts(parts);
       setProperties(properties);
     });
 
-    // 更新されたプレイヤーを受信
+    // 更新プレイヤーの受信
     socket.on('UPDATE_PLAYERS', (players: Player[]) => {
       setPlayers(players.sort((a, b) => a.id - b.id));
     });
 
-    // 更新されたカーソルを受信
+    // 更新カーソルの受信
     socket.on('UPDATE_CURSORS', ({ cursors }) => {
       setCursors(cursors);
     });
@@ -84,8 +84,8 @@ export default function PrototypeEdit2() {
       .then((response) => {
         const { prototype, versions } = response;
 
-        // プロトタイプのタイプが編集版でない場合
-        if (prototype.type !== 'EDIT') {
+        // プレビュー版でない場合
+        if (prototype.type !== 'PREVIEW') {
           router.replace(`/prototypes/groups/${prototype.groupId}`);
           return;
         }
@@ -95,7 +95,7 @@ export default function PrototypeEdit2() {
       .catch((error) => console.error('Error fetching prototypes:', error));
   }, [getPrototypeVersions, prototypeId, router]);
 
-  // バージョン番号
+  // プロトタイプバージョン番号
   const versionNumber = useMemo(() => {
     return prototype?.versions.find((version) => version.id === versionId)
       ?.versionNumber;
@@ -107,7 +107,7 @@ export default function PrototypeEdit2() {
   return (
     <SocketProvider socket={socket}>
       <PrototypeVersionIdProvider prototypeVersionId={versionId}>
-        <GameBoard
+        <Canvas
           prototypeName={prototype.name}
           parts={parts}
           properties={properties}
@@ -115,9 +115,11 @@ export default function PrototypeEdit2() {
           cursors={cursors}
           prototypeVersionNumber={versionNumber}
           groupId={prototype.groupId}
-          prototypeType="EDIT"
+          prototypeType="PREVIEW"
         />
       </PrototypeVersionIdProvider>
     </SocketProvider>
   );
-}
+};
+
+export default PrototypePlayOld;


### PR DESCRIPTION
# 事前確認(共通)

- [x] PR 前に動作確認をしたか
- [x] 機密情報を含んでいないか

# やったこと<!-- このプルリクエストでやったことを書く -->

This pull request introduces changes to the `frontend` codebase to rename and refactor components related to prototype editing and playing functionality. It also includes the addition of a new `PrototypePlayOld` component and modifications to existing components to switch between `Canvas` and `GameBoard` implementations.

### Component Renaming and Refactoring:

* `frontend/src/app/prototypes/[prototypeId]/versions/[versionId]/edit/old/page.tsx`: Renamed from `edit2/page.tsx` and updated to use `PrototypeEditOld` instead of `PrototypeEdit2`. ([frontend/src/app/prototypes/[prototypeId]/versions/[versionId]/edit/old/page.tsxL3-R11](diffhunk://#diff-e4542771fe734dde73f037a2f1d9e81113f93a52fd21c4837365f2de6fe690eaL3-R11))
* [`frontend/src/features/prototype/components/organisms/PrototypeEditOld.tsx`](diffhunk://#diff-1da99e1aaa8c42c81be76d92c57764391d1dff4c38f850d18d247f5746945203L15-R23): Renamed from `PrototypeEdit2.tsx` and switched from `GameBoard` to `Canvas` for rendering. [[1]](diffhunk://#diff-1da99e1aaa8c42c81be76d92c57764391d1dff4c38f850d18d247f5746945203L15-R23) [[2]](diffhunk://#diff-1da99e1aaa8c42c81be76d92c57764391d1dff4c38f850d18d247f5746945203L110-R110)

### Component Addition:

* [`frontend/src/features/prototype/components/organisms/PrototypePlayOld.tsx`](diffhunk://#diff-7056f02cbdc2e4db8d728e353b39554fcdf02c6bbdd34cad614787563d63a07aR1-R125): Added a new component `PrototypePlayOld` that uses `Canvas` for rendering and manages socket communication for prototype play functionality.

### Switching Between Canvas and GameBoard:

* [`frontend/src/features/prototype/components/organisms/PrototypeEdit.tsx`](diffhunk://#diff-3f2d94687c9e60e731ec892bd080d866cf138e9d761da701d98d6504aa372967L15-R23): Updated to replace `Canvas` with `GameBoard` for rendering in the `PrototypeEdit` component. [[1]](diffhunk://#diff-3f2d94687c9e60e731ec892bd080d866cf138e9d761da701d98d6504aa372967L15-R23) [[2]](diffhunk://#diff-3f2d94687c9e60e731ec892bd080d866cf138e9d761da701d98d6504aa372967L110-R110)
* [`frontend/src/features/prototype/components/organisms/PrototypePlay.tsx`](diffhunk://#diff-848b983a86011162eff6f1803b90362a7f8fd9b76443fb8b40bc9608b405c26dL15-R15): Updated to replace `Canvas` with `GameBoard` for rendering in the `PrototypePlay` component. [[1]](diffhunk://#diff-848b983a86011162eff6f1803b90362a7f8fd9b76443fb8b40bc9608b405c26dL15-R15) [[2]](diffhunk://#diff-848b983a86011162eff6f1803b90362a7f8fd9b76443fb8b40bc9608b405c26dL110-R110)

### New Page for Prototype Play:

* `frontend/src/app/prototypes/[prototypeId]/versions/[versionId]/play/old/page.tsx`: Added a new page for playing prototypes using the `PrototypePlayOld` component. ([frontend/src/app/prototypes/[prototypeId]/versions/[versionId]/play/old/page.tsxR1-R15](diffhunk://#diff-0d31bde175fde9739bf46dd03fef2ec28b2a2a90b03d8b565224dd0dcc389fd0R1-R15))

# やらないこと<!-- このプルリクエストでやってもおかしくないけどやらなかったことを書く -->

特になし

# 懸念点や注意点<!-- このプルリクエストにおける懸念点や注意点を書く -->

特になし

# その他<!-- このプルリクエストで上記の項目以外に伝えるべきことを書く -->

特になし


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - プロトタイプのプレビュー再生用ページとコンポーネントを追加しました。

- **リファクタ**
  - 編集・再生画面の一部で使用するコンポーネントを「Canvas」と「GameBoard」に切り替えました。
  - 一部のコンポーネント名やエクスポート方法を変更しました（例：「PrototypeEdit2」→「PrototypeEditOld」）。

- **その他**
  - ページタイトルやランタイム設定を追加・調整しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->