### PR TITLE
Fix inital camera position

### DIFF
--- a/frontend/src/features/prototype/components/organisms/GameBoard.tsx
+++ b/frontend/src/features/prototype/components/organisms/GameBoard.tsx
@@ -133,20 +133,17 @@ export default function GameBoard({
   );
 
   // 最新のパーツを取得する関数
-  const getLatestPart = useCallback(
-    (parts: PartType[]): PartType | null => {
-      return parts.reduce(
-        (latest, current) => {
-          if (!latest) return current;
-          return new Date(current.updatedAt) > new Date(latest.updatedAt)
-            ? current
-            : latest;
-        },
-        null as PartType | null
-      );
-    },
-    []
-  );
+  const getLatestPart = useCallback((parts: PartType[]): PartType | null => {
+    return parts.reduce(
+      (latest, current) => {
+        if (!latest) return current;
+        return new Date(current.updatedAt) > new Date(latest.updatedAt)
+          ? current
+          : latest;
+      },
+      null as PartType | null
+    );
+  }, []);
 
   // 初期カメラ位置を計算する関数
   const calculateInitialCameraPosition = useCallback(

--- a/frontend/src/features/prototype/components/organisms/GameBoard.tsx
+++ b/frontend/src/features/prototype/components/organisms/GameBoard.tsx
@@ -132,43 +132,45 @@ export default function GameBoard({
     [viewportSize, canvasSize]
   );
 
-  // 最新のパーツを取得する関数
-  const getLatestPart = useCallback((parts: PartType[]): PartType | null => {
-    return parts.reduce(
-      (latest, current) => {
-        if (!latest) return current;
-        return new Date(current.updatedAt) > new Date(latest.updatedAt)
-          ? current
-          : latest;
-      },
-      null as PartType | null
-    );
+  // 全パーツの平均センター位置を計算する関数
+  const calculateAveragePartsCenter = useCallback((parts: PartType[]) => {
+    if (parts.length === 0) return null;
+
+    const totalCenterX = parts.reduce((sum, part) => {
+      return sum + (part.position.x + part.width / 2);
+    }, 0);
+
+    const totalCenterY = parts.reduce((sum, part) => {
+      return sum + (part.position.y + part.height / 2);
+    }, 0);
+
+    return {
+      x: totalCenterX / parts.length,
+      y: totalCenterY / parts.length,
+    };
   }, []);
 
   // 初期カメラ位置を計算する関数
   const calculateInitialCameraPosition = useCallback(
-    (latestPart: PartType) => {
-      const partCenterX = latestPart.position.x + latestPart.width / 2;
-      const partCenterY = latestPart.position.y + latestPart.height / 2;
-
-      // カメラの中央がパーツの中心になるようにカメラの左上位置を計算
+    (averageCenter: { x: number; y: number }) => {
+      // カメラの中央が全パーツの平均センターになるようにカメラの左上位置を計算
       const targetX =
-        partCenterX * DEFAULT_INITIAL_SCALE - viewportSize.width / 2;
+        averageCenter.x * DEFAULT_INITIAL_SCALE - viewportSize.width / 2;
       const targetY =
-        partCenterY * DEFAULT_INITIAL_SCALE - viewportSize.height / 2;
+        averageCenter.y * DEFAULT_INITIAL_SCALE - viewportSize.height / 2;
 
       return constrainCamera(targetX, targetY, DEFAULT_INITIAL_SCALE);
     },
     [viewportSize, constrainCamera]
   );
 
-  // 初期カメラ位置を計算する関数（useMemo で最初の一回だけ計算）
-  const latestPart = useMemo(() => {
-    return parts.length > 0 ? getLatestPart(parts) : null;
-  }, [parts, getLatestPart]);
+  // 全パーツの平均センター位置を計算（useMemo で最初の一回だけ計算）
+  const averagePartsCenter = useMemo(() => {
+    return calculateAveragePartsCenter(parts);
+  }, [parts, calculateAveragePartsCenter]);
 
   const initialCamera = useMemo(() => {
-    if (!latestPart) {
+    if (!averagePartsCenter) {
       // パーツがない場合はキャンバス中央を表示
       return {
         x: centerCoords.x * DEFAULT_INITIAL_SCALE - viewportSize.width / 2,
@@ -177,8 +179,13 @@ export default function GameBoard({
       };
     }
 
-    return calculateInitialCameraPosition(latestPart);
-  }, [latestPart, centerCoords, viewportSize, calculateInitialCameraPosition]);
+    return calculateInitialCameraPosition(averagePartsCenter);
+  }, [
+    averagePartsCenter,
+    centerCoords,
+    viewportSize,
+    calculateInitialCameraPosition,
+  ]);
 
   // 初期カメラ位置が変更された場合（partsが読み込まれた場合など）にカメラを更新
   // ただし、一度初期化されたら以降は自動更新しない


### PR DESCRIPTION
# 事前確認(共通)

- [x] PR 前に動作確認をしたか
- [x] 機密情報を含んでいないか

# やったこと<!-- このプルリクエストでやったことを書く -->

This pull request refactors the logic for determining the initial camera position in the `GameBoard` component. The main change replaces the use of the latest part's position with the average center position of all parts, resulting in a more balanced camera initialization.

### Refactoring for camera initialization:

* Replaced the `getLatestPart` function with `calculateAveragePartsCenter`, which computes the average center position of all parts instead of finding the most recently updated part. (`frontend/src/features/prototype/components/organisms/GameBoard.tsx`, [frontend/src/features/prototype/components/organisms/GameBoard.tsxL135-R173](diffhunk://#diff-c744a3a422bf8c68f3e3d51476160645ffd164a9fcc857182f844ff58c1def51L135-R173))
* Updated the `calculateInitialCameraPosition` function to use the average center position for determining the initial camera position, ensuring the camera centers on the average position of all parts. (`frontend/src/features/prototype/components/organisms/GameBoard.tsx`, [frontend/src/features/prototype/components/organisms/GameBoard.tsxL135-R173](diffhunk://#diff-c744a3a422bf8c68f3e3d51476160645ffd164a9fcc857182f844ff58c1def51L135-R173))
* Replaced `latestPart` with `averagePartsCenter` in the memoized calculation of the initial camera position, aligning the logic with the new average-based approach. (`frontend/src/features/prototype/components/organisms/GameBoard.tsx`, [[1]](diffhunk://#diff-c744a3a422bf8c68f3e3d51476160645ffd164a9fcc857182f844ff58c1def51L135-R173) [[2]](diffhunk://#diff-c744a3a422bf8c68f3e3d51476160645ffd164a9fcc857182f844ff58c1def51L183-R188)

# やらないこと<!-- このプルリクエストでやってもおかしくないけどやらなかったことを書く -->

特になし

# 懸念点や注意点<!-- このプルリクエストにおける懸念点や注意点を書く -->

特になし

# その他<!-- このプルリクエストで上記の項目以外に伝えるべきことを書く -->

特になし


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改善**
  - ゲームボードの初期カメラ位置が、最新のパーツではなく全パーツの中心位置に自動調整されるようになりました。これにより、複数パーツが存在する場合でも全体が見やすくなります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->