### PR TITLE
fix: ensure default frontSide is set correctly for non-card parts

### DIFF
--- a/frontend/src/features/prototype/components/molecules/PartPropertySidebar.tsx
+++ b/frontend/src/features/prototype/components/molecules/PartPropertySidebar.tsx
@@ -80,9 +80,10 @@ export default function PartPropertySidebar({
     // 選択中のパーツが存在しない、またはプロパティが存在しない場合
     if (!selectedPart || !selectedPartProperties) return;
 
-    return selectedPartProperties.find(
-      (p) => p.side === selectedPart.frontSide
-    );
+    // カードパーツの場合はfrontSideを使用、それ以外は'front'をデフォルトとする
+    const targetSide = selectedPart.frontSide || 'front';
+
+    return selectedPartProperties.find((p) => p.side === targetSide);
   }, [selectedPart, selectedPartProperties]);
 
   useEffect(() => {
@@ -124,6 +125,9 @@ export default function PartPropertySidebar({
     // カードパーツの場合
     if (selectedPart.type === 'card') {
       newPart.frontSide = selectedPart.frontSide;
+    } else {
+      // カード以外のパーツの場合はデフォルトで'front'を設定
+      newPart.frontSide = 'front';
     }
 
     // 手札パーツの場合
@@ -135,8 +139,12 @@ export default function PartPropertySidebar({
     const newPartProperties: Omit<
       PartProperty,
       'id' | 'partId' | 'createdAt' | 'updatedAt'
-    >[] = selectedPartProperties.map(
-      ({ side, name, description, color, imageId, textColor }) => {
+    >[] = selectedPartProperties
+      .filter(({ side }) => {
+        // カードパーツの場合は両面、それ以外は'front'のみ
+        return selectedPart.type === 'card' ? true : side === 'front';
+      })
+      .map(({ side, name, description, color, imageId, textColor }) => {
         return {
           side,
           name,
@@ -145,8 +153,7 @@ export default function PartPropertySidebar({
           textColor,
           imageId,
         };
-      }
-    );
+      });
     onAddPart({ part: newPart, properties: newPartProperties });
   };
 


### PR DESCRIPTION
# 事前確認(共通)

- [x] PR 前に動作確認をしたか
- [x] 機密情報を含んでいないか

# やったこと<!-- このプルリクエストでやったことを書く -->

This pull request refines the handling of `frontSide` properties for different part types in the `PartPropertySidebar` component. The changes ensure that non-card parts default to using `'front'` for their `frontSide` property and filter their properties accordingly.

### Enhancements to `frontSide` handling:

* Updated the logic to determine the `targetSide` for property selection. For card parts, it uses `frontSide`, while for non-card parts, it defaults to `'front'`. (`frontend/src/features/prototype/components/molecules/PartPropertySidebar.tsx`, [frontend/src/features/prototype/components/molecules/PartPropertySidebar.tsxL83-R86](diffhunk://#diff-ce31ffca2a5f189b4d162394479352a30809cb5ad8b781e588e51553148c0bc0L83-R86))
* Ensured that non-card parts explicitly set `frontSide` to `'front'` when creating a new part. (`frontend/src/features/prototype/components/molecules/PartPropertySidebar.tsx`, [frontend/src/features/prototype/components/molecules/PartPropertySidebar.tsxR128-R130](diffhunk://#diff-ce31ffca2a5f189b4d162394479352a30809cb5ad8b781e588e51553148c0bc0R128-R130))

### Filtering part properties:

* Added a filter to include both sides for card parts but only the `'front'` side for non-card parts when mapping `newPartProperties`. (`frontend/src/features/prototype/components/molecules/PartPropertySidebar.tsx`, [[1]](diffhunk://#diff-ce31ffca2a5f189b4d162394479352a30809cb5ad8b781e588e51553148c0bc0L138-R147) [[2]](diffhunk://#diff-ce31ffca2a5f189b4d162394479352a30809cb5ad8b781e588e51553148c0bc0L148-R156)

# やらないこと<!-- このプルリクエストでやってもおかしくないけどやらなかったことを書く -->

特になし

# 懸念点や注意点<!-- このプルリクエストにおける懸念点や注意点を書く -->

特になし

# その他<!-- このプルリクエストで上記の項目以外に伝えるべきことを書く -->

特になし


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * 非カードパーツの複製時に、常に「front」側のプロパティのみがコピーされるようになり、サイドの扱いが一貫しました。  
  * 非カードパーツ選択時のプロパティ表示が正しく「front」側になるよう改善されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->