### PR TITLE
Improve part creation ux

### DIFF
--- a/frontend/src/features/prototype/components/molecules/PartCreateMenu.tsx
+++ b/frontend/src/features/prototype/components/molecules/PartCreateMenu.tsx
@@ -14,18 +14,18 @@ import {
 
 import { Part, PartProperty } from '@/api/types';
 import { PART_DEFAULT_CONFIG } from '@/features/prototype/const';
+import { CANVAS_SIZE } from '@/features/prototype/constants/gameBoard';
 import { AddPartProps } from '@/features/prototype/type';
 
 export default function PartCreateMenu({
   onAddPart,
+  camera,
+  viewportSize,
 }: {
-  // パーツを追加時の処理
   onAddPart: ({ part, properties }: AddPartProps) => void;
+  camera: { x: number; y: number; scale: number };
+  viewportSize: { width: number; height: number };
 }) {
-  /**
-   * パーツを作成する
-   * @param partType - パーツのタイプ
-   */
   const handleCreatePart = (
     partType: 'card' | 'token' | 'hand' | 'deck' | 'area'
   ) => {
@@ -44,13 +44,44 @@ export default function PartCreateMenu({
       return;
     }
 
-    // 新しいパーツ
+    // パーツを中央に配置する座標を計算する関数
+    const getCenteredPosition = (
+      partWidth: number,
+      partHeight: number,
+      camera: { x: number; y: number; scale: number },
+      viewportSize: { width: number; height: number }
+    ) => {
+      const cameraCenterX = (camera.x + viewportSize.width / 2) / camera.scale;
+      const cameraCenterY = (camera.y + viewportSize.height / 2) / camera.scale;
+
+      const constrainedX = Math.max(
+        0,
+        Math.min(
+          CANVAS_SIZE - partWidth,
+          Math.round(cameraCenterX - partWidth / 2)
+        )
+      );
+      const constrainedY = Math.max(
+        0,
+        Math.min(
+          CANVAS_SIZE - partHeight,
+          Math.round(cameraCenterY - partHeight / 2)
+        )
+      );
+      return { x: constrainedX, y: constrainedY };
+    };
+
     const newPart: Omit<
       Part,
       'id' | 'prototypeId' | 'order' | 'createdAt' | 'updatedAt'
     > = {
       type: partType,
-      position: { x: 0, y: 0 }, // 仮の位置（GameBoardのhandleAddPartで上書きされる）
+      position: getCenteredPosition(
+        partConfig.width,
+        partConfig.height,
+        camera,
+        viewportSize
+      ),
       width: partConfig.width,
       height: partConfig.height,
     };

--- a/frontend/src/features/prototype/components/molecules/PartPropertySidebar.tsx
+++ b/frontend/src/features/prototype/components/molecules/PartPropertySidebar.tsx
@@ -114,8 +114,8 @@ export default function PartPropertySidebar({
       type: selectedPart.type,
       // NOTE： 少し複製元からずらす
       position: {
-        x: selectedPart.position.x + 10,
-        y: selectedPart.position.y + 10,
+        x: selectedPart.position.x + 25,
+        y: selectedPart.position.y + 25,
       },
       width: selectedPart.width,
       height: selectedPart.height,

--- a/frontend/src/features/prototype/components/organisms/GameBoard.tsx
+++ b/frontend/src/features/prototype/components/organisms/GameBoard.tsx
@@ -216,6 +216,18 @@ export default function GameBoard({
   }, [constrainCamera]);
   const handleWheel = (e: Konva.KonvaEventObject<WheelEvent>) => {
     e.evt.preventDefault();
+    // macOSトラックパッドの二本指移動でパン、Ctrlキー押下時はズーム
+    if (!e.evt.ctrlKey && !e.evt.metaKey) {
+      // パン（カメラ移動）
+      const { deltaX, deltaY } = e.evt;
+      setCamera((prev) => {
+        const newX = prev.x + deltaX;
+        const newY = prev.y + deltaY;
+        return constrainCamera(newX, newY, prev.scale);
+      });
+      return;
+    }
+    // ズーム（従来通り）
     const scaleBy = 1.05;
     const oldScale = camera.scale;
     const stage = stageRef.current;

--- a/frontend/src/features/prototype/components/organisms/GameBoard.tsx
+++ b/frontend/src/features/prototype/components/organisms/GameBoard.tsx
@@ -18,6 +18,13 @@ import LeftSidebar from '@/features/prototype/components/molecules/LeftSidebar';
 import PartCreateMenu from '@/features/prototype/components/molecules/PartCreateMenu';
 import PartPropertySidebar from '@/features/prototype/components/molecules/PartPropertySidebar';
 import ZoomToolbar from '@/features/prototype/components/molecules/ZoomToolbar';
+import {
+  GRID_SIZE,
+  CANVAS_SIZE,
+  MIN_SCALE,
+  MAX_SCALE,
+  DEFAULT_INITIAL_SCALE,
+} from '@/features/prototype/constants/gameBoard';
 import { DebugModeProvider } from '@/features/prototype/contexts/DebugModeContext';
 import { useGrabbingCursor } from '@/features/prototype/hooks/useGrabbingCursor';
 import { usePartReducer } from '@/features/prototype/hooks/usePartReducer';
@@ -31,12 +38,6 @@ import {
   saveImageToIndexedDb,
   updateImageParamsInIndexedDb,
 } from '@/utils/db';
-
-const GRID_SIZE = 50;
-const CANVAS_SIZE = 5000;
-const MIN_SCALE = 0.18;
-const MAX_SCALE = 8;
-const DEFAULT_INITIAL_SCALE = 0.5;
 
 interface GameBoardProps {
   prototypeName: string;
@@ -463,41 +464,13 @@ export default function GameBoard({
       measureOperation('Part Addition', () => {
         setSelectedPartIds([]);
 
-        const cameraCenterX =
-          (camera.x + viewportSize.width / 2) / camera.scale;
-        const cameraCenterY =
-          (camera.y + viewportSize.height / 2) / camera.scale;
-
-        const constrainedX = Math.max(
-          0,
-          Math.min(
-            CANVAS_SIZE - part.width,
-            Math.round(cameraCenterX - part.width / 2)
-          )
-        );
-        const constrainedY = Math.max(
-          0,
-          Math.min(
-            CANVAS_SIZE - part.height,
-            Math.round(cameraCenterY - part.height / 2)
-          )
-        );
-
-        const partWithCenteredPosition = {
-          ...part,
-          position: {
-            x: constrainedX,
-            y: constrainedY,
-          },
-        };
-
         dispatch({
           type: 'ADD_PART',
-          payload: { part: partWithCenteredPosition, properties },
+          payload: { part, properties },
         });
       });
     },
-    [dispatch, camera, viewportSize, measureOperation]
+    [dispatch, measureOperation]
   );
 
   const handleDeleteImage = useCallback(
@@ -788,7 +761,11 @@ export default function GameBoard({
       {gameBoardMode === GameBoardMode.CREATE && (
         <>
           {/* フローティングパーツ作成メニュー */}
-          <PartCreateMenu onAddPart={handleAddPart} />
+          <PartCreateMenu
+            onAddPart={handleAddPart}
+            camera={camera}
+            viewportSize={viewportSize}
+          />
 
           {/* プロパティサイドバー */}
           {selectedPartIds.length === 1 && (

--- a/frontend/src/features/prototype/components/organisms/GameBoard.tsx
+++ b/frontend/src/features/prototype/components/organisms/GameBoard.tsx
@@ -29,6 +29,7 @@ import { DebugModeProvider } from '@/features/prototype/contexts/DebugModeContex
 import { useGrabbingCursor } from '@/features/prototype/hooks/useGrabbingCursor';
 import { usePartReducer } from '@/features/prototype/hooks/usePartReducer';
 import { usePerformanceTracker } from '@/features/prototype/hooks/usePerformanceTracker';
+import { useSocket } from '@/features/prototype/hooks/useSocket';
 import { AddPartProps, DeleteImageProps } from '@/features/prototype/type';
 import { CursorInfo } from '@/features/prototype/types/cursor';
 import { GameBoardMode } from '@/features/prototype/types/gameBoardMode';
@@ -672,6 +673,19 @@ export default function GameBoard({
     return map;
   }, [parts, properties, images]);
 
+  const { socket } = useSocket();
+
+  useEffect(() => {
+    // パーツ追加時に自分の追加したパーツを選択状態にする
+    const handleAddPartResponse = (data: { partId: number }) => {
+      setSelectedPartIds([data.partId]);
+    };
+    if (!socket) return;
+    socket.on('ADD_PART_RESPONSE', handleAddPartResponse);
+    return () => {
+      socket.off('ADD_PART_RESPONSE', handleAddPartResponse);
+    };
+  }, [socket]);
   return (
     <DebugModeProvider>
       <Stage

--- a/frontend/src/features/prototype/constants/gameBoard.ts
+++ b/frontend/src/features/prototype/constants/gameBoard.ts
@@ -1,0 +1,5 @@
+export const GRID_SIZE = 50;
+export const CANVAS_SIZE = 5000;
+export const MIN_SCALE = 0.18;
+export const MAX_SCALE = 8;
+export const DEFAULT_INITIAL_SCALE = 0.5;


### PR DESCRIPTION
# 事前確認(共通)

- [x] PR 前に動作確認をしたか
- [x] 機密情報を含んでいないか

# やったこと<!-- このプルリクエストでやったことを書く -->

This pull request introduces several enhancements and refactorings to the `GameBoard` and related components in the prototype feature. The most notable changes include centralizing constants for the game board, improving part placement logic, adding camera and viewport handling for better user interaction, and introducing socket-based event handling for real-time updates.

### Refactoring and Centralization:
* Extracted game board constants (`GRID_SIZE`, `CANVAS_SIZE`, `MIN_SCALE`, `MAX_SCALE`, `DEFAULT_INITIAL_SCALE`) into a new file, `frontend/src/features/prototype/constants/gameBoard.ts`, for better maintainability and reuse. (`[[1]](diffhunk://#diff-c744a3a422bf8c68f3e3d51476160645ffd164a9fcc857182f844ff58c1def51R21-R32)`, `[[2]](diffhunk://#diff-c744a3a422bf8c68f3e3d51476160645ffd164a9fcc857182f844ff58c1def51L35-L40)`, `[[3]](diffhunk://#diff-f34ec2db07e9af21d1e572d8d58fb581705a9157c8edaf832fc67ea181879bc8R1-R5)`)

### Improved Part Placement:
* Added a utility function `getCenteredPosition` in `PartCreateMenu` to calculate and constrain the position of new parts to the center of the camera view. This ensures parts are placed centrally and within bounds. (`[[1]](diffhunk://#diff-25be0fbae81c4538161bebc62880dc5bf249fbc4304642c7155c2cc445c615c6R17-L28)`, `[[2]](diffhunk://#diff-25be0fbae81c4538161bebc62880dc5bf249fbc4304642c7155c2cc445c615c6L47-R84)`)
* Updated the default offset for duplicated parts in `PartPropertySidebar` to improve visual clarity. (`[frontend/src/features/prototype/components/molecules/PartPropertySidebar.tsxL117-R118](diffhunk://#diff-ce31ffca2a5f189b4d162394479352a30809cb5ad8b781e588e51553148c0bc0L117-R118)`)

### Enhanced Camera and Viewport Handling:
* Enhanced `GameBoard` to support panning with a macOS trackpad and zooming with a modifier key (e.g., Ctrl). This improves the user experience for navigating the game board. (`[frontend/src/features/prototype/components/organisms/GameBoard.tsxR219-R230](diffhunk://#diff-c744a3a422bf8c68f3e3d51476160645ffd164a9fcc857182f844ff58c1def51R219-R230)`)
* Passed `camera` and `viewportSize` props to `PartCreateMenu` for accurate part placement relative to the current view. (`[frontend/src/features/prototype/components/organisms/GameBoard.tsxL791-R794](diffhunk://#diff-c744a3a422bf8c68f3e3d51476160645ffd164a9fcc857182f844ff58c1def51L791-R794)`)

### Real-Time Updates:
* Integrated socket-based event handling in `GameBoard` to automatically select newly added parts in real-time, improving collaboration and responsiveness. (`[frontend/src/features/prototype/components/organisms/GameBoard.tsxR688-R700](diffhunk://#diff-c744a3a422bf8c68f3e3d51476160645ffd164a9fcc857182f844ff58c1def51R688-R700)`)

# やらないこと<!-- このプルリクエストでやってもおかしくないけどやらなかったことを書く -->

特になし

# 懸念点や注意点<!-- このプルリクエストにおける懸念点や注意点を書く -->

特になし

# その他<!-- このプルリクエストで上記の項目以外に伝えるべきことを書く -->

特になし


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * パーツ作成時に、カメラ位置とズームに基づきパーツがビューポート中央に配置されるようになりました。
  * ゲームボードのグリッドサイズやズーム範囲などの設定値が追加されました。

* **改善**
  * パーツ複製時の位置オフセットが10から25に拡大され、複製パーツがより離れて配置されるようになりました。
  * ゲームボードのトラックパッド操作で、2本指パンとズーム操作を区別できるようになりました。
  * パーツ追加時、サーバーから返されたIDのパーツが自動で選択されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->