### PR TITLE
Improve part creation ux

### DIFF
--- a/frontend/src/features/prototype/components/molecules/PartCreateMenu.tsx
+++ b/frontend/src/features/prototype/components/molecules/PartCreateMenu.tsx
@@ -70,9 +70,9 @@ export default function PartCreateMenu({
           Math.round(cameraCenterY - partHeight / 2)
         )
       );
-      // 既存パーツと重ならない位置までxのみ+50ずつずらす（whileを使わず安全に）
+      // 既存パーツと重ならない位置までxのみ+25ずつずらす
       const baseX = x;
-      const candidate = Array.from({ length: 100 }, (_, i) => baseX + 50 * i)
+      const candidate = Array.from({ length: 100 }, (_, i) => baseX + 25 * i)
         .map((candidateX) => ({
           x: Math.min(candidateX, CANVAS_SIZE - partWidth),
           y,

--- a/frontend/src/features/prototype/components/molecules/PartCreateMenu.tsx
+++ b/frontend/src/features/prototype/components/molecules/PartCreateMenu.tsx
@@ -73,19 +73,23 @@ export default function PartCreateMenu({
       // 既存パーツと重ならない位置までxのみ+50ずつずらす（whileを使わず安全に）
       const baseX = x;
       const candidate = Array.from({ length: 100 }, (_, i) => baseX + 50 * i)
-        .map((candidateX) => ({ x: Math.min(candidateX, CANVAS_SIZE - partWidth), y }))
-        .find((pos) =>
-          !parts.some((p) =>
-            isRectOverlap(
-              { x: pos.x, y: pos.y, width: partWidth, height: partHeight },
-              {
-                x: p.position.x,
-                y: p.position.y,
-                width: p.width,
-                height: p.height,
-              }
+        .map((candidateX) => ({
+          x: Math.min(candidateX, CANVAS_SIZE - partWidth),
+          y,
+        }))
+        .find(
+          (pos) =>
+            !parts.some((p) =>
+              isRectOverlap(
+                { x: pos.x, y: pos.y, width: partWidth, height: partHeight },
+                {
+                  x: p.position.x,
+                  y: p.position.y,
+                  width: p.width,
+                  height: p.height,
+                }
+              )
             )
-          )
         );
       return candidate ?? { x, y };
     };
@@ -145,17 +149,24 @@ export default function PartCreateMenu({
   };
 
   // パーツタイプとアイコンのマッピング
-  const partTypes = [
+  const group1 = [
+    {
+      type: 'token' as const,
+      name: PART_DEFAULT_CONFIG.TOKEN.name,
+      icon: <Gi3dMeeple className="h-5 w-5 text-white" />,
+    },
     {
       type: 'card' as const,
       name: PART_DEFAULT_CONFIG.CARD.name,
       icon: <GiCard10Clubs className="h-5 w-5 text-white" />,
     },
     {
-      type: 'token' as const,
-      name: PART_DEFAULT_CONFIG.TOKEN.name,
-      icon: <Gi3dMeeple className="h-5 w-5 text-white" />,
+      type: 'area' as const,
+      name: PART_DEFAULT_CONFIG.AREA.name,
+      icon: <BiArea className="h-5 w-5 text-white" />,
     },
+  ];
+  const group2 = [
     {
       type: 'hand' as const,
       name: PART_DEFAULT_CONFIG.HAND.name,
@@ -166,29 +177,51 @@ export default function PartCreateMenu({
       name: PART_DEFAULT_CONFIG.DECK.name,
       icon: <GiStoneBlock className="h-5 w-5 text-white" />,
     },
-    {
-      type: 'area' as const,
-      name: PART_DEFAULT_CONFIG.AREA.name,
-      icon: <BiArea className="h-5 w-5 text-white" />,
-    },
   ];
 
   return (
-    <div className="fixed bottom-4 left-1/2 transform -translate-x-1/2 z-[10000] flex items-center justify-center rounded-xl bg-content shadow-lg border border-wood-light/30 p-2">
-      <div className="flex items-center justify-center gap-2">
-        {partTypes.map((partType) => (
-          <button
-            key={partType.type}
-            onClick={() => handleCreatePart(partType.type)}
-            className="group relative flex items-center justify-center w-12 h-12 bg-gradient-to-br from-wood to-wood-dark hover:from-wood-dark hover:to-wood-darkest rounded-lg transition-all duration-200 hover:scale-105 hover:shadow-md"
-            title={`${partType.name}を作成`}
-          >
-            {partType.icon}
-            <div className="absolute -top-10 left-1/2 transform -translate-x-1/2 bg-header text-white text-xs px-2 py-1 rounded whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity duration-200 pointer-events-none">
-              {partType.name}
-            </div>
-          </button>
-        ))}
+    <div className="fixed bottom-4 left-1/2 transform -translate-x-1/2 z-[10000] flex items-center justify-center gap-8">
+      {/* 左グループ: 部品 */}
+      <div className="rounded-xl bg-content shadow-lg border border-wood-light/30 p-3 flex flex-col items-center min-w-[140px]">
+        <div className="flex items-center gap-1 mb-2">
+          <span className="text-xs text-wood-dark font-bold">部品</span>
+        </div>
+        <div className="flex items-center gap-2">
+          {group1.map((partType) => (
+            <button
+              key={partType.type}
+              onClick={() => handleCreatePart(partType.type)}
+              className="group relative flex items-center justify-center w-12 h-12 bg-gradient-to-br from-wood to-wood-dark hover:from-wood-dark hover:to-wood-darkest rounded-lg transition-all duration-200 hover:scale-105 hover:shadow-md"
+              title={`${partType.name}を作成`}
+            >
+              {partType.icon}
+              <div className="absolute -top-10 left-1/2 transform -translate-x-1/2 bg-header text-white text-xs px-2 py-1 rounded whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity duration-200 pointer-events-none">
+                {partType.name}
+              </div>
+            </button>
+          ))}
+        </div>
+      </div>
+      {/* 右グループ: 仕組み */}
+      <div className="rounded-xl bg-content shadow-lg border border-wood-light/30 p-3 flex flex-col items-center min-w-[140px]">
+        <div className="flex items-center gap-1 mb-2">
+          <span className="text-xs text-wood-dark font-bold">仕組み</span>
+        </div>
+        <div className="flex items-center gap-2">
+          {group2.map((partType) => (
+            <button
+              key={partType.type}
+              onClick={() => handleCreatePart(partType.type)}
+              className="group relative flex items-center justify-center w-12 h-12 bg-gradient-to-br from-wood to-wood-dark hover:from-wood-dark hover:to-wood-darkest rounded-lg transition-all duration-200 hover:scale-105 hover:shadow-md"
+              title={`${partType.name}を作成`}
+            >
+              {partType.icon}
+              <div className="absolute -top-10 left-1/2 transform -translate-x-1/2 bg-header text-white text-xs px-2 py-1 rounded whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity duration-200 pointer-events-none">
+                {partType.name}
+              </div>
+            </button>
+          ))}
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/features/prototype/components/organisms/GameBoard.tsx
+++ b/frontend/src/features/prototype/components/organisms/GameBoard.tsx
@@ -794,6 +794,7 @@ export default function GameBoard({
             onAddPart={handleAddPart}
             camera={camera}
             viewportSize={viewportSize}
+            parts={parts} // 追加
           />
 
           {/* プロパティサイドバー */}

--- a/frontend/src/features/prototype/utils/overlap.ts
+++ b/frontend/src/features/prototype/utils/overlap.ts
@@ -1,0 +1,17 @@
+// 汎用的な矩形の重なり判定ユーティリティ
+export type Rect = { x: number; y: number; width: number; height: number };
+
+/**
+ * 2つの矩形が重なっているか判定する
+ * @param a - 矩形A
+ * @param b - 矩形B
+ * @returns 重なっていればtrue
+ */
+export function isRectOverlap(a: Rect, b: Rect): boolean {
+  return (
+    a.x < b.x + b.width &&
+    a.x + a.width > b.x &&
+    a.y < b.y + b.height &&
+    a.y + a.height > b.y
+  );
+}


### PR DESCRIPTION
# 事前確認(共通)

- [x] PR 前に動作確認をしたか
- [x] 機密情報を含んでいないか

# やったこと<!-- このプルリクエストでやったことを書く -->

This pull request enhances the `PartCreateMenu` component by introducing collision detection for new parts, improving UI grouping, and adding a utility for rectangle overlap detection. It also updates the `GameBoard` component to support these changes. Below are the most significant changes grouped by theme:

### Collision Detection and Positioning:
* Updated `PartCreateMenu` to reposition new parts dynamically to avoid overlap with existing parts by using a new utility function `isRectOverlap`. The logic iteratively adjusts the `x` coordinate of a new part until a non-overlapping position is found. (`frontend/src/features/prototype/components/molecules/PartCreateMenu.tsx`, [frontend/src/features/prototype/components/molecules/PartCreateMenu.tsxL56-R94](diffhunk://#diff-25be0fbae81c4538161bebc62880dc5bf249fbc4304642c7155c2cc445c615c6L56-R94))

### Utility Function:
* Added a new utility function `isRectOverlap` in `frontend/src/features/prototype/utils/overlap.ts` to determine whether two rectangles overlap. This function is used in the collision detection logic. (`frontend/src/features/prototype/utils/overlap.ts`, [frontend/src/features/prototype/utils/overlap.tsR1-R17](diffhunk://#diff-f70f70746b9e8160de72ea40ce015c6fbfb1fd32654e921ce28fadde5ffdedf7R1-R17))

### UI Improvements:
* Refactored the `PartCreateMenu` UI to group part types into two categories (`group1` and `group2`) and visually separate them in the interface. Each group is displayed in its own styled container with labels. (`frontend/src/features/prototype/components/molecules/PartCreateMenu.tsx`, [[1]](diffhunk://#diff-25be0fbae81c4538161bebc62880dc5bf249fbc4304642c7155c2cc445c615c6L129-R169) [[2]](diffhunk://#diff-25be0fbae81c4538161bebc62880dc5bf249fbc4304642c7155c2cc445c615c6L150-R211)

### Integration with GameBoard:
* Updated the `GameBoard` component to pass the `parts` array to `PartCreateMenu`, enabling the collision detection logic to access existing parts on the board. (`frontend/src/features/prototype/components/organisms/GameBoard.tsx`, [frontend/src/features/prototype/components/organisms/GameBoard.tsxR797](diffhunk://#diff-c744a3a422bf8c68f3e3d51476160645ffd164a9fcc857182f844ff58c1def51R797))

# やらないこと<!-- このプルリクエストでやってもおかしくないけどやらなかったことを書く -->

特になし

# 懸念点や注意点<!-- このプルリクエストにおける懸念点や注意点を書く -->

特になし

# その他<!-- このプルリクエストで上記の項目以外に伝えるべきことを書く -->

特になし


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


* **新機能**
  * 新しい部品作成時、既存部品と重ならない位置に自動配置されるようになりました。
  * 部品作成メニューのUIが「部品」と「仕組み」の2つのグループに分かれ、見やすくなりました。

* **改善**
  * 部品配置時の重なり判定ロジックを追加し、より直感的な操作が可能になりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->