### PR TITLE
feat: add front and back descriptions to part configuration

### DIFF
--- a/frontend/src/features/prototype/components/molecules/PartCreateMenu.tsx
+++ b/frontend/src/features/prototype/components/molecules/PartCreateMenu.tsx
@@ -141,8 +141,17 @@ export default function PartCreateMenu({
     >[] =
       partType === 'card'
         ? [
-            { side: 'front', ...commonProperties },
-            { side: 'back', ...commonProperties },
+            {
+              side: 'front',
+              ...commonProperties,
+              description:
+                partConfig.frontDescription || partConfig.description,
+            },
+            {
+              side: 'back',
+              ...commonProperties,
+              description: partConfig.backDescription || partConfig.description,
+            },
           ]
         : [{ side: 'front', ...commonProperties }];
 

--- a/frontend/src/features/prototype/const.ts
+++ b/frontend/src/features/prototype/const.ts
@@ -24,6 +24,8 @@ export const PART_DEFAULT_CONFIG: Record<string, PartDefaultConfig> = {
     description: '',
     color: '#FFFFFF',
     textColor: '#000000',
+    frontDescription: '表',
+    backDescription: '裏',
   },
   // トークン
   TOKEN: {

--- a/frontend/src/features/prototype/type.ts
+++ b/frontend/src/features/prototype/type.ts
@@ -17,6 +17,9 @@ export interface PartDefaultConfig {
   description: string;
   textColor: string;
   color: string;
+  // カード専用フィールド（optional）
+  frontDescription?: string;
+  backDescription?: string;
 }
 
 // キャンバスのカメラ


### PR DESCRIPTION
# 事前確認(共通)

- [x] PR 前に動作確認をしたか
- [x] 機密情報を含んでいないか

# やったこと<!-- このプルリクエストでやったことを書く -->

This pull request introduces enhancements to the handling of part descriptions in the `PartCreateMenu` component, specifically for cards, by adding support for optional `frontDescription` and `backDescription` fields. These changes improve flexibility and customization for card configurations.

### Enhancements to part descriptions:

* **Updated `PartCreateMenu` to support per-side descriptions for cards**: Modified the logic in `PartCreateMenu` to include `frontDescription` and `backDescription` fields when available, falling back to the general `description` field if specific side descriptions are not provided. (`frontend/src/features/prototype/components/molecules/PartCreateMenu.tsx`)

* **Added `frontDescription` and `backDescription` to default part configurations**: Updated `PART_DEFAULT_CONFIG` to include default values (`表` for `frontDescription` and `裏` for `backDescription`) for card-specific fields. (`frontend/src/features/prototype/const.ts`)

* **Extended `PartDefaultConfig` interface to support new fields**: Added optional `frontDescription` and `backDescription` fields to the `PartDefaultConfig` interface, ensuring type safety for these new properties. (`frontend/src/features/prototype/type.ts`)

# やらないこと<!-- このプルリクエストでやってもおかしくないけどやらなかったことを書く -->

特になし

# 懸念点や注意点<!-- このプルリクエストにおける懸念点や注意点を書く -->

特になし

# その他<!-- このプルリクエストで上記の項目以外に伝えるべきことを書く -->

特になし


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * カードタイプのパーツで、表面と裏面それぞれに個別の説明文を設定できるようになりました（従来は共通の説明文のみ）。
* **改善**
  * カード作成時、表面と裏面の説明文が分かれて表示されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->