### PR TITLE
feat: add mode toggle button and selection rectangle functionality

### DIFF
--- a/frontend/src/features/prototype/components/atoms/ModeToggleButton.tsx
+++ b/frontend/src/features/prototype/components/atoms/ModeToggleButton.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { MdPanTool } from 'react-icons/md';
+
+interface ModeToggleButtonProps {
+  isSelectionMode: boolean;
+  onToggle: () => void;
+}
+
+export default function ModeToggleButton({
+  isSelectionMode,
+  onToggle,
+}: ModeToggleButtonProps) {
+  return (
+    <div className="absolute bottom-4 left-4 z-50 flex flex-col gap-2">
+      <div className="relative group">
+        <button
+          className={`relative p-3 rounded-full shadow-md transition-all duration-300 ${
+            !isSelectionMode
+              ? 'bg-kibako-primary text-kibako-white ring-2 ring-kibako-accent ring-offset-2 shadow-lg'
+              : 'bg-gray-300 text-gray-500 hover:bg-gray-400'
+          }`}
+          onClick={onToggle}
+          aria-label="Toggle Pan Mode"
+        >
+          <MdPanTool
+            className={`w-6 h-6 transition-transform duration-300 ${
+              !isSelectionMode ? 'scale-110' : 'scale-100'
+            }`}
+          />
+        </button>
+        {/* ツールチップ */}
+        <div className="absolute left-0 bottom-full mb-1 bg-header text-kibako-white text-[10px] px-1.5 py-0.5 rounded whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity duration-200 pointer-events-none z-[200]">
+          {!isSelectionMode
+            ? 'ボードをドラッグ&ドロップで移動できるモードをオフにする'
+            : 'ボードをドラッグ&ドロップで移動できるモードをオンにする'}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/features/prototype/components/atoms/ModeToggleButton.tsx
+++ b/frontend/src/features/prototype/components/atoms/ModeToggleButton.tsx
@@ -20,7 +20,9 @@ export default function ModeToggleButton({
               : 'bg-gray-300 text-gray-500 hover:bg-gray-400'
           }`}
           onClick={onToggle}
-          aria-label="Toggle Pan Mode"
+          aria-label={
+            isSelectionMode ? 'パンモードに切り替え' : '選択モードに切り替え'
+          }
         >
           <MdPanTool
             className={`w-6 h-6 transition-transform duration-300 ${

--- a/frontend/src/features/prototype/components/atoms/SelectionRect.tsx
+++ b/frontend/src/features/prototype/components/atoms/SelectionRect.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { Rect } from 'react-konva';
+
+interface SelectionRectProps {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  visible: boolean;
+}
+
+export default function SelectionRect({
+  x,
+  y,
+  width,
+  height,
+  visible,
+}: SelectionRectProps) {
+  if (!visible) return null;
+
+  return (
+    <Rect
+      x={x}
+      y={y}
+      width={width}
+      height={height}
+      fill="rgba(0, 120, 255, 0.15)"
+      stroke="#0078ff"
+      strokeWidth={1}
+      dash={[4, 2]}
+      listening={false}
+    />
+  );
+}

--- a/frontend/src/features/prototype/hooks/useSelection.ts
+++ b/frontend/src/features/prototype/hooks/useSelection.ts
@@ -1,0 +1,148 @@
+import type { KonvaEventObject } from 'konva/lib/Node';
+import { useCallback, useRef, useState } from 'react';
+
+import { Part as PartType } from '@/api/types';
+import { isRectOverlap } from '@/features/prototype/utils/overlap';
+
+interface SelectionRect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  visible: boolean;
+}
+
+interface Camera {
+  x: number;
+  y: number;
+  scale: number;
+}
+
+export function useSelection() {
+  const [isSelectionMode, setIsSelectionMode] = useState<boolean>(true);
+  const [selectionRect, setSelectionRect] = useState<SelectionRect>({
+    x: 0,
+    y: 0,
+    width: 0,
+    height: 0,
+    visible: false,
+  });
+  const selectionStartRef = useRef<{ x: number; y: number } | null>(null);
+  const justFinishedSelectionRef = useRef<boolean>(false);
+
+  // Stage座標→カメラ考慮のキャンバス座標に変換
+  const toCanvasCoords = useCallback(
+    (stageX: number, stageY: number, camera: Camera) => {
+      return {
+        x: (stageX + camera.x) / camera.scale,
+        y: (stageY + camera.y) / camera.scale,
+      };
+    },
+    []
+  );
+
+  // 選択開始
+  const handleSelectionStart = useCallback(
+    (e: KonvaEventObject<MouseEvent>, camera: Camera) => {
+      if (!isSelectionMode) return;
+
+      e.cancelBubble = true;
+      const pos = e.target.getStage()?.getPointerPosition();
+      if (!pos) return;
+
+      const { x, y } = toCanvasCoords(pos.x, pos.y, camera);
+      selectionStartRef.current = { x, y };
+      setSelectionRect({ x, y, width: 0, height: 0, visible: true });
+    },
+    [isSelectionMode, toCanvasCoords]
+  );
+
+  // 選択中の移動
+  const handleSelectionMove = useCallback(
+    (e: KonvaEventObject<MouseEvent>, camera: Camera) => {
+      if (!isSelectionMode || !selectionStartRef.current) return;
+
+      const pos = e.target.getStage()?.getPointerPosition();
+      if (!pos) return;
+
+      const { x, y } = toCanvasCoords(pos.x, pos.y, camera);
+      const start = selectionStartRef.current;
+      const rect = {
+        x: Math.min(start.x, x),
+        y: Math.min(start.y, y),
+        width: Math.abs(x - start.x),
+        height: Math.abs(y - start.y),
+        visible: true,
+      };
+      setSelectionRect(rect);
+    },
+    [isSelectionMode, toCanvasCoords]
+  );
+
+  // 選択終了
+  const handleSelectionEnd = useCallback(
+    (
+      e: KonvaEventObject<MouseEvent>,
+      parts: PartType[],
+      onPartsSelected: (partIds: number[]) => void
+    ) => {
+      if (!isSelectionMode || !selectionStartRef.current) return;
+
+      e.cancelBubble = true;
+
+      const rect = selectionRect;
+      if (rect.width > 0 && rect.height > 0) {
+        const selected = parts.filter((part) => {
+          const partRect = {
+            x: part.position.x,
+            y: part.position.y,
+            width: part.width,
+            height: part.height,
+          };
+          return isRectOverlap(rect, partRect);
+        });
+        const newSelectedIds = selected.map((p) => p.id);
+        onPartsSelected(newSelectedIds);
+        justFinishedSelectionRef.current = true;
+      } else {
+        justFinishedSelectionRef.current = false;
+      }
+
+      setSelectionRect((r) => ({ ...r, visible: false }));
+      selectionStartRef.current = null;
+    },
+    [isSelectionMode, selectionRect]
+  );
+
+  const toggleMode = useCallback(() => {
+    setIsSelectionMode((prev) => !prev);
+  }, []);
+
+  const isSelectionInProgress = useCallback(() => {
+    return selectionStartRef.current !== null;
+  }, []);
+
+  const isJustFinishedSelection = useCallback(() => {
+    const result = justFinishedSelectionRef.current;
+    if (result) {
+      justFinishedSelectionRef.current = false;
+    }
+    return result;
+  }, []);
+
+  return {
+    // States
+    isSelectionMode,
+    selectionRect,
+
+    // Handlers
+    handleSelectionStart,
+    handleSelectionMove,
+    handleSelectionEnd,
+    toggleMode,
+
+    // Utilities
+    isSelectionInProgress,
+    isJustFinishedSelection,
+  };
+}


### PR DESCRIPTION
# 事前確認(共通)

- [x] PR 前に動作確認をしたか
- [x] 機密情報を含んでいないか

# やったこと<!-- このプルリクエストでやったことを書く -->

This pull request introduces a new selection mode feature to the `GameBoard` component, allowing users to select multiple parts using a rectangular selection tool. Key changes include the addition of a `ModeToggleButton` for toggling selection mode, a `SelectionRect` component for visualizing the selection area, and a new `useSelection` hook for managing selection logic. The `GameBoard` component has been updated to integrate these features.

### New Components:
* **`ModeToggleButton`**: A button to toggle between selection mode and pan mode. Includes visual and tooltip updates based on the current mode.
* **`SelectionRect`**: A visual representation of the selection rectangle, rendered only when selection mode is active and the rectangle is visible.

### New Hook:
* **`useSelection`**: Manages the state and logic for selection mode, including starting, moving, and ending a rectangular selection, as well as toggling selection mode. Provides utility functions like `isSelectionInProgress` and `isJustFinishedSelection`.

### Integration with `GameBoard`:
* **Imports and State Management**: Added imports for `ModeToggleButton`, `SelectionRect`, and `useSelection`. Integrated `useSelection` to manage selection-related state and handlers. [[1]](diffhunk://#diff-c744a3a422bf8c68f3e3d51476160645ffd164a9fcc857182f844ff58c1def51R16-R18) [[2]](diffhunk://#diff-c744a3a422bf8c68f3e3d51476160645ffd164a9fcc857182f844ff58c1def51R35) [[3]](diffhunk://#diff-c744a3a422bf8c68f3e3d51476160645ffd164a9fcc857182f844ff58c1def51R646-R673)
* **Event Handling**: Updated `GameBoard`'s event handlers to disable certain interactions (e.g., background clicks, stage clicks) during selection mode or when a selection is in progress. [[1]](diffhunk://#diff-c744a3a422bf8c68f3e3d51476160645ffd164a9fcc857182f844ff58c1def51R476-R484) [[2]](diffhunk://#diff-c744a3a422bf8c68f3e3d51476160645ffd164a9fcc857182f844ff58c1def51R646-R673)
* **Rendering Updates**: Added `ModeToggleButton` and `SelectionRect` to the `GameBoard`'s render tree. Adjusted cursor styles and draggable properties based on the active mode. [[1]](diffhunk://#diff-c744a3a422bf8c68f3e3d51476160645ffd164a9fcc857182f844ff58c1def51R730-L714) [[2]](diffhunk://#diff-c744a3a422bf8c68f3e3d51476160645ffd164a9fcc857182f844ff58c1def51L729-R780) [[3]](diffhunk://#diff-c744a3a422bf8c68f3e3d51476160645ffd164a9fcc857182f844ff58c1def51R826-R833)

These changes collectively enhance the `GameBoard`'s functionality by introducing an intuitive and interactive way to select multiple parts.

# やらないこと<!-- このプルリクエストでやってもおかしくないけどやらなかったことを書く -->

特になし

# 懸念点や注意点<!-- このプルリクエストにおける懸念点や注意点を書く -->

特になし

# その他<!-- このプルリクエストで上記の項目以外に伝えるべきことを書く -->

特になし


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


* **新機能**
  * ゲームボードに矩形選択モードを追加し、複数アイテムの範囲選択が可能になりました。
  * 選択モードの切り替えボタンを画面左下に追加し、モードの切り替え時に日本語ツールチップが表示されます。
  * 選択範囲が視覚的に青い矩形で表示されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->