### PR TITLE
Improve UI uniformity

### DIFF
--- a/frontend/src/features/prototype/components/atoms/DebugInfo.tsx
+++ b/frontend/src/features/prototype/components/atoms/DebugInfo.tsx
@@ -46,8 +46,8 @@ const DebugInfo: React.FC<DebugInfoProps> = ({
     <div
       style={{
         position: 'fixed',
-        bottom: '0.5rem',
-        left: '0.5rem',
+        bottom: '1rem',
+        left: '1rem',
         background: 'rgba(0, 0, 0, 0.7)',
         color: 'white',
         padding: '10px',

--- a/frontend/src/features/prototype/components/atoms/DebugInfo.tsx
+++ b/frontend/src/features/prototype/components/atoms/DebugInfo.tsx
@@ -46,8 +46,8 @@ const DebugInfo: React.FC<DebugInfoProps> = ({
     <div
       style={{
         position: 'fixed',
-        bottom: '20px',
-        left: '20px',
+        bottom: '0.5rem',
+        left: '0.5rem',
         background: 'rgba(0, 0, 0, 0.7)',
         color: 'white',
         padding: '10px',

--- a/frontend/src/features/prototype/components/atoms/Part2.tsx
+++ b/frontend/src/features/prototype/components/atoms/Part2.tsx
@@ -153,7 +153,7 @@ const Part2 = forwardRef<PartHandle, Part2Props>(
         return;
       }
 
-      if (isCard && isFlippedNeeded) {
+      if (isCard && !isFlippedNeeded) {
         reverseCard(!isFlipped, true);
         return;
       }

--- a/frontend/src/features/prototype/components/molecules/PartCreateSidebar.tsx
+++ b/frontend/src/features/prototype/components/molecules/PartCreateSidebar.tsx
@@ -114,7 +114,7 @@ export default function PartCreateSidebar({
   return (
     <>
       {!isLeftSidebarMinimized ? (
-        <div className="fixed left-2 top-4 flex flex-col rounded-xl border border-wood-lightest/40 bg-gradient-to-r from-content to-content-secondary shadow-md overflow-auto w-[240px] max-h-[90vh]">
+        <div className="fixed left-2 top-2 flex flex-col rounded-xl border border-wood-lightest/40 bg-gradient-to-r from-content to-content-secondary shadow-md overflow-auto w-[240px] max-h-[90vh]">
           <div className="flex h-[48px] items-center justify-between p-4">
             <button
               onClick={() => router.push(`/prototypes/groups/${groupId}`)}
@@ -171,7 +171,7 @@ export default function PartCreateSidebar({
           </div>
         </div>
       ) : (
-        <div className="fixed left-2 top-4 flex h-[48px] items-center justify-between rounded-xl border border-wood-lightest/40 bg-gradient-to-r from-content to-content-secondary p-4 shadow-md w-[240px]">
+        <div className="fixed left-2 top-2 flex h-[48px] items-center justify-between rounded-xl border border-wood-lightest/40 bg-gradient-to-r from-content to-content-secondary p-4 shadow-md w-[240px]">
           <button
             onClick={() => router.push(`/prototypes/groups/${groupId}`)}
             className="p-2 hover:bg-wood-lightest/20 rounded-full transition-colors flex-shrink-0"

--- a/frontend/src/features/prototype/components/molecules/PartCreateSidebar.tsx
+++ b/frontend/src/features/prototype/components/molecules/PartCreateSidebar.tsx
@@ -114,7 +114,7 @@ export default function PartCreateSidebar({
   return (
     <>
       {!isLeftSidebarMinimized ? (
-        <div className="fixed left-2 top-2 flex flex-col rounded-xl border border-wood-lightest/40 bg-gradient-to-r from-content to-content-secondary shadow-md overflow-auto w-[240px] max-h-[90vh]">
+        <div className="fixed left-4 top-4 flex flex-col rounded-xl border border-wood-lightest/40 bg-gradient-to-r from-content to-content-secondary shadow-md overflow-auto w-[240px] max-h-[90vh]">
           <div className="flex h-[48px] items-center justify-between p-4">
             <button
               onClick={() => router.push(`/prototypes/groups/${groupId}`)}
@@ -171,7 +171,7 @@ export default function PartCreateSidebar({
           </div>
         </div>
       ) : (
-        <div className="fixed left-2 top-2 flex h-[48px] items-center justify-between rounded-xl border border-wood-lightest/40 bg-gradient-to-r from-content to-content-secondary p-4 shadow-md w-[240px]">
+        <div className="fixed left-4 top-4 flex h-[48px] items-center justify-between rounded-xl border border-wood-lightest/40 bg-gradient-to-r from-content to-content-secondary p-4 shadow-md w-[240px]">
           <button
             onClick={() => router.push(`/prototypes/groups/${groupId}`)}
             className="p-2 hover:bg-wood-lightest/20 rounded-full transition-colors flex-shrink-0"

--- a/frontend/src/features/prototype/components/molecules/PartPropertySidebar.tsx
+++ b/frontend/src/features/prototype/components/molecules/PartPropertySidebar.tsx
@@ -6,7 +6,14 @@
 
 import axios from 'axios';
 import React, { useState, useMemo, useEffect, useRef } from 'react';
+import { BiArea } from 'react-icons/bi';
 import { FaRegCopy, FaRegTrashAlt, FaImage, FaSpinner } from 'react-icons/fa';
+import {
+  Gi3dMeeple,
+  GiCard10Clubs,
+  GiPokerHand,
+  GiStoneBlock,
+} from 'react-icons/gi';
 
 import { useImages } from '@/api/hooks/useImages';
 import { Part, PartProperty, Player } from '@/api/types';
@@ -230,11 +237,24 @@ export default function PartPropertySidebar({
   return (
     <>
       {selectedPart && (
-        <div className="fixed top-4 right-4 flex w-[240px] flex-col rounded-lg shadow-lg border border-gray-200 bg-white max-h-[calc(100vh-32px)] overflow-y-auto">
-          <div className="border-b border-gray-200 rounded-t-lg bg-gray-50 py-2 px-4">
-            <span className="text-[12px] font-medium text-gray-700">
-              プロパティ編集
-            </span>
+        <div className="fixed top-4 right-4 flex w-[240px] flex-col rounded-lg shadow-lg border border-wood-lightest/40 bg-gradient-to-r from-content to-content-secondary max-h-[calc(100vh-32px)] overflow-y-auto">
+          <div className="border-b border-wood-lightest/60 rounded-t-lg bg-gradient-to-r from-wood-light/30 to-wood-light/20 py-2 px-4">
+            <div className="flex items-center">
+              {selectedPart.type === 'card' ? (
+                <GiCard10Clubs className="h-4 w-4 text-wood-dark mr-2" />
+              ) : selectedPart.type === 'token' ? (
+                <Gi3dMeeple className="h-4 w-4 text-wood-dark mr-2" />
+              ) : selectedPart.type === 'hand' ? (
+                <GiPokerHand className="h-4 w-4 text-wood-dark mr-2" />
+              ) : selectedPart.type === 'deck' ? (
+                <GiStoneBlock className="h-4 w-4 text-wood-dark mr-2" />
+              ) : selectedPart.type === 'area' ? (
+                <BiArea className="h-4 w-4 text-wood-dark mr-2" />
+              ) : null}
+              <span className="text-[12px] font-medium text-wood-darkest">
+                プロパティ編集
+              </span>
+            </div>
           </div>
           <div className="flex flex-col gap-2 p-4">
             <span className="mb-2 text-[11px] font-medium">共通</span>
@@ -268,7 +288,7 @@ export default function PartPropertySidebar({
               </div>
             )}
             <div className="flex flex-col gap-1">
-              <p className="text-[9px] font-medium text-gray-500">位置</p>
+              <p className="text-[9px] font-medium text-wood-dark">位置</p>
               <div className="flex w-full gap-2 mb-2">
                 <NumberInput
                   key={`${selectedPart.id}-x-${selectedPart.position.x}`}
@@ -303,7 +323,7 @@ export default function PartPropertySidebar({
                   icon={<>Y</>}
                 />
               </div>
-              <p className="text-[9px] font-medium text-gray-500">サイズ</p>
+              <p className="text-[9px] font-medium text-wood-dark">サイズ</p>
               <div className="flex w-full gap-2 mb-2">
                 <NumberInput
                   key={`${selectedPart.id}-width-${selectedPart.width}`}
@@ -334,7 +354,7 @@ export default function PartPropertySidebar({
                   icon={<>H</>}
                 />
               </div>
-              <p className="text-[9px] font-medium text-gray-500">名前</p>
+              <p className="text-[9px] font-medium text-wood-dark">名前</p>
               <div className="flex w-full mb-2">
                 <TextInput
                   key={`${selectedPart.id}-name-${currentProperty?.name}`}
@@ -343,7 +363,7 @@ export default function PartPropertySidebar({
                   icon={<>T</>}
                 />
               </div>
-              <p className="text-[9px] font-medium text-gray-500">説明</p>
+              <p className="text-[9px] font-medium text-wood-dark">説明</p>
               <div className="flex w-full mb-2">
                 <TextInput
                   key={`${selectedPart.id}-description-${currentProperty?.description}`}
@@ -355,7 +375,9 @@ export default function PartPropertySidebar({
                   multiline
                 />
               </div>
-              <p className="text-[9px] font-medium text-gray-500">テキスト色</p>
+              <p className="text-[9px] font-medium text-wood-dark">
+                テキスト色
+              </p>
               <div className="w-full mb-2 px-4">
                 <div className="grid grid-cols-4 gap-2">
                   {TEXT_COLORS.map((textColor) => (
@@ -373,7 +395,7 @@ export default function PartPropertySidebar({
                   ))}
                 </div>
               </div>
-              <p className="text-[9px] font-medium text-gray-500">背景色</p>
+              <p className="text-[9px] font-medium text-wood-dark">背景色</p>
               <div className="w-full mb-2 px-4">
                 <div className="grid grid-cols-4 gap-2">
                   {COLORS.map((color) => (

--- a/frontend/src/features/prototype/components/molecules/PartPropertySidebar.tsx
+++ b/frontend/src/features/prototype/components/molecules/PartPropertySidebar.tsx
@@ -230,7 +230,7 @@ export default function PartPropertySidebar({
   return (
     <>
       {selectedPart && (
-        <div className="fixed top-2 right-2 flex w-[240px] flex-col rounded-lg shadow-lg border border-gray-200 bg-white max-h-[calc(100vh-32px)] overflow-y-auto">
+        <div className="fixed top-4 right-4 flex w-[240px] flex-col rounded-lg shadow-lg border border-gray-200 bg-white max-h-[calc(100vh-32px)] overflow-y-auto">
           <div className="border-b border-gray-200 rounded-t-lg bg-gray-50 py-2 px-4">
             <span className="text-[12px] font-medium text-gray-700">
               プロパティ編集

--- a/frontend/src/features/prototype/components/molecules/PartPropertySidebar.tsx
+++ b/frontend/src/features/prototype/components/molecules/PartPropertySidebar.tsx
@@ -230,8 +230,12 @@ export default function PartPropertySidebar({
   return (
     <>
       {selectedPart && (
-        <div className="fixed h-full top-0 right-0 flex w-[240px] flex-col border-l border-gray-200 bg-white">
-          <div className="border-b border-gray-200"></div>
+        <div className="fixed top-2 right-2 flex w-[240px] flex-col rounded-lg shadow-lg border border-gray-200 bg-white max-h-[calc(100vh-32px)] overflow-y-auto">
+          <div className="border-b border-gray-200 rounded-t-lg bg-gray-50 py-2 px-4">
+            <span className="text-[12px] font-medium text-gray-700">
+              プロパティ編集
+            </span>
+          </div>
           <div className="flex flex-col gap-2 p-4">
             <span className="mb-2 text-[11px] font-medium">共通</span>
             <div className="flex items-center px-2 pb-2">

--- a/frontend/src/features/prototype/components/molecules/ShortcutHelpPanel.tsx
+++ b/frontend/src/features/prototype/components/molecules/ShortcutHelpPanel.tsx
@@ -23,7 +23,7 @@ export default function ShortcutHelpPanel({
   const [isExpanded, setIsExpanded] = useState(false);
 
   return (
-    <div className="fixed left-[255px] top-4 z-50">
+    <div className="fixed left-[16.25rem] top-[1.75rem] z-50">
       <div className="relative">
         <button
           onClick={() => setIsExpanded(!isExpanded)}

--- a/frontend/src/features/prototype/components/molecules/ShortcutHelpPanel.tsx
+++ b/frontend/src/features/prototype/components/molecules/ShortcutHelpPanel.tsx
@@ -23,7 +23,7 @@ export default function ShortcutHelpPanel({
   const [isExpanded, setIsExpanded] = useState(false);
 
   return (
-    <div className="fixed left-[255px] top-6 z-50">
+    <div className="fixed left-[255px] top-4 z-50">
       <div className="relative">
         <button
           onClick={() => setIsExpanded(!isExpanded)}


### PR DESCRIPTION
# 事前確認(共通)

- [x] PR 前に動作確認をしたか
- [x] 機密情報を含んでいないか

# やったこと<!-- このプルリクエストでやったことを書く -->

This pull request includes several changes aimed at improving the user interface styling and functionality across multiple components in the `frontend/src/features/prototype` directory. The most notable updates include adjustments to spacing and positioning for better consistency, improvements to conditional logic, and enhancements to the visual design of the `PartPropertySidebar`.

### UI Styling Updates:
* [`frontend/src/features/prototype/components/atoms/DebugInfo.tsx`](diffhunk://#diff-76c57dfae26b0bbfc0fe863b663f8fa38eec7e4bf3f9dce4b801f2b5f8aa8564L49-R50): Adjusted `bottom` and `left` values from `20px` to `1rem` for better alignment with modern spacing conventions.
* [`frontend/src/features/prototype/components/molecules/PartCreateSidebar.tsx`](diffhunk://#diff-0f7f6527f4b2e43b5beeb196a3db2130237d089dc42766904cb85bcbd1cf85d1L117-R117): Updated `left` values from `2` to `4` for both minimized and non-minimized states to improve visual alignment. [[1]](diffhunk://#diff-0f7f6527f4b2e43b5beeb196a3db2130237d089dc42766904cb85bcbd1cf85d1L117-R117) [[2]](diffhunk://#diff-0f7f6527f4b2e43b5beeb196a3db2130237d089dc42766904cb85bcbd1cf85d1L174-R174)
* [`frontend/src/features/prototype/components/molecules/ShortcutHelpPanel.tsx`](diffhunk://#diff-adc28b045880026dc883d3ec4a265dda9dc5644f020cbab875d7ba810e9b9013L26-R26): Changed `left` and `top` values to use `rem` units for consistent scaling.

### Functional Logic Enhancements:
* [`frontend/src/features/prototype/components/atoms/Part2.tsx`](diffhunk://#diff-b3e44d7db85ffd8d1659582e97ca3efa4ada55e8897ea2d3d7dadded6061512dL156-R156): Fixed conditional logic by reversing the check on `isFlippedNeeded` within the `isCard` block to ensure proper functionality.

### Visual Design Improvements:
* `frontend/src/features/prototype/components/molecules/PartPropertySidebar.tsx`: 
  - Added new icons (`GiCard10Clubs`, `Gi3dMeeple`, `GiPokerHand`, `GiStoneBlock`, `BiArea`) to visually represent part types in the header.
  - Updated text color classes from `text-gray-500` to `text-wood-dark` for multiple labels to align with the overall design theme. [[1]](diffhunk://#diff-ce31ffca2a5f189b4d162394479352a30809cb5ad8b781e588e51553148c0bc0L267-R291) [[2]](diffhunk://#diff-ce31ffca2a5f189b4d162394479352a30809cb5ad8b781e588e51553148c0bc0L302-R326) [[3]](diffhunk://#diff-ce31ffca2a5f189b4d162394479352a30809cb5ad8b781e588e51553148c0bc0L333-R357) [[4]](diffhunk://#diff-ce31ffca2a5f189b4d162394479352a30809cb5ad8b781e588e51553148c0bc0L342-R366) [[5]](diffhunk://#diff-ce31ffca2a5f189b4d162394479352a30809cb5ad8b781e588e51553148c0bc0L354-R380) [[6]](diffhunk://#diff-ce31ffca2a5f189b4d162394479352a30809cb5ad8b781e588e51553148c0bc0L372-R398)

# やらないこと<!-- このプルリクエストでやってもおかしくないけどやらなかったことを書く -->

特になし

# 懸念点や注意点<!-- このプルリクエストにおける懸念点や注意点を書く -->

特になし

# その他<!-- このプルリクエストで上記の項目以外に伝えるべきことを書く -->

特になし
