### PR TITLE
implement server-side image cleanup and socket update

### DIFF
--- a/backend/src/routes/image.ts
+++ b/backend/src/routes/image.ts
@@ -209,7 +209,7 @@ router.get(
  *           enum: [front, back]
  *       - name: emitUpdate
  *         in: query
- *         required: false
+ *         required: true
  *         description: 更新をemitするかどうか（デフォルトはfalse）
  *         schema:
  *           type: string

--- a/backend/src/routes/image.ts
+++ b/backend/src/routes/image.ts
@@ -2,7 +2,7 @@ import { Router, Request, Response, NextFunction } from 'express';
 import multer from 'multer';
 import { uploadImageToS3 } from '../services/imageUploadService';
 import { fetchImageFromS3 } from '../services/imageFetchService';
-import { deleteImageFromS3 } from '../services/imageDeleteService';
+import { cleanupImageIfUnused } from '../services/imageCleanupService';
 import { pipeline } from 'stream/promises';
 
 import ImageModel from '../models/Image';
@@ -12,6 +12,7 @@ import {
   UnauthorizedError,
   NotFoundError,
 } from '../errors/CustomError';
+import { emitUpdatedPartsAndProperties } from '../socket/prototypeHandler';
 
 const router = Router();
 const upload = multer({ storage: multer.memoryStorage() }); // バッファとして読み込み
@@ -187,8 +188,35 @@ router.get(
  *         description: 削除する画像のID
  *         schema:
  *           type: string
+ *       - name: prototypeId
+ *         in: query
+ *         required: true
+ *         description: プロトタイプID
+ *         schema:
+ *           type: string
+ *       - name: partId
+ *         in: query
+ *         required: true
+ *         description: パーツID
+ *         schema:
+ *           type: string
+ *       - name: side
+ *         in: query
+ *         required: true
+ *         description: 面（front または back）
+ *         schema:
+ *           type: string
+ *           enum: [front, back]
+ *       - name: emitUpdate
+ *         in: query
+ *         required: false
+ *         description: 更新をemitするかどうか（デフォルトはfalse）
+ *         schema:
+ *           type: string
+ *           enum: [true, false]
+ *           default: false
  *     responses:
- *       '204':
+ *       '200':
  *         description: 画像が正常に削除されました
  *       '400':
  *         description: Image ID が指定されていない、またはリクエストが不正です
@@ -219,9 +247,14 @@ router.delete(
   '/:imageId',
   async (req: Request, res: Response, next: NextFunction) => {
     const { imageId } = req.params;
+    const { prototypeId, partId, side, emitUpdate } = req.query; // クエリパラメータから取得
     try {
       if (!imageId) {
         throw new ValidationError('Image ID が指定されていません');
+      }
+
+      if (!prototypeId || !partId || !side) {
+        throw new ValidationError('partId、sideおよびsideの指定が必要です');
       }
       // TODO: 画像のアクセス権を確認するロジックを追加(例: ユーザーがその画像にアクセスできるかどうか)
       // ここでは単純にユーザーが認証されているかどうかを確認
@@ -232,10 +265,18 @@ router.delete(
       if (!image) {
         throw new NotFoundError('指定された画像が存在しません');
       }
-      await deleteImageFromS3(image.storagePath);
-      // 画像のメタデータをDBから削除
-      await image.destroy();
-      res.status(204).send();
+      const result = await cleanupImageIfUnused(
+        imageId,
+        partId as string,
+        side as 'front' | 'back'
+      );
+      // UPDATE_PARTSをemit
+      const io = req.app.get('io');
+      if (io && emitUpdate === 'true') {
+        // emitUpdateが"true"の場合はemitする
+        emitUpdatedPartsAndProperties(io, prototypeId as string);
+      }
+      res.status(200).json(result);
     } catch (error) {
       next(error);
     }

--- a/backend/src/routes/image.ts
+++ b/backend/src/routes/image.ts
@@ -199,7 +199,7 @@ router.get(
  *         required: true
  *         description: パーツID
  *         schema:
- *           type: string
+ *           type: number
  *       - name: side
  *         in: query
  *         required: true

--- a/backend/src/routes/image.ts
+++ b/backend/src/routes/image.ts
@@ -254,7 +254,7 @@ router.delete(
       }
 
       if (!prototypeId || !partId || !side) {
-        throw new ValidationError('partId、sideおよびsideの指定が必要です');
+        throw new ValidationError('prototypeId、partId、sideの指定が必要です');
       }
       // TODO: 画像のアクセス権を確認するロジックを追加(例: ユーザーがその画像にアクセスできるかどうか)
       // ここでは単純にユーザーが認証されているかどうかを確認
@@ -267,7 +267,7 @@ router.delete(
       }
       const result = await cleanupImageIfUnused(
         imageId,
-        partId as string,
+        String(partId),
         side as 'front' | 'back'
       );
       // UPDATE_PARTSをemit

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -93,6 +93,8 @@ const io = new Server(server, {
   },
 });
 
+app.set('io', io);
+
 // データベース接続
 sequelize
   .sync()

--- a/backend/src/services/imageCleanupService.ts
+++ b/backend/src/services/imageCleanupService.ts
@@ -24,6 +24,7 @@ export const cleanupImageIfUnused = async (
       ? parseInt(result.count, 10)
       : result.count;
 
+  // 他のパーツでもそのimageIdが使われている場合
   if (count > 1) {
     // PartPropertyのimageIdのみクリアする
     await sequelize.query(

--- a/backend/src/services/imageCleanupService.ts
+++ b/backend/src/services/imageCleanupService.ts
@@ -1,0 +1,53 @@
+import ImageModel from '../models/Image';
+import { deleteImageFromS3 } from './imageDeleteService';
+import sequelize from '../models/index';
+import { QueryTypes } from 'sequelize';
+
+/**
+ * 画像が他で使われていなければDBとストレージから削除
+ * @param imageId - 削除対象の画像ID
+ * @returns { deleted: boolean }
+ */
+export const cleanupImageIfUnused = async (
+  imageId: string,
+  partId: string,
+  side: 'front' | 'back'
+): Promise<{ deleted: boolean }> => {
+  // 他で使われていないかチェック（COUNT(*)が2以上の場合に削除する）
+  const [result] = (await sequelize.query(
+    `SELECT COUNT(*) AS "count" FROM "PartProperties" WHERE "imageId" = :imageId`,
+    { replacements: { imageId }, type: QueryTypes.SELECT }
+  )) as [{ count: number | string }];
+
+  // countはDBによってstring型で返る場合があるので数値化
+  const count =
+    typeof result.count === 'string'
+      ? parseInt(result.count, 10)
+      : result.count;
+
+  if (count > 1) {
+    // PartPropertyのimageIdのみクリアする
+    await sequelize.query(
+      `UPDATE "PartProperties" SET "imageId" = NULL WHERE "partId" = :partId AND "side" = :side`,
+      {
+        replacements: { partId, side },
+        type: QueryTypes.UPDATE,
+      }
+    );
+    // 画像は削除しない
+    return { deleted: false };
+  }
+
+  // S3とDBから削除
+  const image = await ImageModel.findByPk(imageId);
+  if (image) {
+    await deleteImageFromS3(image.storagePath);
+    // image.destroy()により、PartProperty.imageIdはDBの
+    // ON DELETE SET NULL制約により自動的にNULLに更新される
+    await image.destroy();
+    return { deleted: true };
+  }
+  // 画像が見つからない場合は何もしない
+  console.warn(`Image with ID ${imageId} not found for cleanup.`);
+  return { deleted: false };
+};

--- a/backend/src/services/imageCleanupService.ts
+++ b/backend/src/services/imageCleanupService.ts
@@ -13,7 +13,6 @@ export const cleanupImageIfUnused = async (
   partId: string,
   side: 'front' | 'back'
 ): Promise<{ deleted: boolean }> => {
-  // 他で使われていないかチェック（COUNT(*)が2以上の場合に削除する）
   const [result] = (await sequelize.query(
     `SELECT COUNT(*) AS "count" FROM "PartProperties" WHERE "imageId" = :imageId`,
     { replacements: { imageId }, type: QueryTypes.SELECT }

--- a/backend/src/socket/prototypeHandler.ts
+++ b/backend/src/socket/prototypeHandler.ts
@@ -57,7 +57,10 @@ async function fetchPartsAndProperties(prototypeId: string) {
  * @param io - Server
  * @param {string} prototypeId- プロトタイプバージョンID
  */
-async function emitUpdatedPartsAndProperties(io: Server, prototypeId: string) {
+export async function emitUpdatedPartsAndProperties(
+  io: Server,
+  prototypeId: string
+) {
   const { parts, properties } = await fetchPartsAndProperties(prototypeId);
   io.to(prototypeId).emit('UPDATE_PARTS', { parts, properties });
 }

--- a/backend/swagger-output.json
+++ b/backend/swagger-output.json
@@ -1641,7 +1641,7 @@
           {
             "name": "emitUpdate",
             "in": "query",
-            "required": false,
+            "required": true,
             "description": "更新をemitするかどうか（デフォルトはfalse）",
             "schema": {
               "type": "string",

--- a/backend/swagger-output.json
+++ b/backend/swagger-output.json
@@ -442,104 +442,33 @@
     }
   },
   "paths": {
-    "/auth/google": {
+    "/api/users/search": {
       "get": {
         "tags": [
-          "Auth"
+          "Users"
         ],
-        "summary": "Googleログイン",
-        "description": "Googleアカウントを使用してログインします。",
-        "responses": {
-          "302": {
-            "description": "リダイレクト",
-            "headers": {
-              "Location": {
-                "description": "リダイレクト先のURL",
-                "schema": {
-                  "type": "string"
-                },
-                "example": "https://accounts.google.com/o/oauth2/auth"
-              }
+        "summary": "ユーザー検索",
+        "description": "ユーザー名でユーザーを検索します。",
+        "parameters": [
+          {
+            "name": "username",
+            "in": "query",
+            "required": true,
+            "description": "検索するユーザー名",
+            "schema": {
+              "type": "string"
             }
           }
-        }
-      }
-    },
-    "/auth/google/callback": {
-      "get": {
-        "tags": [
-          "Auth"
         ],
-        "summary": "Googleログインコールバック",
-        "description": "GoogleログインのコールバックURL。",
-        "responses": {
-          "302": {
-            "description": "ログイン成功時にリダイレクト",
-            "headers": {
-              "Location": {
-                "description": "リダイレクト先のURL",
-                "schema": {
-                  "type": "string"
-                },
-                "example": "http://localhost:3000/groups"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/auth/logout": {
-      "post": {
-        "tags": [
-          "Auth"
-        ],
-        "summary": "ログアウト",
-        "description": "現在のセッションを終了し、ユーザーをログアウトします。",
         "responses": {
           "200": {
-            "description": "ログアウト成功",
+            "description": "検索結果を返します",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SuccessResponse"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "ログアウト失敗",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error500Response"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/auth/user": {
-      "get": {
-        "tags": [
-          "Auth"
-        ],
-        "summary": "ユーザー情報取得",
-        "description": "現在ログインしているユーザーの情報を取得します。",
-        "responses": {
-          "200": {
-            "description": "ユーザー情報を返します",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "string"
-                    },
-                    "username": {
-                      "type": "string"
-                    }
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/User"
                   }
                 }
               }
@@ -548,314 +477,19 @@
         }
       }
     },
-    "/api/images": {
-      "post": {
-        "tags": [
-          "Images"
-        ],
-        "summary": "画像アップロード",
-        "description": "S3に画像をアップロードし、画像のメタデータを保存します。",
-        "requestBody": {
-          "required": true,
-          "content": {
-            "multipart/form-data": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "image": {
-                    "type": "string",
-                    "format": "binary",
-                    "description": "アップロードする画像ファイル"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "画像が正常にアップロードされました",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "$ref": "#/components/schemas/Image"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "アップロード対象の画像が存在しない、またはサポートされていない画像形式です",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error400Response"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "認証されていないユーザーです",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error401Response"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "画像のアップロードに失敗しました",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error500Response"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/images/{imageId}": {
-      "get": {
-        "tags": [
-          "Images"
-        ],
-        "summary": "画像取得",
-        "description": "S3から指定された画像を取得し、画像データを直接返します。",
-        "parameters": [
-          {
-            "name": "imageId",
-            "in": "path",
-            "required": true,
-            "description": "取得する画像のID",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "画像が正常に取得されました",
-            "content": {
-              "image/jpeg": {
-                "schema": {
-                  "type": "string",
-                  "format": "binary"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Image ID が指定されていない、またはリクエストが不正です",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error400Response"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "認証されていないユーザーです",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error401Response"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "指定された画像が存在しません",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error404Response"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "画像を取得できませんでした",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error500Response"
-                }
-              }
-            }
-          }
-        }
-      },
-      "delete": {
-        "tags": [
-          "Images"
-        ],
-        "summary": "画像削除",
-        "description": "S3から指定された画像を削除します。",
-        "parameters": [
-          {
-            "name": "imageId",
-            "in": "path",
-            "required": true,
-            "description": "削除する画像のID",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "prototypeId",
-            "in": "query",
-            "required": true,
-            "description": "プロトタイプID",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "partId",
-            "in": "query",
-            "required": true,
-            "description": "パーツID",
-            "schema": {
-              "type": "number"
-            }
-          },
-          {
-            "name": "side",
-            "in": "query",
-            "required": true,
-            "description": "面（front または back）",
-            "schema": {
-              "type": "string",
-              "enum": [
-                "front",
-                "back"
-              ]
-            }
-          },
-          {
-            "name": "emitUpdate",
-            "in": "query",
-            "required": false,
-            "description": "更新をemitするかどうか（デフォルトはfalse）",
-            "schema": {
-              "type": "string",
-              "enum": [
-                true,
-                false
-              ],
-              "default": false
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "画像が正常に削除されました"
-          },
-          "400": {
-            "description": "Image ID が指定されていない、またはリクエストが不正です",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error400Response"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "認証されていないユーザーです",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error401Response"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "指定された画像が存在しません",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error404Response"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "画像を削除できませんでした",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error500Response"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/prototypes/{prototypeId}": {
-      "get": {
-        "tags": [
-          "Prototypes"
-        ],
-        "summary": "特定のプロトタイプ取得",
-        "description": "指定されたIDのプロトタイプを取得します。",
-        "parameters": [
-          {
-            "name": "prototypeId",
-            "in": "path",
-            "required": true,
-            "description": "プロトタイプのID",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "プロトタイプを返します",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "prototype": {
-                      "$ref": "#/components/schemas/Prototype"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "プロトタイプが見つかりません",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error404Response"
-                }
-              }
-            }
-          }
-        }
-      },
+    "/api/users/{userId}": {
       "put": {
         "tags": [
-          "Prototypes"
+          "Users"
         ],
-        "summary": "プロトタイプ更新",
-        "description": "指定されたIDのプロトタイプを更新します。",
+        "summary": "ユーザー情報更新",
+        "description": "ユーザー名を更新します。",
         "parameters": [
           {
-            "name": "prototypeId",
+            "name": "userId",
             "in": "path",
             "required": true,
-            "description": "プロトタイプのID",
+            "description": "更新するユーザーのID",
             "schema": {
               "type": "string"
             }
@@ -867,15 +501,13 @@
             "application/json": {
               "schema": {
                 "type": "object",
+                "required": [
+                  "username"
+                ],
                 "properties": {
-                  "name": {
-                    "type": "string"
-                  },
-                  "minPlayers": {
-                    "type": "integer"
-                  },
-                  "maxPlayers": {
-                    "type": "integer"
+                  "username": {
+                    "type": "string",
+                    "description": "新しいユーザー名"
                   }
                 }
               }
@@ -884,64 +516,26 @@
         },
         "responses": {
           "200": {
-            "description": "プロトタイプを更新しました",
+            "description": "ユーザー情報が更新されました",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Prototype"
+                  "$ref": "#/components/schemas/User"
                 }
               }
             }
           },
-          "404": {
-            "description": "プロトタイプが見つかりません",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error404Response"
-                }
-              }
-            }
-          }
-        }
-      },
-      "delete": {
-        "tags": [
-          "Prototypes"
-        ],
-        "summary": "プロトタイプ削除",
-        "description": "指定されたIDのプロトタイプを削除します。",
-        "parameters": [
-          {
-            "name": "prototypeId",
-            "in": "path",
-            "required": true,
-            "description": "プロトタイプのID",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "プロトタイプを削除しました",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/SuccessResponse"
-                }
-              }
-            }
+          "400": {
+            "description": "リクエストが不正です"
+          },
+          "401": {
+            "description": "アクセス権がありません"
           },
           "404": {
-            "description": "プロトタイプが見つかりません",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error404Response"
-                }
-              }
-            }
+            "description": "ユーザーが見つかりません"
+          },
+          "500": {
+            "description": "サーバーエラー"
           }
         }
       }
@@ -1708,19 +1302,19 @@
         }
       }
     },
-    "/api/users/search": {
+    "/api/prototypes/{prototypeId}": {
       "get": {
         "tags": [
-          "Users"
+          "Prototypes"
         ],
-        "summary": "ユーザー検索",
-        "description": "ユーザー名でユーザーを検索します。",
+        "summary": "特定のプロトタイプ取得",
+        "description": "指定されたIDのプロトタイプを取得します。",
         "parameters": [
           {
-            "name": "username",
-            "in": "query",
+            "name": "prototypeId",
+            "in": "path",
             "required": true,
-            "description": "検索するユーザー名",
+            "description": "プロトタイプのID",
             "schema": {
               "type": "string"
             }
@@ -1728,34 +1322,44 @@
         ],
         "responses": {
           "200": {
-            "description": "検索結果を返します",
+            "description": "プロトタイプを返します",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/User"
+                  "type": "object",
+                  "properties": {
+                    "prototype": {
+                      "$ref": "#/components/schemas/Prototype"
+                    }
                   }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "プロトタイプが見つかりません",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error404Response"
                 }
               }
             }
           }
         }
-      }
-    },
-    "/api/users/{userId}": {
+      },
       "put": {
         "tags": [
-          "Users"
+          "Prototypes"
         ],
-        "summary": "ユーザー情報更新",
-        "description": "ユーザー名を更新します。",
+        "summary": "プロトタイプ更新",
+        "description": "指定されたIDのプロトタイプを更新します。",
         "parameters": [
           {
-            "name": "userId",
+            "name": "prototypeId",
             "in": "path",
             "required": true,
-            "description": "更新するユーザーのID",
+            "description": "プロトタイプのID",
             "schema": {
               "type": "string"
             }
@@ -1767,13 +1371,15 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "username"
-                ],
                 "properties": {
-                  "username": {
-                    "type": "string",
-                    "description": "新しいユーザー名"
+                  "name": {
+                    "type": "string"
+                  },
+                  "minPlayers": {
+                    "type": "integer"
+                  },
+                  "maxPlayers": {
+                    "type": "integer"
                   }
                 }
               }
@@ -1782,26 +1388,420 @@
         },
         "responses": {
           "200": {
-            "description": "ユーザー情報が更新されました",
+            "description": "プロトタイプを更新しました",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/User"
+                  "$ref": "#/components/schemas/Prototype"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "プロトタイプが見つかりません",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error404Response"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Prototypes"
+        ],
+        "summary": "プロトタイプ削除",
+        "description": "指定されたIDのプロトタイプを削除します。",
+        "parameters": [
+          {
+            "name": "prototypeId",
+            "in": "path",
+            "required": true,
+            "description": "プロトタイプのID",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "プロトタイプを削除しました",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SuccessResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "プロトタイプが見つかりません",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error404Response"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/images": {
+      "post": {
+        "tags": [
+          "Images"
+        ],
+        "summary": "画像アップロード",
+        "description": "S3に画像をアップロードし、画像のメタデータを保存します。",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "image": {
+                    "type": "string",
+                    "format": "binary",
+                    "description": "アップロードする画像ファイル"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "画像が正常にアップロードされました",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "$ref": "#/components/schemas/Image"
                 }
               }
             }
           },
           "400": {
-            "description": "リクエストが不正です"
+            "description": "アップロード対象の画像が存在しない、またはサポートされていない画像形式です",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error400Response"
+                }
+              }
+            }
           },
           "401": {
-            "description": "アクセス権がありません"
-          },
-          "404": {
-            "description": "ユーザーが見つかりません"
+            "description": "認証されていないユーザーです",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error401Response"
+                }
+              }
+            }
           },
           "500": {
-            "description": "サーバーエラー"
+            "description": "画像のアップロードに失敗しました",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error500Response"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/images/{imageId}": {
+      "get": {
+        "tags": [
+          "Images"
+        ],
+        "summary": "画像取得",
+        "description": "S3から指定された画像を取得し、画像データを直接返します。",
+        "parameters": [
+          {
+            "name": "imageId",
+            "in": "path",
+            "required": true,
+            "description": "取得する画像のID",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "画像が正常に取得されました",
+            "content": {
+              "image/jpeg": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Image ID が指定されていない、またはリクエストが不正です",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error400Response"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "認証されていないユーザーです",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error401Response"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "指定された画像が存在しません",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error404Response"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "画像を取得できませんでした",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error500Response"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Images"
+        ],
+        "summary": "画像削除",
+        "description": "S3から指定された画像を削除します。",
+        "parameters": [
+          {
+            "name": "imageId",
+            "in": "path",
+            "required": true,
+            "description": "削除する画像のID",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "prototypeId",
+            "in": "query",
+            "required": true,
+            "description": "プロトタイプID",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "partId",
+            "in": "query",
+            "required": true,
+            "description": "パーツID",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "name": "side",
+            "in": "query",
+            "required": true,
+            "description": "面（front または back）",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "front",
+                "back"
+              ]
+            }
+          },
+          {
+            "name": "emitUpdate",
+            "in": "query",
+            "required": false,
+            "description": "更新をemitするかどうか（デフォルトはfalse）",
+            "schema": {
+              "type": "string",
+              "enum": [
+                true,
+                false
+              ],
+              "default": false
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "画像が正常に削除されました"
+          },
+          "400": {
+            "description": "Image ID が指定されていない、またはリクエストが不正です",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error400Response"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "認証されていないユーザーです",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error401Response"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "指定された画像が存在しません",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error404Response"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "画像を削除できませんでした",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error500Response"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/auth/google": {
+      "get": {
+        "tags": [
+          "Auth"
+        ],
+        "summary": "Googleログイン",
+        "description": "Googleアカウントを使用してログインします。",
+        "responses": {
+          "302": {
+            "description": "リダイレクト",
+            "headers": {
+              "Location": {
+                "description": "リダイレクト先のURL",
+                "schema": {
+                  "type": "string"
+                },
+                "example": "https://accounts.google.com/o/oauth2/auth"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/auth/google/callback": {
+      "get": {
+        "tags": [
+          "Auth"
+        ],
+        "summary": "Googleログインコールバック",
+        "description": "GoogleログインのコールバックURL。",
+        "responses": {
+          "302": {
+            "description": "ログイン成功時にリダイレクト",
+            "headers": {
+              "Location": {
+                "description": "リダイレクト先のURL",
+                "schema": {
+                  "type": "string"
+                },
+                "example": "http://localhost:3000/groups"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/auth/logout": {
+      "post": {
+        "tags": [
+          "Auth"
+        ],
+        "summary": "ログアウト",
+        "description": "現在のセッションを終了し、ユーザーをログアウトします。",
+        "responses": {
+          "200": {
+            "description": "ログアウト成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SuccessResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "ログアウト失敗",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error500Response"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/auth/user": {
+      "get": {
+        "tags": [
+          "Auth"
+        ],
+        "summary": "ユーザー情報取得",
+        "description": "現在ログインしているユーザーの情報を取得します。",
+        "responses": {
+          "200": {
+            "description": "ユーザー情報を返します",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "username": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
           }
         }
       }
@@ -1809,20 +1809,20 @@
   },
   "tags": [
     {
-      "name": "Auth",
-      "description": "認証関連のAPI"
-    },
-    {
-      "name": "Images",
-      "description": "画像管理API"
+      "name": "Users",
+      "description": "ユーザー管理API"
     },
     {
       "name": "Prototypes",
       "description": "プロトタイプ管理API"
     },
     {
-      "name": "Users",
-      "description": "ユーザー管理API"
+      "name": "Images",
+      "description": "画像管理API"
+    },
+    {
+      "name": "Auth",
+      "description": "認証関連のAPI"
     }
   ]
 }

--- a/backend/swagger-output.json
+++ b/backend/swagger-output.json
@@ -704,10 +704,55 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "prototypeId",
+            "in": "query",
+            "required": true,
+            "description": "プロトタイプID",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "partId",
+            "in": "query",
+            "required": true,
+            "description": "パーツID",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "side",
+            "in": "query",
+            "required": true,
+            "description": "面（front または back）",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "front",
+                "back"
+              ]
+            }
+          },
+          {
+            "name": "emitUpdate",
+            "in": "query",
+            "required": false,
+            "description": "更新をemitするかどうか（デフォルトはfalse）",
+            "schema": {
+              "type": "string",
+              "enum": [
+                true,
+                false
+              ],
+              "default": false
+            }
           }
         ],
         "responses": {
-          "204": {
+          "200": {
             "description": "画像が正常に削除されました"
           },
           "400": {

--- a/backend/swagger-output.json
+++ b/backend/swagger-output.json
@@ -720,7 +720,7 @@
             "required": true,
             "description": "パーツID",
             "schema": {
-              "type": "string"
+              "type": "number"
             }
           },
           {

--- a/frontend/src/api/endpoints/images.ts
+++ b/frontend/src/api/endpoints/images.ts
@@ -1,6 +1,10 @@
 import axiosInstance from '@/api/client';
 
-import { ImagesCreateData, ImagesDeleteData } from '../types';
+import {
+  ImagesCreateData,
+  ImagesDeleteData,
+  ImagesDeleteParams,
+} from '../types';
 
 export const imagesService = {
   /*
@@ -22,8 +26,14 @@ export const imagesService = {
   /*
    * 画像データ削除
    */
-  deleteImage: async (imageId: string): Promise<ImagesDeleteData> => {
-    const response = await axiosInstance.delete(`/api/images/${imageId}`);
+  deleteImage: async (
+    imageId: string,
+    params: Omit<ImagesDeleteParams, 'imageId'>
+  ): Promise<ImagesDeleteData> => {
+    const query = `?prototypeId=${params.prototypeId}&partId=${params.partId}&side=${params.side}&emitUpdate=${params.emitUpdate}`;
+    const response = await axiosInstance.delete(
+      `/api/images/${imageId}${query}`
+    );
     return response.data;
   },
 };

--- a/frontend/src/api/hooks/useImages.ts
+++ b/frontend/src/api/hooks/useImages.ts
@@ -1,5 +1,7 @@
 import { useCallback } from 'react';
 
+import { ImagesDeleteParams } from '../types';
+
 import { imagesService } from '@/api/endpoints/images';
 
 export const useImages = () => {
@@ -20,9 +22,12 @@ export const useImages = () => {
   /**
    * 画像削除
    */
-  const deleteImage = useCallback(async (imageId: string) => {
-    return await imagesService.deleteImage(imageId);
-  }, []);
+  const deleteImage = useCallback(
+    async (imageId: string, params: Omit<ImagesDeleteParams, 'imageId'>) => {
+      return await imagesService.deleteImage(imageId, params);
+    },
+    []
+  );
 
   return {
     fetchImage,

--- a/frontend/src/api/hooks/useImages.ts
+++ b/frontend/src/api/hooks/useImages.ts
@@ -1,8 +1,8 @@
 import { useCallback } from 'react';
 
-import { ImagesDeleteParams } from '../types';
-
 import { imagesService } from '@/api/endpoints/images';
+
+import { ImagesDeleteParams } from '../types';
 
 export const useImages = () => {
   /**

--- a/frontend/src/api/types/Api.ts
+++ b/frontend/src/api/types/Api.ts
@@ -53,109 +53,42 @@ export class Api<
   SecurityDataType = unknown,
 > extends HttpClient<SecurityDataType> {
   /**
-   * @description S3に画像をアップロードし、画像のメタデータを保存します。
+   * @description ユーザー名でユーザーを検索します。
    *
-   * @tags Images
-   * @name ImagesCreate
-   * @summary 画像アップロード
-   * @request POST:/api/images
+   * @tags Users
+   * @name UsersSearchList
+   * @summary ユーザー検索
+   * @request GET:/api/users/search
    */
-  imagesCreate = (data: ImagesCreatePayload, params: RequestParams = {}) =>
-    this.request<ImagesCreateData, Error400Response | Error500Response>({
-      path: `/api/images`,
-      method: 'POST',
-      body: data,
-      type: ContentType.FormData,
-      format: 'json',
-      ...params,
-    });
-  /**
-   * @description S3から指定された画像を取得し、画像データを直接返します。
-   *
-   * @tags Images
-   * @name ImagesDetail
-   * @summary 画像取得
-   * @request GET:/api/images/{imageId}
-   */
-  imagesDetail = (imageId: string, params: RequestParams = {}) =>
-    this.request<
-      ImagesDetailData,
-      Error400Response | Error404Response | Error500Response
-    >({
-      path: `/api/images/${imageId}`,
-      method: 'GET',
-      format: 'blob',
-      ...params,
-    });
-  /**
-   * @description S3から指定された画像を削除します。
-   *
-   * @tags Images
-   * @name ImagesDelete
-   * @summary 画像削除
-   * @request DELETE:/api/images/{imageId}
-   */
-  imagesDelete = (
-    { imageId, ...query }: ImagesDeleteParams,
+  usersSearchList = (
+    query: UsersSearchListParams,
     params: RequestParams = {}
   ) =>
-    this.request<
-      ImagesDeleteData,
-      Error400Response | Error404Response | Error500Response
-    >({
-      path: `/api/images/${imageId}`,
-      method: 'DELETE',
+    this.request<UsersSearchListData, any>({
+      path: `/api/users/search`,
+      method: 'GET',
       query: query,
-      ...params,
-    });
-  /**
-   * @description 指定されたIDのプロトタイプを取得します。
-   *
-   * @tags Prototypes
-   * @name PrototypesDetail
-   * @summary 特定のプロトタイプ取得
-   * @request GET:/api/prototypes/{prototypeId}
-   */
-  prototypesDetail = (prototypeId: string, params: RequestParams = {}) =>
-    this.request<PrototypesDetailData, Error404Response>({
-      path: `/api/prototypes/${prototypeId}`,
-      method: 'GET',
       format: 'json',
       ...params,
     });
   /**
-   * @description 指定されたIDのプロトタイプを更新します。
+   * @description ユーザー名を更新します。
    *
-   * @tags Prototypes
-   * @name PrototypesUpdate
-   * @summary プロトタイプ更新
-   * @request PUT:/api/prototypes/{prototypeId}
+   * @tags Users
+   * @name UsersUpdate
+   * @summary ユーザー情報更新
+   * @request PUT:/api/users/{userId}
    */
-  prototypesUpdate = (
-    prototypeId: string,
-    data: PrototypesUpdatePayload,
+  usersUpdate = (
+    userId: string,
+    data: UsersUpdatePayload,
     params: RequestParams = {}
   ) =>
-    this.request<PrototypesUpdateData, Error404Response>({
-      path: `/api/prototypes/${prototypeId}`,
+    this.request<UsersUpdateData, void>({
+      path: `/api/users/${userId}`,
       method: 'PUT',
       body: data,
       type: ContentType.Json,
-      format: 'json',
-      ...params,
-    });
-  /**
-   * @description 指定されたIDのプロトタイプを削除します。
-   *
-   * @tags Prototypes
-   * @name PrototypesDelete
-   * @summary プロトタイプ削除
-   * @request DELETE:/api/prototypes/{prototypeId}
-   */
-  prototypesDelete = (prototypeId: string, params: RequestParams = {}) =>
-    this.request<PrototypesDeleteData, Error404Response>({
-      path: `/api/prototypes/${prototypeId}`,
-      method: 'DELETE',
       format: 'json',
       ...params,
     });
@@ -438,43 +371,110 @@ export class Api<
       ...params,
     });
   /**
-   * @description ユーザー名でユーザーを検索します。
+   * @description 指定されたIDのプロトタイプを取得します。
    *
-   * @tags Users
-   * @name UsersSearchList
-   * @summary ユーザー検索
-   * @request GET:/api/users/search
+   * @tags Prototypes
+   * @name PrototypesDetail
+   * @summary 特定のプロトタイプ取得
+   * @request GET:/api/prototypes/{prototypeId}
    */
-  usersSearchList = (
-    query: UsersSearchListParams,
-    params: RequestParams = {}
-  ) =>
-    this.request<UsersSearchListData, any>({
-      path: `/api/users/search`,
+  prototypesDetail = (prototypeId: string, params: RequestParams = {}) =>
+    this.request<PrototypesDetailData, Error404Response>({
+      path: `/api/prototypes/${prototypeId}`,
       method: 'GET',
-      query: query,
       format: 'json',
       ...params,
     });
   /**
-   * @description ユーザー名を更新します。
+   * @description 指定されたIDのプロトタイプを更新します。
    *
-   * @tags Users
-   * @name UsersUpdate
-   * @summary ユーザー情報更新
-   * @request PUT:/api/users/{userId}
+   * @tags Prototypes
+   * @name PrototypesUpdate
+   * @summary プロトタイプ更新
+   * @request PUT:/api/prototypes/{prototypeId}
    */
-  usersUpdate = (
-    userId: string,
-    data: UsersUpdatePayload,
+  prototypesUpdate = (
+    prototypeId: string,
+    data: PrototypesUpdatePayload,
     params: RequestParams = {}
   ) =>
-    this.request<UsersUpdateData, void>({
-      path: `/api/users/${userId}`,
+    this.request<PrototypesUpdateData, Error404Response>({
+      path: `/api/prototypes/${prototypeId}`,
       method: 'PUT',
       body: data,
       type: ContentType.Json,
       format: 'json',
+      ...params,
+    });
+  /**
+   * @description 指定されたIDのプロトタイプを削除します。
+   *
+   * @tags Prototypes
+   * @name PrototypesDelete
+   * @summary プロトタイプ削除
+   * @request DELETE:/api/prototypes/{prototypeId}
+   */
+  prototypesDelete = (prototypeId: string, params: RequestParams = {}) =>
+    this.request<PrototypesDeleteData, Error404Response>({
+      path: `/api/prototypes/${prototypeId}`,
+      method: 'DELETE',
+      format: 'json',
+      ...params,
+    });
+  /**
+   * @description S3に画像をアップロードし、画像のメタデータを保存します。
+   *
+   * @tags Images
+   * @name ImagesCreate
+   * @summary 画像アップロード
+   * @request POST:/api/images
+   */
+  imagesCreate = (data: ImagesCreatePayload, params: RequestParams = {}) =>
+    this.request<ImagesCreateData, Error400Response | Error500Response>({
+      path: `/api/images`,
+      method: 'POST',
+      body: data,
+      type: ContentType.FormData,
+      format: 'json',
+      ...params,
+    });
+  /**
+   * @description S3から指定された画像を取得し、画像データを直接返します。
+   *
+   * @tags Images
+   * @name ImagesDetail
+   * @summary 画像取得
+   * @request GET:/api/images/{imageId}
+   */
+  imagesDetail = (imageId: string, params: RequestParams = {}) =>
+    this.request<
+      ImagesDetailData,
+      Error400Response | Error404Response | Error500Response
+    >({
+      path: `/api/images/${imageId}`,
+      method: 'GET',
+      format: 'blob',
+      ...params,
+    });
+  /**
+   * @description S3から指定された画像を削除します。
+   *
+   * @tags Images
+   * @name ImagesDelete
+   * @summary 画像削除
+   * @request DELETE:/api/images/{imageId}
+   */
+  imagesDelete = (
+    { imageId, ...query }: ImagesDeleteParams,
+    params: RequestParams = {}
+  ) =>
+    this.request<
+      ImagesDeleteData,
+      Error400Response | Error404Response | Error500Response
+    >({
+      path: `/api/images/${imageId}`,
+      method: 'DELETE',
+      query: query,
       ...params,
     });
 }

--- a/frontend/src/api/types/Api.ts
+++ b/frontend/src/api/types/Api.ts
@@ -17,6 +17,7 @@ import {
   ImagesCreateData,
   ImagesCreatePayload,
   ImagesDeleteData,
+  ImagesDeleteParams,
   ImagesDetailData,
   PrototypeGroupsAccessUsersListData,
   PrototypeGroupsCreateData,
@@ -94,13 +95,17 @@ export class Api<
    * @summary 画像削除
    * @request DELETE:/api/images/{imageId}
    */
-  imagesDelete = (imageId: string, params: RequestParams = {}) =>
+  imagesDelete = (
+    { imageId, ...query }: ImagesDeleteParams,
+    params: RequestParams = {}
+  ) =>
     this.request<
       ImagesDeleteData,
       Error400Response | Error404Response | Error500Response
     >({
       path: `/api/images/${imageId}`,
       method: 'DELETE',
+      query: query,
       ...params,
     });
   /**

--- a/frontend/src/api/types/data-contracts.ts
+++ b/frontend/src/api/types/data-contracts.ts
@@ -273,7 +273,7 @@ export interface ImagesDeleteParams {
    * 更新をemitするかどうか（デフォルトはfalse）
    * @default false
    */
-  emitUpdate?: 'true' | 'false';
+  emitUpdate: 'true' | 'false';
   /** 削除する画像のID */
   imageId: string;
 }

--- a/frontend/src/api/types/data-contracts.ts
+++ b/frontend/src/api/types/data-contracts.ts
@@ -166,6 +166,22 @@ export type ImagesCreateData = Image;
 /** @format binary */
 export type ImagesDetailData = File;
 
+export interface ImagesDeleteParams {
+  /** プロトタイプID */
+  prototypeId: string;
+  /** パーツID */
+  partId: string;
+  /** 面（front または back） */
+  side: 'front' | 'back';
+  /**
+   * 更新をemitするかどうか（デフォルトはfalse）
+   * @default false
+   */
+  emitUpdate?: 'true' | 'false';
+  /** 削除する画像のID */
+  imageId: string;
+}
+
 export type ImagesDeleteData = any;
 
 export interface PrototypesDetailData {

--- a/frontend/src/api/types/data-contracts.ts
+++ b/frontend/src/api/types/data-contracts.ts
@@ -170,7 +170,7 @@ export interface ImagesDeleteParams {
   /** プロトタイプID */
   prototypeId: string;
   /** パーツID */
-  partId: string;
+  partId: number;
   /** 面（front または back） */
   side: 'front' | 'back';
   /**

--- a/frontend/src/api/types/data-contracts.ts
+++ b/frontend/src/api/types/data-contracts.ts
@@ -146,57 +146,19 @@ export interface UserRole {
   updatedAt: string;
 }
 
-export type LogoutCreateData = SuccessResponse;
-
-export interface UserListData {
-  id?: string;
-  username?: string;
+export interface UsersSearchListParams {
+  /** 検索するユーザー名 */
+  username: string;
 }
 
-export interface ImagesCreatePayload {
-  /**
-   * アップロードする画像ファイル
-   * @format binary
-   */
-  image?: File;
+export type UsersSearchListData = User[];
+
+export interface UsersUpdatePayload {
+  /** 新しいユーザー名 */
+  username: string;
 }
 
-export type ImagesCreateData = Image;
-
-/** @format binary */
-export type ImagesDetailData = File;
-
-export interface ImagesDeleteParams {
-  /** プロトタイプID */
-  prototypeId: string;
-  /** パーツID */
-  partId: number;
-  /** 面（front または back） */
-  side: 'front' | 'back';
-  /**
-   * 更新をemitするかどうか（デフォルトはfalse）
-   * @default false
-   */
-  emitUpdate?: 'true' | 'false';
-  /** 削除する画像のID */
-  imageId: string;
-}
-
-export type ImagesDeleteData = any;
-
-export interface PrototypesDetailData {
-  prototype?: Prototype;
-}
-
-export interface PrototypesUpdatePayload {
-  name?: string;
-  minPlayers?: number;
-  maxPlayers?: number;
-}
-
-export type PrototypesUpdateData = Prototype;
-
-export type PrototypesDeleteData = SuccessResponse;
+export type UsersUpdateData = User;
 
 export type PrototypeGroupsListData = {
   prototypeGroup?: PrototypeGroup;
@@ -273,16 +235,54 @@ export interface PrototypeGroupsRolesUpdatePayload {
 
 export type PrototypeGroupsRolesUpdateData = any;
 
-export interface UsersSearchListParams {
-  /** 検索するユーザー名 */
-  username: string;
+export interface PrototypesDetailData {
+  prototype?: Prototype;
 }
 
-export type UsersSearchListData = User[];
-
-export interface UsersUpdatePayload {
-  /** 新しいユーザー名 */
-  username: string;
+export interface PrototypesUpdatePayload {
+  name?: string;
+  minPlayers?: number;
+  maxPlayers?: number;
 }
 
-export type UsersUpdateData = User;
+export type PrototypesUpdateData = Prototype;
+
+export type PrototypesDeleteData = SuccessResponse;
+
+export interface ImagesCreatePayload {
+  /**
+   * アップロードする画像ファイル
+   * @format binary
+   */
+  image?: File;
+}
+
+export type ImagesCreateData = Image;
+
+/** @format binary */
+export type ImagesDetailData = File;
+
+export interface ImagesDeleteParams {
+  /** プロトタイプID */
+  prototypeId: string;
+  /** パーツID */
+  partId: number;
+  /** 面（front または back） */
+  side: 'front' | 'back';
+  /**
+   * 更新をemitするかどうか（デフォルトはfalse）
+   * @default false
+   */
+  emitUpdate?: 'true' | 'false';
+  /** 削除する画像のID */
+  imageId: string;
+}
+
+export type ImagesDeleteData = any;
+
+export type LogoutCreateData = SuccessResponse;
+
+export interface UserListData {
+  id?: string;
+  username?: string;
+}

--- a/frontend/src/features/prototype/type.ts
+++ b/frontend/src/features/prototype/type.ts
@@ -110,3 +110,12 @@ export interface PartPropertyWithImage extends PartProperty {
 export type PartPropertyUpdate = Omit<Partial<PartProperty>, 'imageId'> & {
   imageId?: string | null;
 };
+
+// 画像削除時のprops
+export interface DeleteImageProps {
+  imageId: string;
+  partId: number;
+  side: 'front' | 'back';
+  prototypeId: string;
+  emitUpdate: 'true' | 'false';
+}


### PR DESCRIPTION
# 事前確認(共通)

- [x] PR 前に動作確認をしたか
- [x] 機密情報を含んでいないか

# やったこと
- 指定されたオブジェクトからのみ参照されている画像に対し、S3からの物理削除およびDBの削除または更新を行うAPIを追加
- 画像クリア時の対応：削除対象の画像が存在する場合、削除後にクライアントへ Socket 通知を emit し、関連オブジェクトの更新情報を送信する
- パーツ削除時の対応：削除対象の画像が存在する場合、削除処理のみを実行する（Socket通知はemitしない）


# やらないこと
特になし

# 懸念点や注意点<!-- このプルリクエストにおける懸念点や注意点を書く -->

特になし

# その他<!-- このプルリクエストで上記の項目以外に伝えるべきことを書く -->

特になし


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 画像削除時に、プロトタイプID・パーツID・面（front/back）・emitUpdateフラグの指定が必須になりました。
  * 画像削除APIのレスポンスが204から200に変更され、削除結果がJSONで返されます。
  * 画像削除時に、他で未使用の場合のみストレージ・DBから物理削除されます。
  * 画像削除後、emitUpdateが有効な場合はWebSocketで更新通知が送信されます。
  * 画像削除操作がサイドバーやボード上から実行できるようになりました。
  * パーツ削除時、関連画像もまとめて削除されます。

* **API仕様変更**
  * 画像削除APIのパラメータ・レスポンス仕様が更新されました。
  * 型定義・APIフック類も新仕様に対応しました。

* **UIの改善**
  * 画像削除操作がサイドバーやボード上から実行できるようになりました。
  * パーツ削除時、関連画像もまとめて削除されます。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->