### PR TITLE
Rename flip card event to REVERSE_CARD

### DIFF
--- a/backend/src/socket/prototypeHandler.ts
+++ b/backend/src/socket/prototypeHandler.ts
@@ -238,15 +238,14 @@ function handleDeletePart(socket: Socket, io: Server) {
   });
 }
 
-// TODO: ReverseCardという名前に変える
 /**
  * カードを反転させる
  * @param socket - Socket
  * @param io - Server
  */
-function handleFlipCard(socket: Socket, io: Server) {
+function handleReverseCard(socket: Socket, io: Server) {
   socket.on(
-    'FLIP_CARD',
+    'REVERSE_CARD',
     async ({
       cardId,
       isNextFlipped,
@@ -262,7 +261,7 @@ function handleFlipCard(socket: Socket, io: Server) {
           { where: { id: cardId } }
         );
 
-        io.to(prototypeVersionId).emit('FLIP_CARD', {
+        io.to(prototypeVersionId).emit('REVERSE_CARD', {
           cardId,
           isNextFlipped,
         });
@@ -475,7 +474,7 @@ export default function handlePrototype(socket: Socket, io: Server) {
   handleAddPart(socket, io);
   handleUpdatePart(socket, io);
   handleDeletePart(socket, io);
-  handleFlipCard(socket, io);
+  handleReverseCard(socket, io);
   handleChangeOrder(socket, io);
   handleShuffleDeck(socket, io);
   handleUpdatePlayerUser(socket, io);

--- a/frontend/src/features/prototype/components/organisms/Canvas.tsx
+++ b/frontend/src/features/prototype/components/organisms/Canvas.tsx
@@ -155,7 +155,7 @@ export default function Canvas({
   // ソケットイベントの定義
   useEffect(() => {
     socket.on(
-      'FLIP_CARD',
+      'REVERSE_CARD',
       ({
         cardId,
         isNextFlipped,
@@ -178,7 +178,7 @@ export default function Canvas({
     });
 
     return () => {
-      socket.off('FLIP_CARD');
+      socket.off('REVERSE_CARD');
       socket.off('ADD_PART_RESPONSE');
     };
   }, [socket, parts]);

--- a/frontend/src/features/prototype/hooks/useCanvasEvents.ts
+++ b/frontend/src/features/prototype/hooks/useCanvasEvents.ts
@@ -425,7 +425,7 @@ export const useCanvasEvents = ({
     // 裏返し設定が変更された場合のみカードを裏返す
     if (isPreviousParentReverseRequired !== isNextParentReverseRequired) {
       dispatch({
-        type: 'FLIP_CARD',
+        type: 'REVERSE_CARD',
         payload: {
           cardId: cardPart.id,
           isNextFlipped: isNextParentReverseRequired,

--- a/frontend/src/features/prototype/hooks/useCard.ts
+++ b/frontend/src/features/prototype/hooks/useCard.ts
@@ -42,7 +42,7 @@ export const useCard = (part: Part, ref: React.ForwardedRef<PartHandle>) => {
       // ソケットをemitする場合
       if (needsSocketEmit) {
         dispatch({
-          type: 'FLIP_CARD',
+          type: 'REVERSE_CARD',
           payload: { cardId: part.id, isNextFlipped },
         });
       }

--- a/frontend/src/features/prototype/hooks/usePartReducer.ts
+++ b/frontend/src/features/prototype/hooks/usePartReducer.ts
@@ -25,7 +25,7 @@ export type PartAction =
       };
     }
   // カードの裏返し
-  | { type: 'FLIP_CARD'; payload: { cardId: number; isNextFlipped: boolean } }
+  | { type: 'REVERSE_CARD'; payload: { cardId: number; isNextFlipped: boolean } }
   // パーツの更新
   | {
       type: 'UPDATE_PART';
@@ -70,8 +70,8 @@ export const usePartReducer = () => {
             });
             break;
           // カードの裏返し
-          case 'FLIP_CARD':
-            socket.emit('FLIP_CARD', {
+          case 'REVERSE_CARD':
+            socket.emit('REVERSE_CARD', {
               cardId: action.payload.cardId,
               isNextFlipped: action.payload.isNextFlipped,
             });
@@ -90,7 +90,7 @@ export const usePartReducer = () => {
               'isReversible' in action.payload.updatePart &&
               action.payload.isFlipped
             ) {
-              socket.emit('FLIP_CARD', {
+              socket.emit('REVERSE_CARD', {
                 cardId: action.payload.partId,
                 isNextFlipped: !action.payload.isFlipped,
               });


### PR DESCRIPTION
## Summary
- rename the socket event `FLIP_CARD` to `REVERSE_CARD`
- adjust backend handler name
- update frontend dispatchers and listeners

## Testing
- `npm run lint` *(fails: Cannot find module)*


------
https://chatgpt.com/codex/tasks/task_e_684ab84bdfc4832aa48a6cb8a38f057c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **リファクタ**
  - カードの反転に関するイベント名やアクションタイプを「FLIP_CARD」から「REVERSE_CARD」へ統一的に変更しました。これにより、UIや操作方法に変更はありませんが、表示や通知の文言が一部変わる場合があります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->