### PR TITLE
fix: update initial camera position logic to focus on the latest part

### DIFF
--- a/frontend/src/features/prototype/components/organisms/GameBoard.tsx
+++ b/frontend/src/features/prototype/components/organisms/GameBoard.tsx
@@ -148,8 +148,8 @@ export default function GameBoard({
 
       const scale = 0.5;
 
-      const targetX = partCenterX * scale - viewportSize.width / 2;
-      const targetY = partCenterY * scale - viewportSize.height / 2;
+      const targetX = partCenterX - viewportSize.width / (2 * scale);
+      const targetY = partCenterY - viewportSize.height / (2 * scale);
 
       const constrainedPosition = constrainCamera(targetX, targetY, scale);
 

--- a/frontend/src/features/prototype/components/organisms/GameBoard.tsx
+++ b/frontend/src/features/prototype/components/organisms/GameBoard.tsx
@@ -94,16 +94,6 @@ export default function GameBoard({
     [canvasSize]
   );
 
-  const initialCameraPosition = useMemo(() => {
-    return {
-      x: centerCoords.x - viewportSize.width / 2 / 0.5,
-      y: centerCoords.y - viewportSize.height / 2 / 0.5,
-      scale: 0.5,
-    };
-  }, [centerCoords, viewportSize]);
-
-  const [camera, setCamera] = useState(initialCameraPosition);
-
   const constrainCamera = useCallback(
     (x: number, y: number, scale: number) => {
       let constrainedX = x;
@@ -140,6 +130,40 @@ export default function GameBoard({
     },
     [viewportSize, canvasSize]
   );
+
+  const initialCameraPosition = useMemo(() => {
+    const latestPart = parts.reduce(
+      (latest, current) => {
+        if (!latest) return current;
+        return new Date(current.updatedAt) > new Date(latest.updatedAt)
+          ? current
+          : latest;
+      },
+      null as PartType | null
+    );
+
+    if (latestPart) {
+      const partCenterX = latestPart.position.x + latestPart.width / 2;
+      const partCenterY = latestPart.position.y + latestPart.height / 2;
+
+      const scale = 0.5;
+
+      const targetX = partCenterX * scale - viewportSize.width / 2;
+      const targetY = partCenterY * scale - viewportSize.height / 2;
+
+      const constrainedPosition = constrainCamera(targetX, targetY, scale);
+
+      return constrainedPosition;
+    }
+
+    return {
+      x: centerCoords.x - viewportSize.width / 2 / 0.5,
+      y: centerCoords.y - viewportSize.height / 2 / 0.5,
+      scale: 0.5,
+    };
+  }, [centerCoords, viewportSize, parts, constrainCamera]);
+
+  const [camera, setCamera] = useState(initialCameraPosition);
 
   useEffect(() => {
     const handleResize = () => {


### PR DESCRIPTION
# 事前確認(共通)

- [x] PR 前に動作確認をしたか
- [x] 機密情報を含んでいないか

# やったこと<!-- このプルリクエストでやったことを書く -->

This pull request updates the `GameBoard` component in `GameBoard.tsx` to improve how the initial camera position is calculated. The changes replace the static calculation of the camera's starting position with logic that dynamically centers the camera on the most recently updated game part, if available.

Enhancements to camera initialization:

* **Dynamic camera positioning based on game parts**:
  - The `initialCameraPosition` calculation now checks for the most recently updated game part (`latestPart`) and centers the camera on it. If no parts are available, the fallback logic remains unchanged.
  
* **Refactored `initialCameraPosition` logic**:
  - The `useMemo` hook for `initialCameraPosition` was updated to include dependencies on `parts` and `constrainCamera`, ensuring the camera's position is recalculated appropriately when these values change.

* **Removed redundant code**:
  - The previous static initialization of `initialCameraPosition` and its associated state setup were removed to streamline the logic.

# やらないこと<!-- このプルリクエストでやってもおかしくないけどやらなかったことを書く -->

特になし

# 懸念点や注意点<!-- このプルリクエストにおける懸念点や注意点を書く -->

特になし

# その他<!-- このプルリクエストで上記の項目以外に伝えるべきことを書く -->

特になし


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **改善**
  - ゲームボード表示時、カメラが常にキャンバス中央ではなく、最新更新パーツを中心に表示されるようになりました。パーツが存在しない場合は従来通り中央に表示されます。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->