### PR TITLE
Add instructions for hands in play page

### DIFF
--- a/frontend/src/features/prototype/components/atoms/DebugInfo.tsx
+++ b/frontend/src/features/prototype/components/atoms/DebugInfo.tsx
@@ -16,6 +16,8 @@ interface DebugInfoProps {
   // Prototype info
   prototypeName: string;
   prototypeVersionNumber?: string;
+  prototypeVersion?: string;
+  isMasterPreview?: boolean;
   groupId: string;
   prototypeType: 'EDIT' | 'PREVIEW';
   // Data
@@ -30,6 +32,8 @@ const DebugInfo: React.FC<DebugInfoProps> = ({
   camera,
   prototypeName,
   prototypeVersionNumber,
+  prototypeVersion,
+  isMasterPreview,
   groupId,
   prototypeType,
   parts,
@@ -66,6 +70,38 @@ const DebugInfo: React.FC<DebugInfoProps> = ({
           paddingBottom: '4px',
         }}
       >
+        <strong>Current Status</strong>
+      </div>
+      <div
+        style={{
+          fontWeight: 'bold',
+          color: selectedPartIds.length ? '#ffcc00' : 'white',
+          marginBottom: '5px',
+        }}
+      >
+        Selected Parts: {selectedPartIds.length}
+      </div>
+      {selectedPartIds.length > 0 && (
+        <div
+          style={{ marginLeft: '10px', fontSize: '12px', marginBottom: '5px' }}
+        >
+          IDs: {selectedPartIds.join(', ')}
+        </div>
+      )}
+      <div>Prototype: {prototypeName}</div>
+      <div>Version: {prototypeVersionNumber || 'N/A'}</div>
+      {prototypeVersion && <div>Version Detail: {prototypeVersion}</div>}
+      <div>Is Master Preview: {isMasterPreview ? 'Yes' : 'No'}</div>
+      <div>Type: {prototypeType}</div>
+
+      <div
+        style={{
+          borderBottom: '1px solid rgba(255, 255, 255, 0.2)',
+          marginTop: '12px',
+          marginBottom: '8px',
+          paddingBottom: '4px',
+        }}
+      >
         <strong>Camera</strong>
       </div>
       <div>X: {Math.round(camera.x)}</div>
@@ -84,8 +120,10 @@ const DebugInfo: React.FC<DebugInfoProps> = ({
       </div>
       <div>Name: {prototypeName}</div>
       <div>Version: {prototypeVersionNumber || 'N/A'}</div>
+      {prototypeVersion && <div>Version Detail: {prototypeVersion}</div>}
       <div>Group ID: {groupId}</div>
       <div>Type: {prototypeType}</div>
+      <div>Is Master Preview: {isMasterPreview ? 'Yes' : 'No'}</div>
 
       <div
         style={{
@@ -116,12 +154,6 @@ const DebugInfo: React.FC<DebugInfoProps> = ({
         </div>
       )}
       <div>Cursors: {Object.keys(cursors).length}</div>
-      <div>Selected: {selectedPartIds.length}</div>
-      {selectedPartIds.length > 0 && (
-        <div style={{ marginLeft: '10px', fontSize: '12px' }}>
-          IDs: {selectedPartIds.join(', ')}
-        </div>
-      )}
 
       <div
         style={{

--- a/frontend/src/features/prototype/components/atoms/DebugInfo.tsx
+++ b/frontend/src/features/prototype/components/atoms/DebugInfo.tsx
@@ -15,9 +15,8 @@ interface DebugInfoProps {
   };
   // Prototype info
   prototypeName: string;
-  prototypeVersionNumber?: string;
-  prototypeVersion?: string;
-  isMasterPreview?: boolean;
+  prototypeVersionNumber: string;
+  isMasterPreview: boolean;
   groupId: string;
   prototypeType: 'EDIT' | 'PREVIEW';
   // Data
@@ -32,7 +31,6 @@ const DebugInfo: React.FC<DebugInfoProps> = ({
   camera,
   prototypeName,
   prototypeVersionNumber,
-  prototypeVersion,
   isMasterPreview,
   groupId,
   prototypeType,
@@ -88,12 +86,6 @@ const DebugInfo: React.FC<DebugInfoProps> = ({
           IDs: {selectedPartIds.join(', ')}
         </div>
       )}
-      <div>Prototype: {prototypeName}</div>
-      <div>Version: {prototypeVersionNumber || 'N/A'}</div>
-      {prototypeVersion && <div>Version Detail: {prototypeVersion}</div>}
-      <div>Is Master Preview: {isMasterPreview ? 'Yes' : 'No'}</div>
-      <div>Type: {prototypeType}</div>
-
       <div
         style={{
           borderBottom: '1px solid rgba(255, 255, 255, 0.2)',
@@ -120,7 +112,6 @@ const DebugInfo: React.FC<DebugInfoProps> = ({
       </div>
       <div>Name: {prototypeName}</div>
       <div>Version: {prototypeVersionNumber || 'N/A'}</div>
-      {prototypeVersion && <div>Version Detail: {prototypeVersion}</div>}
       <div>Group ID: {groupId}</div>
       <div>Type: {prototypeType}</div>
       <div>Is Master Preview: {isMasterPreview ? 'Yes' : 'No'}</div>

--- a/frontend/src/features/prototype/components/molecules/PartCreateSidebar.tsx
+++ b/frontend/src/features/prototype/components/molecules/PartCreateSidebar.tsx
@@ -35,7 +35,7 @@ function SidebarHeader({
   const router = useRouter();
 
   return (
-    <div className="flex h-[48px] items-center justify-between p-4">
+    <div className="flex h-[48px] items-center justify-between px-2 py-4">
       <button
         onClick={() => router.push(`/prototypes/groups/${groupId}`)}
         className="p-2 hover:bg-wood-lightest/20 rounded-full transition-colors flex-shrink-0"

--- a/frontend/src/features/prototype/components/molecules/PreviewSidebars.tsx
+++ b/frontend/src/features/prototype/components/molecules/PreviewSidebars.tsx
@@ -116,9 +116,19 @@ export default function PreviewSidebars({
         <>
           <div className="border-b border-wood-light/30" />
           <div className="flex flex-col gap-2 p-4">
-            <span className="mb-2 text-xs font-medium uppercase tracking-wide text-wood-dark/70">
-              プレイヤー割り当て
-            </span>
+            <div className="flex flex-col items-start justify-between mb-2">
+              <span className="text-xs font-medium uppercase tracking-wide text-wood-dark/70">
+                プレイヤー割り当て
+              </span>
+              <details className="text-xs">
+                <summary className="cursor-pointer text-wood-dark/60 hover:text-wood-dark">
+                  詳細
+                </summary>
+                <div className="p-2 mt-1 bg-wood-lightest/20 rounded-md text-wood-dark/80">
+                  手札のプレイヤー番号とユーザーを紐づけます。
+                </div>
+              </details>
+            </div>
             <div className="flex flex-col gap-1">
               {players.map((player) => (
                 <div key={player.id}>

--- a/frontend/src/features/prototype/components/molecules/PreviewSidebars.tsx
+++ b/frontend/src/features/prototype/components/molecules/PreviewSidebars.tsx
@@ -17,12 +17,14 @@ import { usePartReducer } from '@/features/prototype/hooks/usePartReducer';
 function SidebarHeader({
   prototypeName,
   prototypeVersionNumber,
+  isMasterPreview,
   groupId,
   isMinimized,
   onToggle,
 }: {
   prototypeName: string;
   prototypeVersionNumber?: string;
+  isMasterPreview: boolean;
   groupId: string;
   isMinimized: boolean;
   onToggle: () => void;
@@ -30,7 +32,7 @@ function SidebarHeader({
   const router = useRouter();
 
   return (
-    <div className="flex h-[48px] items-center justify-between p-4">
+    <div className="flex h-[48px] items-center justify-between px-2 py-4">
       <button
         onClick={() => router.push(`/prototypes/groups/${groupId}`)}
         className="p-2 hover:bg-wood-lightest/20 rounded-full transition-colors flex-shrink-0"
@@ -47,19 +49,21 @@ function SidebarHeader({
         </h2>
         {prototypeVersionNumber && (
           <span className="px-1.5 py-0.5 text-[10px] bg-blue-100 text-blue-600 rounded-md min-w-1 border border-blue-600 flex-shrink-0">
-            {prototypeVersionNumber === 'MASTER'
+            {isMasterPreview
               ? 'プレビュー'
               : `プレイルーム${prototypeVersionNumber.replace('.0.0', '')}`}
           </span>
         )}
       </div>
-      <button
-        onClick={onToggle}
-        aria-label={isMinimized ? 'サイドバーを展開' : 'サイドバーを最小化'}
-        className="p-2 rounded-full transition-transform hover:scale-110"
-      >
-        <IoMenu className="h-5 w-5 text-wood-dark hover:text-header transition-colors" />
-      </button>
+      {!isMasterPreview && (
+        <button
+          onClick={onToggle}
+          aria-label={isMinimized ? 'サイドバーを展開' : 'サイドバーを最小化'}
+          className="p-2 rounded-full transition-transform hover:scale-110"
+        >
+          <IoMenu className="h-5 w-5 text-wood-dark hover:text-header transition-colors" />
+        </button>
+      )}
     </div>
   );
 }
@@ -67,6 +71,7 @@ function SidebarHeader({
 export default function PreviewSidebars({
   prototypeName,
   prototypeVersionNumber,
+  isMasterPreview,
   groupId,
   players,
 }: {
@@ -74,6 +79,8 @@ export default function PreviewSidebars({
   prototypeName: string;
   // プロトタイプバージョン番号
   prototypeVersionNumber?: string;
+  // プロトタイプのグループ
+  isMasterPreview: boolean;
   // グループID
   groupId: string;
   // プレイヤー
@@ -107,12 +114,13 @@ export default function PreviewSidebars({
       <SidebarHeader
         prototypeName={prototypeName}
         prototypeVersionNumber={prototypeVersionNumber}
+        isMasterPreview={isMasterPreview}
         groupId={groupId}
         isMinimized={isLeftSidebarMinimized}
         onToggle={toggleSidebar}
       />
 
-      {!isLeftSidebarMinimized && (
+      {!isLeftSidebarMinimized && !isMasterPreview && (
         <>
           <div className="border-b border-wood-light/30" />
           <div className="flex flex-col gap-2 p-4">

--- a/frontend/src/features/prototype/components/organisms/Canvas.tsx
+++ b/frontend/src/features/prototype/components/organisms/Canvas.tsx
@@ -556,6 +556,7 @@ export default function Canvas({
         <PreviewSidebars
           prototypeName={prototypeName}
           prototypeVersionNumber={prototypeVersionNumber}
+          isMasterPreview={isMasterPreview}
           groupId={groupId}
           players={players}
         />

--- a/frontend/src/features/prototype/components/organisms/GameBoard.tsx
+++ b/frontend/src/features/prototype/components/organisms/GameBoard.tsx
@@ -691,6 +691,7 @@ export default function GameBoard({
         <PreviewSidebars
           prototypeName={prototypeName}
           prototypeVersionNumber={prototypeVersionNumber}
+          isMasterPreview={isMasterPreview}
           groupId={groupId}
           players={players}
         />

--- a/frontend/src/features/prototype/components/organisms/GameBoard.tsx
+++ b/frontend/src/features/prototype/components/organisms/GameBoard.tsx
@@ -706,7 +706,8 @@ export default function GameBoard({
       <DebugInfo
         camera={camera}
         prototypeName={prototypeName}
-        prototypeVersionNumber={prototypeVersionNumber}
+        prototypeVersionNumber={prototypeVersionNumber ?? ''}
+        isMasterPreview={isMasterPreview}
         groupId={groupId}
         prototypeType={prototypeType}
         parts={parts}


### PR DESCRIPTION
# 事前確認(共通)

- [x] PR 前に動作確認をしたか
- [x] 機密情報を含んでいないか

# やったこと<!-- このプルリクエストでやったことを書く -->

This pull request introduces changes to improve the debugging interface and sidebar behavior in the prototype feature. The most significant updates include adding the `isMasterPreview` property to several components, enhancing the `DebugInfo` display, and refining sidebar behavior based on the `isMasterPreview` state.

### Debugging Interface Enhancements:
* [`frontend/src/features/prototype/components/atoms/DebugInfo.tsx`](diffhunk://#diff-76c57dfae26b0bbfc0fe863b663f8fa38eec7e4bf3f9dce4b801f2b5f8aa8564L18-R19): Added the `isMasterPreview` property and updated the display to show whether the current view is a master preview. Improved the "Selected Parts" section by adding a bold header, part count, and IDs for selected parts. Removed redundant code for displaying selected part IDs. [[1]](diffhunk://#diff-76c57dfae26b0bbfc0fe863b663f8fa38eec7e4bf3f9dce4b801f2b5f8aa8564L18-R19) [[2]](diffhunk://#diff-76c57dfae26b0bbfc0fe863b663f8fa38eec7e4bf3f9dce4b801f2b5f8aa8564R117) [[3]](diffhunk://#diff-76c57dfae26b0bbfc0fe863b663f8fa38eec7e4bf3f9dce4b801f2b5f8aa8564L119-L124)

### Sidebar Behavior Refinements:
* [`frontend/src/features/prototype/components/molecules/PreviewSidebars.tsx`](diffhunk://#diff-ec921fe3a5f76a2e00e7d7114896ef213343a570263feb48648a340f7ed42f27R20-R35): Incorporated the `isMasterPreview` property to adjust sidebar behavior. Hid the minimize button and certain sidebar sections when `isMasterPreview` is true. Added detailed explanations for player assignments in the sidebar. [[1]](diffhunk://#diff-ec921fe3a5f76a2e00e7d7114896ef213343a570263feb48648a340f7ed42f27R20-R35) [[2]](diffhunk://#diff-ec921fe3a5f76a2e00e7d7114896ef213343a570263feb48648a340f7ed42f27L50-R83) [[3]](diffhunk://#diff-ec921fe3a5f76a2e00e7d7114896ef213343a570263feb48648a340f7ed42f27R117-R139)

### Code Integration Updates:
* [`frontend/src/features/prototype/components/organisms/GameBoard.tsx`](diffhunk://#diff-c744a3a422bf8c68f3e3d51476160645ffd164a9fcc857182f844ff58c1def51R694): Passed the `isMasterPreview` property to both `PreviewSidebars` and `DebugInfo` components to ensure consistent behavior across the interface. [[1]](diffhunk://#diff-c744a3a422bf8c68f3e3d51476160645ffd164a9fcc857182f844ff58c1def51R694) [[2]](diffhunk://#diff-c744a3a422bf8c68f3e3d51476160645ffd164a9fcc857182f844ff58c1def51L709-R711)

### Minor UI Adjustments:
* [`frontend/src/features/prototype/components/molecules/PartCreateSidebar.tsx`](diffhunk://#diff-0f7f6527f4b2e43b5beeb196a3db2130237d089dc42766904cb85bcbd1cf85d1L38-R38): Adjusted padding in the sidebar header for better alignment and spacing.

# やらないこと<!-- このプルリクエストでやってもおかしくないけどやらなかったことを書く -->

特になし

# 懸念点や注意点<!-- このプルリクエストにおける懸念点や注意点を書く -->

特になし

# その他<!-- このプルリクエストで上記の項目以外に伝えるべきことを書く -->

特になし


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - 「マスタープレビュー」状態を示す新しい情報表示を追加し、該当モード時にはサイドバーの一部UI（サイドバーの最小化ボタンやプレイヤー割り当て機能など）を非表示にしました。

- **UI改善**
  - デバッグパネル内の選択パーツ表示を上部に移動し、「現在の状態」として強調表示しました。
  - サイドバーのヘッダー部分のパディングを調整し、レイアウトを改善しました。
  - プレイヤー割り当てセクションに説明文付きの折りたたみ表示を追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->