### PR TITLE
fix: adjust sidebar and shortcut help panel positioning for better layout

### DIFF
--- a/frontend/src/features/prototype/components/molecules/LeftSidebar.tsx
+++ b/frontend/src/features/prototype/components/molecules/LeftSidebar.tsx
@@ -296,7 +296,7 @@ export default function LeftSidebar({
 
   return (
     <div
-      className={`fixed left-4 top-4 flex flex-col rounded-xl border border-wood-lightest/40 bg-gradient-to-r from-content to-content-secondary shadow-md w-[18rem] ${
+      className={`fixed left-4 top-4 flex flex-col rounded-xl border border-wood-lightest/40 bg-gradient-to-r from-content to-content-secondary shadow-md w-[16rem] ${
         !isLeftSidebarMinimized ? 'overflow-auto max-h-[90vh]' : 'h-[48px]'
       }`}
     >

--- a/frontend/src/features/prototype/components/molecules/ShortcutHelpPanel.tsx
+++ b/frontend/src/features/prototype/components/molecules/ShortcutHelpPanel.tsx
@@ -40,7 +40,7 @@ export default function ShortcutHelpPanel({
   }, []);
 
   return (
-    <div className="fixed left-[20rem] top-[1.75rem] z-50">
+    <div className="fixed left-[18rem] top-[1.75rem] z-50">
       <div className="relative">
         <button
           onClick={() => setIsExpanded(!isExpanded)}


### PR DESCRIPTION
# 事前確認(共通)

- [x] PR 前に動作確認をしたか
- [x] 機密情報を含んでいないか

# やったこと<!-- このプルリクエストでやったことを書く -->

This pull request makes minor adjustments to the layout of two components in the prototype's frontend. The changes primarily involve reducing the width of the `LeftSidebar` and shifting the position of the `ShortcutHelpPanel`.

Layout adjustments:

* [`frontend/src/features/prototype/components/molecules/LeftSidebar.tsx`](diffhunk://#diff-738e99c9379cc69752c08d423504353857538bfc257a6d4f3f25e7dd9e96ab02L299-R299): Reduced the width of the `LeftSidebar` component from `18rem` to `16rem` for a more compact design.
* [`frontend/src/features/prototype/components/molecules/ShortcutHelpPanel.tsx`](diffhunk://#diff-adc28b045880026dc883d3ec4a265dda9dc5644f020cbab875d7ba810e9b9013L43-R43): Adjusted the horizontal position of the `ShortcutHelpPanel` component, moving it closer by changing the `left` property from `20rem` to `18rem`.

# やらないこと<!-- このプルリクエストでやってもおかしくないけどやらなかったことを書く -->

特になし

# 懸念点や注意点<!-- このプルリクエストにおける懸念点や注意点を書く -->

特になし

# その他<!-- このプルリクエストで上記の項目以外に伝えるべきことを書く -->

特になし


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **スタイル**
  - サイドバーの幅が狭くなりました。
  - ショートカットヘルプパネルの表示位置が調整されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->