### PR TITLE
Refactor game board controls

### DIFF
--- a/frontend/src/features/prototype/components/molecules/LeftSidebar.tsx
+++ b/frontend/src/features/prototype/components/molecules/LeftSidebar.tsx
@@ -1,7 +1,3 @@
-/**
- * @page サイドバーコンポーネント（プレビューモードとパーツ作成モードを兼ねている）
- */
-
 'use client';
 
 import Link from 'next/link';

--- a/frontend/src/features/prototype/components/molecules/LeftSidebar.tsx
+++ b/frontend/src/features/prototype/components/molecules/LeftSidebar.tsx
@@ -17,6 +17,8 @@ import { Prototype, Project } from '@/api/types';
 import { GameBoardMode } from '@/features/prototype/types/gameBoardMode';
 import formatDate from '@/utils/dateFormat';
 
+import ShortcutHelpPanel from './ShortcutHelpPanel';
+
 export default function LeftSidebar({
   prototypeName,
   gameBoardMode,
@@ -307,6 +309,7 @@ export default function LeftSidebar({
       {!isLeftSidebarMinimized &&
         gameBoardMode !== GameBoardMode.PLAY &&
         renderSidebarContent()}
+      <ShortcutHelpPanel />
     </div>
   );
 }

--- a/frontend/src/features/prototype/components/molecules/LeftSidebar.tsx
+++ b/frontend/src/features/prototype/components/molecules/LeftSidebar.tsx
@@ -37,11 +37,6 @@ export default function LeftSidebar({
     instancesByVersion: Record<string, Prototype[]>;
   } | null>(null);
   const [isRoomCreating, setIsRoomCreating] = useState(false);
-  const [activeTab, setActiveTab] = useState<GameBoardMode>(
-    gameBoardMode === GameBoardMode.PLAY
-      ? GameBoardMode.PLAY
-      : GameBoardMode.CREATE
-  );
 
   /**
    * プロトタイプを取得する
@@ -140,130 +135,72 @@ export default function LeftSidebar({
     }
   };
 
-  // 新デザイン: トグルで「作る」「遊ぶ」切り替え
+  // サイドバーのルームリスト部分のみを表示する
   const renderSidebarContent = () => {
     if (!prototypeInfo) return null;
     return (
       <div className="p-2 overflow-y-auto scrollbar-hide space-y-4">
-        {/* アイコンメインのトグルボタン */}
-        <div className="flex gap-1 mb-2">
+        <div className="flex flex-col gap-2 py-0.5 px-0">
+          {/* 新しいルーム作成ボタン */}
           <button
-            className={`flex-1 flex flex-col items-center py-1.5 rounded-lg font-bold border transition-all ${
-              activeTab === GameBoardMode.CREATE
-                ? 'bg-kibako-tertiary text-kibako-primary border-kibako-secondary'
-                : 'bg-kibako-white text-kibako-secondary border-kibako-tertiary hover:bg-kibako-tertiary'
-            }`}
-            onClick={() => setActiveTab(GameBoardMode.CREATE)}
+            onClick={handleCreateRoom}
+            disabled={isRoomCreating}
+            className="relative flex items-center bg-gradient-to-br from-kibako-tertiary to-kibako-white rounded-xl px-3 py-3 shadow-md min-w-[120px] text-left transition-all gap-2 border-2 border-dashed border-kibako-secondary hover:border-kibako-accent hover:border-solid mb-2 disabled:opacity-60 disabled:cursor-not-allowed"
+            title="新しいルームを作る"
           >
-            <BsBoxSeam
-              className={`h-6 w-6 mb-0.5 ${activeTab === GameBoardMode.CREATE ? 'text-kibako-primary' : 'text-kibako-secondary'}`}
-            />
-            <span className="text-[10px] font-normal tracking-widest">
-              作る
-            </span>
-          </button>
-          <button
-            className={`flex-1 flex flex-col items-center py-1.5 rounded-lg font-bold border transition-all ${
-              activeTab === GameBoardMode.PLAY
-                ? 'bg-kibako-tertiary text-kibako-primary border-kibako-secondary'
-                : 'bg-kibako-white text-kibako-secondary border-kibako-tertiary hover:bg-kibako-tertiary'
-            }`}
-            onClick={() => setActiveTab(GameBoardMode.PLAY)}
-          >
-            <MdMeetingRoom
-              className={`h-6 w-6 mb-0.5 ${activeTab === GameBoardMode.PLAY ? 'text-kibako-primary' : 'text-kibako-secondary'}`}
-            />
-            <span className="text-[10px] font-normal tracking-widest">
-              遊ぶ
-            </span>
-          </button>
-        </div>
-        {/* 作るタブは空 */}
-        {activeTab === GameBoardMode.CREATE && <div />}
-        {/* 遊ぶタブ */}
-        {activeTab === GameBoardMode.PLAY && (
-          <div>
-            <div className="flex flex-col gap-2 py-0.5 px-0">
-              {/* 新しいルーム作成ボタン */}
-              <button
-                onClick={handleCreateRoom}
-                disabled={isRoomCreating}
-                className="relative flex items-center bg-gradient-to-br from-kibako-tertiary to-kibako-white rounded-xl px-3 py-3 shadow-md min-w-[120px] text-left transition-all gap-2 border-2 border-dashed border-kibako-secondary hover:border-kibako-accent hover:border-solid mb-2 disabled:opacity-60 disabled:cursor-not-allowed"
-                title="新しいルームを作る"
-              >
-                <MdMeetingRoom className="h-7 w-7 text-kibako-accent flex-shrink-0 mr-1" />
-                <div className="flex flex-col min-w-0 flex-1">
-                  <span className="text-sm font-semibold text-kibako-primary truncate block max-w-[180px]">
-                    新しいルームを作る
-                  </span>
-                  <span className="text-xs text-kibako-secondary mt-0.5 flex items-center gap-1">
-                    今のボードの状態を保存して
-                    <br />
-                    ルームを作成します
-                  </span>
-                </div>
-                <IoAdd className="h-5 w-5 text-kibako-secondary ml-1 transition-colors" />
-              </button>
-              {prototypeInfo.instances
-                .slice()
-                .sort((a, b) =>
-                  b.createdAt && a.createdAt
-                    ? new Date(b.createdAt).getTime() -
-                      new Date(a.createdAt).getTime()
-                    : 0
-                )
-                .map((instance) => (
-                  <div key={instance.id} className="relative flex-shrink-0">
-                    <Link
-                      href={`/projects/${projectId}/prototypes/${instance.id}`}
-                      className="group"
-                      title={`${instance.name ?? instance.versionNumber + '版'}のルームを開く`}
-                    >
-                      <div className="flex items-center bg-gradient-to-br from-kibako-tertiary to-kibako-white rounded-xl px-3 py-3 shadow-md min-w-[120px] text-left transition-all gap-2 group-hover:bg-kibako-accent/10 group-hover:border-kibako-accent border border-transparent">
-                        <MdMeetingRoom className="h-7 w-7 text-kibako-accent flex-shrink-0 mr-1" />
-                        <div className="flex flex-col min-w-0 flex-1">
-                          <span className="text-sm font-semibold text-kibako-primary truncate block max-w-[180px]">
-                            {instance.name}
-                          </span>
-                          <span className="text-xs text-kibako-secondary mt-0.5 flex items-center gap-1">
-                            <span className="font-bold">入室する</span>
-                          </span>
-                        </div>
-                      </div>
-                    </Link>
-                    <button
-                      onClick={() => handleDeleteRoom(instance.id)}
-                      className="absolute right-2 top-1/2 -translate-y-1/2 p-1 rounded-full group/delete hover:bg-kibako-accent/20 focus:outline-none flex items-center justify-center"
-                      title="ルームを削除"
-                    >
-                      <MdDelete className="h-5 w-5 text-kibako-secondary transition-colors" />
-                    </button>
-                  </div>
-                ))}
+            <MdMeetingRoom className="h-7 w-7 text-kibako-accent flex-shrink-0 mr-1" />
+            <div className="flex flex-col min-w-0 flex-1">
+              <span className="text-sm font-semibold text-kibako-primary truncate block max-w-[180px]">
+                新しいルームを作る
+              </span>
+              <span className="text-xs text-kibako-secondary mt-0.5 flex items-center gap-1">
+                今のボードの状態を保存して
+                <br />
+                遊び場を作成します
+              </span>
             </div>
-          </div>
-        )}
+            <IoAdd className="h-5 w-5 text-kibako-secondary ml-1 transition-colors" />
+          </button>
+          {prototypeInfo.instances
+            .slice()
+            .sort((a, b) =>
+              b.createdAt && a.createdAt
+                ? new Date(b.createdAt).getTime() -
+                  new Date(a.createdAt).getTime()
+                : 0
+            )
+            .map((instance) => (
+              <div key={instance.id} className="relative flex-shrink-0">
+                <Link
+                  href={`/projects/${projectId}/prototypes/${instance.id}`}
+                  className="group"
+                  title={`${instance.name ?? instance.versionNumber + '版'}のルームを開く`}
+                >
+                  <div className="flex items-center bg-gradient-to-br from-kibako-tertiary to-kibako-white rounded-xl px-3 py-3 shadow-md min-w-[120px] text-left transition-all gap-2 group-hover:bg-kibako-accent/10 group-hover:border-kibako-accent border border-transparent">
+                    <MdMeetingRoom className="h-7 w-7 text-kibako-accent flex-shrink-0 mr-1" />
+                    <div className="flex flex-col min-w-0 flex-1">
+                      <span className="text-sm font-semibold text-kibako-primary truncate block max-w-[180px]">
+                        {instance.name}
+                      </span>
+                      <span className="text-xs text-kibako-secondary mt-0.5 flex items-center gap-1">
+                        <span className="font-bold">入室する</span>
+                      </span>
+                    </div>
+                  </div>
+                </Link>
+                <button
+                  onClick={() => handleDeleteRoom(instance.id)}
+                  className="absolute right-2 top-1/2 -translate-y-1/2 p-1 rounded-full group/delete hover:bg-kibako-accent/20 focus:outline-none flex items-center justify-center"
+                  title="ルームを削除"
+                >
+                  <MdDelete className="h-5 w-5 text-kibako-secondary transition-colors" />
+                </button>
+              </div>
+            ))}
+        </div>
       </div>
     );
   };
-
-  // タブ切り替え時の遷移処理
-  useEffect(() => {
-    if (activeTab === 'create' && prototypeInfo?.master?.id) {
-      router.push(
-        `/projects/${projectId}/prototypes/${prototypeInfo.master.id}`
-      );
-    }
-  }, [activeTab, prototypeInfo?.master?.id, projectId, router]);
-
-  // gameBoardModeが変わったときもactiveTabを同期
-  useEffect(() => {
-    setActiveTab(
-      gameBoardMode === GameBoardMode.PLAY
-        ? GameBoardMode.PLAY
-        : GameBoardMode.CREATE
-    );
-  }, [gameBoardMode]);
 
   return (
     <div

--- a/frontend/src/features/prototype/components/molecules/LeftSidebar.tsx
+++ b/frontend/src/features/prototype/components/molecules/LeftSidebar.tsx
@@ -3,8 +3,7 @@
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { useState, useEffect, useCallback } from 'react';
-import { BsBoxSeam } from 'react-icons/bs';
-import { IoArrowBack, IoMenu, IoAdd, IoEye } from 'react-icons/io5';
+import { IoArrowBack, IoMenu, IoAdd } from 'react-icons/io5';
 import { MdMeetingRoom, MdDelete } from 'react-icons/md';
 
 import { useProject } from '@/api/hooks/useProject';
@@ -110,31 +109,6 @@ export default function LeftSidebar({
     setIsLeftSidebarMinimized(!isLeftSidebarMinimized);
   };
 
-  const renderTypeBadge = () => {
-    switch (gameBoardMode) {
-      case GameBoardMode.CREATE:
-        return (
-          <span className="ml-2 flex items-center">
-            <BsBoxSeam className="text-kibako-primary h-4 w-4" />
-          </span>
-        );
-      case GameBoardMode.PREVIEW:
-        return (
-          <span className="ml-2 flex items-center">
-            <IoEye className="text-kibako-primary h-4 w-4" />
-          </span>
-        );
-      case GameBoardMode.PLAY:
-        return (
-          <span className="ml-2 flex items-center">
-            <MdMeetingRoom className="text-kibako-primary h-4 w-4" />
-          </span>
-        );
-      default:
-        return null;
-    }
-  };
-
   // サイドバーのルームリスト部分のみを表示する
   const renderSidebarContent = () => {
     if (!prototypeInfo) return null;
@@ -223,7 +197,6 @@ export default function LeftSidebar({
           >
             {prototypeName}
           </h2>
-          {renderTypeBadge()}
         </div>
         {/* ルームを開いている時は開閉ボタンを非表示 */}
         {gameBoardMode !== GameBoardMode.PLAY && (

--- a/frontend/src/features/prototype/components/molecules/ShortcutHelpPanel.tsx
+++ b/frontend/src/features/prototype/components/molecules/ShortcutHelpPanel.tsx
@@ -9,17 +9,25 @@ import { IoClose, IoInformationCircleOutline } from 'react-icons/io5';
 
 type ShortcutInfo = {
   id: string;
-  key: string; // ショートカットキーやアクション
-  description: string; // 説明文
+  key: string;
+  description: string;
 };
 
-interface ShortcutHelpPanelProps {
-  shortcuts: ShortcutInfo[];
-}
+//ショートカット情報の定義
+const SHORTCUTS: ShortcutInfo[] = [
+  {
+    id: 'multi-select',
+    key: 'Shift + クリック',
+    description: '複数のパーツを選択できます',
+  },
+  {
+    id: 'delete',
+    key: 'Delete / Backspace',
+    description: '選択中のパーツを削除します',
+  },
+];
 
-export default function ShortcutHelpPanel({
-  shortcuts,
-}: ShortcutHelpPanelProps) {
+export default function ShortcutHelpPanel() {
   const [isExpanded, setIsExpanded] = useState(false);
 
   // キーボードショートカットのハンドラを追加
@@ -92,7 +100,7 @@ export default function ShortcutHelpPanel({
                       ショートカットヘルプを開閉する
                     </td>
                   </tr>
-                  {shortcuts.map((shortcut) => (
+                  {SHORTCUTS.map((shortcut) => (
                     <tr
                       key={shortcut.id}
                       className="border-b border-wood-light/10 last:border-b-0"

--- a/frontend/src/features/prototype/components/organisms/GameBoard.tsx
+++ b/frontend/src/features/prototype/components/organisms/GameBoard.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import Konva from 'konva';
 import React, {
   useRef,
@@ -21,6 +19,7 @@ import PartCreateMenu from '@/features/prototype/components/molecules/PartCreate
 import PartPropertySidebar from '@/features/prototype/components/molecules/PartPropertySidebar';
 import ZoomToolbar from '@/features/prototype/components/molecules/ZoomToolbar';
 import { DebugModeProvider } from '@/features/prototype/contexts/DebugModeContext';
+import { useGrabbingCursor } from '@/features/prototype/hooks/useGrabbingCursor';
 import { usePartReducer } from '@/features/prototype/hooks/usePartReducer';
 import { usePerformanceTracker } from '@/features/prototype/hooks/usePerformanceTracker';
 import { AddPartProps, DeleteImageProps } from '@/features/prototype/type';
@@ -657,6 +656,8 @@ export default function GameBoard({
     [showContextMenu, handleCloseContextMenu]
   );
 
+  const { isGrabbing, eventHandlers: grabbingHandlers } = useGrabbingCursor();
+
   // パーツの位置をキャンバス内に制限する関数
   const constrainWithinCanvas = useCallback(
     (
@@ -706,6 +707,8 @@ export default function GameBoard({
         ref={stageRef}
         onWheel={handleWheel}
         onClick={handleStageClick}
+        {...grabbingHandlers}
+        style={{ cursor: isGrabbing ? 'grabbing' : 'grab' }}
       >
         <Layer>
           {/* カメラ - カメラの位置とスケールを適用 */}

--- a/frontend/src/features/prototype/components/organisms/GameBoard.tsx
+++ b/frontend/src/features/prototype/components/organisms/GameBoard.tsx
@@ -19,7 +19,6 @@ import Part from '@/features/prototype/components/atoms/Part';
 import LeftSidebar from '@/features/prototype/components/molecules/LeftSidebar';
 import PartCreateMenu from '@/features/prototype/components/molecules/PartCreateMenu';
 import PartPropertySidebar from '@/features/prototype/components/molecules/PartPropertySidebar';
-import ShortcutHelpPanel from '@/features/prototype/components/molecules/ShortcutHelpPanel';
 import ZoomToolbar from '@/features/prototype/components/molecules/ZoomToolbar';
 import { DebugModeProvider } from '@/features/prototype/contexts/DebugModeContext';
 import { usePartReducer } from '@/features/prototype/hooks/usePartReducer';
@@ -782,7 +781,6 @@ export default function GameBoard({
         gameBoardMode={gameBoardMode}
         projectId={projectId}
       />
-      <ShortcutHelpPanel />
 
       {gameBoardMode === GameBoardMode.CREATE && (
         <>

--- a/frontend/src/features/prototype/components/organisms/GameBoard.tsx
+++ b/frontend/src/features/prototype/components/organisms/GameBoard.tsx
@@ -782,21 +782,7 @@ export default function GameBoard({
         gameBoardMode={gameBoardMode}
         projectId={projectId}
       />
-      {/* ショートカットヘルプパネル */}
-      <ShortcutHelpPanel
-        shortcuts={[
-          {
-            id: 'multi-select',
-            key: 'Shift + クリック',
-            description: '複数のパーツを選択できます',
-          },
-          {
-            id: 'delete',
-            key: 'Delete / Backspace',
-            description: '選択中のパーツを削除します',
-          },
-        ]}
-      />
+      <ShortcutHelpPanel />
 
       {gameBoardMode === GameBoardMode.CREATE && (
         <>

--- a/frontend/src/features/prototype/hooks/useGrabbingCursor.ts
+++ b/frontend/src/features/prototype/hooks/useGrabbingCursor.ts
@@ -1,0 +1,19 @@
+import type { KonvaEventObject } from 'konva/lib/Node';
+import { useState } from 'react';
+
+export function useGrabbingCursor() {
+  const [isGrabbing, setIsGrabbing] = useState(false);
+  const handleMouseDown = (e: KonvaEventObject<MouseEvent>) => {
+    if (e.evt.button === 0) setIsGrabbing(true);
+  };
+  const handleMouseUp = () => setIsGrabbing(false);
+  const handleMouseLeave = () => setIsGrabbing(false);
+  return {
+    isGrabbing,
+    eventHandlers: {
+      onMouseDown: handleMouseDown,
+      onMouseUp: handleMouseUp,
+      onMouseLeave: handleMouseLeave,
+    },
+  };
+}


### PR DESCRIPTION
# 事前確認(共通)

- [x] PR 前に動作確認をしたか
- [x] 機密情報を含んでいないか

# やったこと<!-- このプルリクエストでやったことを書く -->

This pull request introduces significant changes to the `LeftSidebar` and `GameBoard` components in the frontend prototype feature, along with the addition of a new `useGrabbingCursor` hook. The changes simplify the `LeftSidebar` functionality by removing the game board mode toggle and associated UI, centralize shortcut definitions in `ShortcutHelpPanel`, and enhance the `GameBoard` UX with a grabbing cursor feature.

### LeftSidebar Simplification:
* Removed the game board mode toggle functionality and its associated UI, including the `activeTab` state and `renderTypeBadge` method. The sidebar now focuses on displaying the room list. (`[[1]](diffhunk://#diff-738e99c9379cc69752c08d423504353857538bfc257a6d4f3f25e7dd9e96ab02L42-L46)`, `[[2]](diffhunk://#diff-738e99c9379cc69752c08d423504353857538bfc257a6d4f3f25e7dd9e96ab02L120-L187)`, `[[3]](diffhunk://#diff-738e99c9379cc69752c08d423504353857538bfc257a6d4f3f25e7dd9e96ab02L247-L269)`, `[[4]](diffhunk://#diff-738e99c9379cc69752c08d423504353857538bfc257a6d4f3f25e7dd9e96ab02L291)`)
* Updated the room creation text from "ルームを作成します" to "遊び場を作成します" for better clarity. (`[frontend/src/features/prototype/components/molecules/LeftSidebar.tsxL204-R133](diffhunk://#diff-738e99c9379cc69752c08d423504353857538bfc257a6d4f3f25e7dd9e96ab02L204-R133)`)
* Added the `ShortcutHelpPanel` component to the sidebar for displaying shortcut information. (`[[1]](diffhunk://#diff-738e99c9379cc69752c08d423504353857538bfc257a6d4f3f25e7dd9e96ab02R15-R16)`, `[[2]](diffhunk://#diff-738e99c9379cc69752c08d423504353857538bfc257a6d4f3f25e7dd9e96ab02R218)`)

### ShortcutHelpPanel Improvements:
* Centralized shortcut definitions within the `ShortcutHelpPanel` component as a constant, removing the need to pass them as props. (`[[1]](diffhunk://#diff-adc28b045880026dc883d3ec4a265dda9dc5644f020cbab875d7ba810e9b9013L12-R30)`, `[[2]](diffhunk://#diff-adc28b045880026dc883d3ec4a265dda9dc5644f020cbab875d7ba810e9b9013L95-R103)`)

### GameBoard Enhancements:
* Integrated a new `useGrabbingCursor` hook to provide a grabbing cursor effect when interacting with the game board, improving user experience. (`[[1]](diffhunk://#diff-c744a3a422bf8c68f3e3d51476160645ffd164a9fcc857182f844ff58c1def51R659-R660)`, `[[2]](diffhunk://#diff-c744a3a422bf8c68f3e3d51476160645ffd164a9fcc857182f844ff58c1def51R710-R711)`)
* Removed the inline `ShortcutHelpPanel` from the `GameBoard` component, as it is now part of the `LeftSidebar`. (`[frontend/src/features/prototype/components/organisms/GameBoard.tsxL785-L799](diffhunk://#diff-c744a3a422bf8c68f3e3d51476160645ffd164a9fcc857182f844ff58c1def51L785-L799)`)

### New Hook:
* Added `useGrabbingCursor` to manage the grabbing cursor state and event handlers for mouse interactions. (`[frontend/src/features/prototype/hooks/useGrabbingCursor.tsR1-R19](diffhunk://#diff-3cafab19f39226c860b1df490aa7a13f162720323edf4cf0c5c257119f7eae6dR1-R19)`)

# やらないこと<!-- このプルリクエストでやってもおかしくないけどやらなかったことを書く -->

特になし

# 懸念点や注意点<!-- このプルリクエストにおける懸念点や注意点を書く -->

特になし

# その他<!-- このプルリクエストで上記の項目以外に伝えるべきことを書く -->

特になし


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 「Create New Room」ボタンのデザインと説明テキストを刷新し、ルーム作成をより分かりやすくしました。
  * サイドバー下部にショートカットヘルプパネルを追加し、利用可能なキーボードショートカットを案内します。
  * 新しい「useGrabbingCursor」フックにより、ドラッグ時のカーソル表示が「グラブ」/「グラビング」に動的に切り替わります。

* **リファクタ**
  * サイドバーのモード切替UIとバッジ表示を削除し、ルーム一覧と作成に特化したシンプルな構成に変更しました。
  * ショートカットヘルプパネルは外部からのデータ受け渡しを廃止し、内部定義のショートカット一覧を表示するようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->