### PR TITLE
Fix some wrong path

### DIFF
--- a/backend/src/factories/prototypeFactory.ts
+++ b/backend/src/factories/prototypeFactory.ts
@@ -10,16 +10,16 @@ import PartModel from '../models/Part';
 import PartPropertyModel from '../models/PartProperty';
 
 /**
- * マスタープロトタイプを作成する
+ * プロトタイプグループを作成する
  *
  * @param userId - ユーザーID
  * @param name - プロトタイプ名
  * @param minPlayers - 最小プレイヤー数
  * @param maxPlayers - 最大プレイヤー数
  * @param transaction - トランザクション
- * @returns 作成したプロトタイプ
+ * @returns 作成したプロトタイプグループとそれに含まれるプロトタイプ
  */
-export async function createPrototypeMaster({
+export async function createPrototypeGroup({
   userId,
   name,
   minPlayers,
@@ -79,7 +79,10 @@ export async function createPrototypeMaster({
     { transaction }
   );
 
-  return masterPrototype;
+  return {
+    prototypeGroup,
+    prototypes: [masterPrototype],
+  };
 }
 
 /**

--- a/backend/src/routes/prototypeGroup.ts
+++ b/backend/src/routes/prototypeGroup.ts
@@ -10,7 +10,7 @@ import { getAccessiblePrototypes } from '../helpers/prototypeHelper';
 import sequelize from '../models';
 import {
   createPrototypeInstance,
-  createPrototypeMaster,
+  createPrototypeGroup,
   createPrototypeVersion,
 } from '../factories/prototypeFactory';
 import PrototypeModel from '../models/Prototype';
@@ -112,7 +112,7 @@ router.post('/', async (req: Request, res: Response) => {
 
   const transaction = await sequelize.transaction();
   try {
-    const newPrototype = await createPrototypeMaster({
+    const group = await createPrototypeGroup({
       userId: user.id,
       name,
       minPlayers: playerCount,
@@ -121,7 +121,7 @@ router.post('/', async (req: Request, res: Response) => {
     });
 
     await transaction.commit();
-    res.status(201).json(newPrototype);
+    res.status(201).json(group);
   } catch (error) {
     await transaction.rollback();
     console.error(error);

--- a/frontend/src/api/client/index.ts
+++ b/frontend/src/api/client/index.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
 
-import { setupResponseInterceptor } from './interceptors';
+import { setupInterceptors } from './interceptors';
 
 const apiUrl = process.env.NEXT_PUBLIC_API_URL;
 
@@ -9,6 +9,6 @@ const axiosInstance = axios.create({
   withCredentials: true,
 });
 
-setupResponseInterceptor(axiosInstance);
+setupInterceptors(axiosInstance);
 
 export default axiosInstance;

--- a/frontend/src/api/client/interceptors.ts
+++ b/frontend/src/api/client/interceptors.ts
@@ -1,17 +1,47 @@
 import { AxiosInstance } from 'axios';
-import Router from 'next/router';
 
-export const setupResponseInterceptor = (instance: AxiosInstance) => {
+// リダイレクト先URL定数
+const REDIRECT_URLS = {
+  UNAUTHORIZED: '/', // 401: 未認証時のリダイレクト先
+  FORBIDDEN: '/prototypes', // 403: 認可エラー時のリダイレクト先
+} as const;
+
+/**
+ * 認証エラーハンドリング用のレスポンスインターセプター
+ * 401: 未認証 -> / にリダイレクト
+ * 403: 認可エラー -> /prototypes にリダイレクト
+ *
+ * Next.jsのrouter/navigationが使えない理由：
+ * - useRouter: フックなので、React コンポーネント内でしか使えない
+ * - redirect: サーバーサイドでしか動作しない
+ * - インターセプター: 両方の環境で実行される可能性がある
+ * そのため、window.location.hrefを使用してクライアントサイドでのみリダイレクトを実行
+ */
+export const setupAuthErrorInterceptor = (instance: AxiosInstance) => {
   instance.interceptors.response.use(
     (response) => response,
     (error) => {
-      if (error.response?.status === 401) {
-        Router.push('/about');
+      const status = error.response?.status;
+
+      if (status === 401) {
+        if (typeof window !== 'undefined') {
+          window.location.href = REDIRECT_URLS.UNAUTHORIZED;
+        }
+      } else if (status === 403) {
+        if (typeof window !== 'undefined') {
+          window.location.href = REDIRECT_URLS.FORBIDDEN;
+        }
       }
-      if (error.response?.status === 403) {
-        Router.push('/prototypes');
-      }
+
       return Promise.reject(error);
     }
   );
+};
+
+/**
+ * 全てのインターセプターをセットアップ
+ */
+export const setupInterceptors = (instance: AxiosInstance) => {
+  setupAuthErrorInterceptor(instance);
+  // 将来的に他のインターセプターもここに追加
 };

--- a/frontend/src/api/endpoints/prototypeGroup.ts
+++ b/frontend/src/api/endpoints/prototypeGroup.ts
@@ -27,7 +27,10 @@ export const prototypeGroupService = {
    */
   createPrototypeGroup: async (
     data: PrototypeGroupsCreatePayload
-  ): Promise<PrototypeGroup> => {
+  ): Promise<{
+    prototypeGroup: PrototypeGroup;
+    prototypes: Array<Prototype>;
+  }> => {
     const response = await axiosInstance.post('/api/prototype-groups', data);
     return response.data;
   },

--- a/frontend/src/features/prototype/components/organisms/CreatePrototypeFrom.tsx
+++ b/frontend/src/features/prototype/components/organisms/CreatePrototypeFrom.tsx
@@ -42,20 +42,23 @@ const CreatePrototypeForm: React.FC = () => {
       setIsCreating(true);
 
       // プロトタイプを作成する
-      const newPrototype = await createPrototypeGroup({
+      const group = await createPrototypeGroup({
         name: form.name,
         playerCount: form.playerCount,
       });
 
-      // フォームをリセットする
-      setForm({
-        name: '',
-        playerCount: 4,
-      });
+      const masterPrototype = group.prototypes.find((p) => p.type === 'MASTER');
+
+      if (!masterPrototype) {
+        throw new Error('マスタープロトタイプが見つかりません。');
+      }
+
       setError(null);
 
       // グループページへ遷移する
-      router.push(`/prototypes/groups/${newPrototype.id}`);
+      router.push(
+        `/prototypes/groups/${group.prototypeGroup.id}/${masterPrototype.id}/edit`
+      );
     } catch (error) {
       console.error('Error creating prototype:', error);
       setError('エラーが発生しました。');


### PR DESCRIPTION
# 事前確認(共通)

- [x] PR 前に動作確認をしたか
- [x] 機密情報を含んでいないか

# やったこと<!-- このプルリクエストでやったことを書く -->

This pull request introduces significant updates to both the backend and frontend to support the creation and handling of prototype groups instead of individual prototypes. Additionally, it refactors the frontend API client to improve error handling and maintainability. Below is a breakdown of the most important changes:

### Backend Changes
* **Prototype Group Creation**: Renamed the `createPrototypeMaster` function to `createPrototypeGroup`, updated its functionality to return both the prototype group and its associated prototypes, and updated all references to this function accordingly. (`backend/src/factories/prototypeFactory.ts`: [[1]](diffhunk://#diff-e390d36040d893cae15fbbe6b703e23b4dbb45445f8c43a98821de61067e6a38L13-R22) [[2]](diffhunk://#diff-e390d36040d893cae15fbbe6b703e23b4dbb45445f8c43a98821de61067e6a38L82-R85); `backend/src/routes/prototypeGroup.ts`: [[3]](diffhunk://#diff-fa76caeb121f9eefbdf0827b75d9c42d71c58d3efde1a2c68df28dac4ad78622L13-R13) [[4]](diffhunk://#diff-fa76caeb121f9eefbdf0827b75d9c42d71c58d3efde1a2c68df28dac4ad78622L115-R115) [[5]](diffhunk://#diff-fa76caeb121f9eefbdf0827b75d9c42d71c58d3efde1a2c68df28dac4ad78622L124-R124)

### Frontend API Client Refactor
* **Interceptor Refactor**: Replaced `setupResponseInterceptor` with `setupInterceptors`, which now includes a dedicated `setupAuthErrorInterceptor` for handling 401 and 403 errors. This uses `window.location.href` for client-side redirection, improving compatibility across environments. (`frontend/src/api/client/index.ts`: [[1]](diffhunk://#diff-3464f1f1285a744b177f7f0d4258aed6326991c8446e61c5258a91c60536b893L3-R3) [[2]](diffhunk://#diff-3464f1f1285a744b177f7f0d4258aed6326991c8446e61c5258a91c60536b893L12-R12); `frontend/src/api/client/interceptors.ts`: [[3]](diffhunk://#diff-42293d19c5e796cf5b4b43107d61138efcc1fd12aa48dc9724a09796dc16bffbL2-R47)

### Frontend Changes
* **Prototype Group Service Update**: Updated the return type of `createPrototypeGroup` to include both the prototype group and its prototypes, ensuring compatibility with the new backend API. (`frontend/src/api/endpoints/prototypeGroup.ts`: [frontend/src/api/endpoints/prototypeGroup.tsL30-R33](diffhunk://#diff-e19a1e590336792b53cd535f17dfe328d5807fdc07af19d7361b1d99c4389810L30-R33))
* **Create Prototype Form Update**: Adjusted the form submission logic to handle the new API response, including identifying the master prototype and redirecting to the appropriate edit page. Added error handling for cases where the master prototype is missing. (`frontend/src/features/prototype/components/organisms/CreatePrototypeFrom.tsx`: [frontend/src/features/prototype/components/organisms/CreatePrototypeFrom.tsxL45-R61](diffhunk://#diff-7f86a84c5e5d60e3de84a4042623fc9f58cd6775c3cd2ac30d9a2e579441b6e4L45-R61))

# やらないこと<!-- このプルリクエストでやってもおかしくないけどやらなかったことを書く -->

特になし

# 懸念点や注意点<!-- このプルリクエストにおける懸念点や注意点を書く -->

特になし

# その他<!-- このプルリクエストで上記の項目以外に伝えるべきことを書く -->

特になし


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - プロトタイプグループ作成時、作成されたグループとマスタープロトタイプの両方の情報が返されるようになりました。
  - プロトタイプグループ作成後、マスタープロトタイプの編集ページへ自動的にリダイレクトされるようになりました。

- **改善**
  - 認証エラー時のリダイレクト処理が改善され、より確実に該当ページへ遷移するようになりました。

- **ドキュメント**
  - 一部関数の説明文が最新の挙動に合わせて更新されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->