### PR TITLE
プロトタイプ一覧ページへのリネーム・UI/UX改善

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -21,6 +21,7 @@
         "react-icons": "^5.3.0",
         "react-konva": "^18.0.5",
         "socket.io-client": "^4.8.1",
+        "tailwind-merge": "^3.3.1",
         "ua-parser-js": "^2.0.3",
         "use-image": "^1.1.2"
       },
@@ -5588,6 +5589,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tailwind-merge": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.3.1.tgz",
+      "integrity": "sha512-gBXpgUm/3rp1lMZZrM/w7D8GKqshif0zAymAhbCyIt8KMe+0v9DQ7cdYLR4FHH/cKpdTXb+A/tKKU3eolfsI+g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/dcastil"
       }
     },
     "node_modules/tailwindcss": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,6 +24,7 @@
     "react-icons": "^5.3.0",
     "react-konva": "^18.0.5",
     "socket.io-client": "^4.8.1",
+    "tailwind-merge": "^3.3.1",
     "ua-parser-js": "^2.0.3",
     "use-image": "^1.1.2"
   },

--- a/frontend/src/app/projects/page.tsx
+++ b/frontend/src/app/projects/page.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import ProjectList from '@/features/prototype/components/organisms/ProjectList';
 
 export const metadata: Metadata = {
-  title: 'プロジェクト一覧',
+  title: 'プロトタイプ一覧',
 };
 
 const ProjectsPage: React.FC = () => {

--- a/frontend/src/components/atoms/Button.tsx
+++ b/frontend/src/components/atoms/Button.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link';
 import { ButtonHTMLAttributes, ReactNode } from 'react';
+import { twMerge } from 'tailwind-merge';
 
 interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   children: ReactNode;
@@ -34,7 +35,9 @@ export default function Button({
     lg: 'px-10 py-5 text-xl',
   };
 
-  const buttonClasses = `${baseStyles} ${variants[variant]} ${sizes[size]} ${className}`;
+  const buttonClasses = twMerge(
+    [baseStyles, variants[variant], sizes[size], className].join(' ')
+  );
 
   return isLoading ? (
     // ローディング中(3つのドットを点滅表示)

--- a/frontend/src/components/molecules/HeaderRightMenu.tsx
+++ b/frontend/src/components/molecules/HeaderRightMenu.tsx
@@ -76,7 +76,7 @@ const HeaderRightMenu: React.FC<HeaderRightMenuProps> = ({ pathname }) => {
             href="/projects"
             className="block w-full text-kibako-primary p-2 text-left hover:bg-kibako-secondary/10 transition-colors duration-200"
           >
-            プロジェクト一覧
+            プロトタイプ一覧
           </Link>
           <Link
             href="/profile/edit"

--- a/frontend/src/components/organisms/Header.tsx
+++ b/frontend/src/components/organisms/Header.tsx
@@ -10,11 +10,11 @@ const Header: React.FC = () => {
   const pathname = usePathname();
 
   /**
-   * プロジェクト一覧画面へ遷移する
-   * 現在すでにプロジェクト一覧画面またはログイン画面にいる場合は何もしない
+   * プロトタイプ一覧画面へ遷移する
+   * 現在すでにプロトタイプ一覧画面またはログイン画面にいる場合は何もしない
    */
   const goToPrototypes = () => {
-    // プロジェクト一覧画面、またはログイン画面の場合
+    // プロトタイプ一覧画面、またはログイン画面の場合
     if (pathname === '/projects' || pathname === '/') return;
 
     router.push('/projects');

--- a/frontend/src/features/prototype/components/organisms/DeletePrototypeConfirmation.tsx
+++ b/frontend/src/features/prototype/components/organisms/DeletePrototypeConfirmation.tsx
@@ -99,7 +99,7 @@ const DeletePrototypeConfirmation = () => {
             onClick={() => router.push('/projects')}
             className="px-4 py-2 bg-gray-200 rounded-md hover:bg-gray-300 transition-colors"
           >
-            プロジェクト一覧へ戻る
+            プロトタイプ一覧へ戻る
           </button>
         </div>
       </div>

--- a/frontend/src/features/prototype/components/organisms/ProjectList.tsx
+++ b/frontend/src/features/prototype/components/organisms/ProjectList.tsx
@@ -9,9 +9,15 @@ import React, {
   useMemo,
   useContext,
 } from 'react';
-import { FaSort, FaSortDown, FaSortUp, FaUserShield } from 'react-icons/fa';
-import { FaBoxOpen, FaPlus } from 'react-icons/fa6';
-import { GiWoodenSign } from 'react-icons/gi';
+import {
+  FaPlus,
+  FaSort,
+  FaSortDown,
+  FaSortUp,
+  FaUserShield,
+} from 'react-icons/fa';
+import { FaBoxOpen } from 'react-icons/fa6';
+import { GiWoodenCrate } from 'react-icons/gi';
 import { IoTrash } from 'react-icons/io5';
 import { RiLoaderLine } from 'react-icons/ri';
 
@@ -278,41 +284,38 @@ const ProjectList: React.FC = () => {
   }, [prototypeList, sortPrototypes]);
 
   if (isLoading) {
-    return <Loading />;
+    return (
+      <div className="fixed inset-0 z-50 flex items-center justify-center bg-white/60">
+        <Loading />
+      </div>
+    );
   }
 
   if (sortedPrototypeList.length === 0) {
     return (
-      <div className="flex flex-col h-full justify-center items-center relative">
-        <div className="text-wood-light">
-          <GiWoodenSign className="w-[600px] h-[600px]" aria-hidden="true" />
-        </div>
-        <div className="absolute inset-0 flex items-center justify-center flex-col">
-          <p className="text-4xl text-wood-darkest text-center w-full mb-12">
-            最初のプロトタイプを
-            <br />
-            作成しましょう
-          </p>
-          <button
-            onClick={handleCreatePrototype}
-            disabled={isCreating}
-            className="flex items-center justify-center gap-3 bg-gradient-to-r from-header via-header-light to-header text-content py-4 px-8 rounded-full hover:from-header-light hover:via-header hover:to-header-light transition-all duration-300 shadow-lg hover:shadow-xl transform hover:-translate-y-1 group text-xl font-bold animate-pulse disabled:opacity-80 disabled:cursor-not-allowed disabled:hover:transform-none"
-            title="新規プロトタイプを作成"
-          >
-            {isCreating ? (
-              <RiLoaderLine
-                className="w-6 h-6 animate-spin"
-                aria-hidden="true"
-              />
-            ) : (
-              <FaPlus
-                className="w-6 h-6 group-hover:rotate-90 transition-transform duration-300"
-                aria-hidden="true"
-              />
-            )}
-            <span>{isCreating ? '作成中...' : 'KIBAKOの世界へ飛び込む！'}</span>
-          </button>
-        </div>
+      <div className="fixed inset-0 z-10">
+        <button
+          onClick={handleCreatePrototype}
+          disabled={isCreating}
+          className={`absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 flex flex-row items-center justify-center gap-4 px-14 py-8 rounded-3xl shadow-[0_10px_40px_0_rgba(0,0,0,0.45),0_2px_8px_0_rgba(0,0,0,0.25)] bg-kibako-primary text-kibako-white text-2xl font-bold transition-all duration-200 border-4 border-kibako-accent hover:bg-kibako-accent hover:text-kibako-primary hover:scale-105 hover:shadow-[0_16px_56px_0_rgba(0,0,0,0.55),0_4px_16px_0_rgba(0,0,0,0.30)] active:scale-95 focus:outline-none focus:ring-4 focus:ring-kibako-accent/40 select-none ${isCreating ? 'opacity-80 cursor-not-allowed' : ''}`}
+          style={{ minWidth: 360, minHeight: 100 }}
+          title="新規プロトタイプを作成する"
+        >
+          {isCreating ? (
+            <RiLoaderLine
+              className="w-14 h-14 animate-spin text-kibako-primary bg-kibako-accent rounded-full p-2 shadow-lg"
+              aria-hidden="true"
+            />
+          ) : (
+            <GiWoodenCrate
+              className="w-20 h-20 text-kibako-accent drop-shadow-xl transform -rotate-6 bg-white rounded-2xl p-2 shadow-lg border-2 border-kibako-accent"
+              aria-hidden="true"
+            />
+          )}
+          <span className="text-2xl font-bold tracking-wide drop-shadow-sm">
+            {isCreating ? '作成中...' : 'KIBAKOの世界へ飛び込む！'}
+          </span>
+        </button>
       </div>
     );
   }


### PR DESCRIPTION
# 事前確認(共通)

- [x] PR 前に動作確認をしたか
- [x] 機密情報を含んでいないか

# やったこと
- プロジェクト一覧ページを「プロトタイプ一覧ページ」へリネーム
- UI/UXの改善（ボタンやテーブルのデザイン調整、空状態の表示改善など）
- コードのリファクタリング（変数名やコメントの整理）

# やらないこと
- バックエンドAPIの仕様変更
- プロトタイプ以外の画面のUI変更

# 懸念点や注意点
- 既存のプロトタイプデータが正しく表示されるか要確認
- ページ遷移や新規作成時の動作確認

# その他
- デザインや文言の微調整が必要な場合は別PRで対応予定
