### PR TITLE
Remove unused ref and forwardRef from PartOnGameBoard and useCard

### DIFF
--- a/frontend/src/features/prototype/components/molecules/PartOnGameBoard.tsx
+++ b/frontend/src/features/prototype/components/molecules/PartOnGameBoard.tsx
@@ -1,5 +1,5 @@
 import Konva from 'konva';
-import React, { forwardRef, useMemo, useRef, useEffect, useState } from 'react';
+import React, { useMemo, useRef, useEffect, useState } from 'react';
 import { Group, Rect, Text, Image } from 'react-konva';
 import useImage from 'use-image';
 
@@ -10,7 +10,6 @@ import { useSocket } from '@/features/prototype/contexts/SocketContext';
 import { useCard } from '@/features/prototype/hooks/useCard';
 import { useDebugMode } from '@/features/prototype/hooks/useDebugMode';
 import { useDeck } from '@/features/prototype/hooks/useDeck';
-import { PartHandle } from '@/features/prototype/type';
 import { GameBoardMode } from '@/features/prototype/types/gameBoardMode';
 
 interface PartOnGameBoardProps {
@@ -33,259 +32,251 @@ interface PartOnGameBoardProps {
   isActive: boolean;
 }
 
-const PartOnGameBoard = forwardRef<PartHandle, PartOnGameBoardProps>(
-  (
-    {
-      part,
-      properties,
-      isOtherPlayerCard = false,
-      gameBoardMode,
-      images,
-      onDragStart,
-      onDragMove,
-      onDragEnd,
-      onClick,
-      onContextMenu,
-      onChangePartOrder,
-      isActive = false,
-    },
-    ref
-  ) => {
-    const groupRef = useRef<Konva.Group>(null);
-    const { isReversing, setIsReversing, reverseCard } = useCard(part, ref);
-    const { shuffleDeck } = useDeck(part);
-    const [scaleX, setScaleX] = useState(1);
-    const { showDebugInfo } = useDebugMode();
-    const { socket } = useSocket();
+export default function PartOnGameBoard({
+  part,
+  properties,
+  isOtherPlayerCard = false,
+  gameBoardMode,
+  images,
+  onDragStart,
+  onDragMove,
+  onDragEnd,
+  onClick,
+  onContextMenu,
+  onChangePartOrder,
+  isActive = false,
+}: PartOnGameBoardProps) {
+  const groupRef = useRef<Konva.Group>(null);
+  const { isReversing, setIsReversing, reverseCard } = useCard(part);
+  const { shuffleDeck } = useDeck(part);
+  const [scaleX, setScaleX] = useState(1);
+  const { showDebugInfo } = useDebugMode();
+  const { socket } = useSocket();
 
-    const isCard = part.type === 'card';
-    const isDeck = part.type === 'deck';
+  const isCard = part.type === 'card';
+  const isDeck = part.type === 'deck';
 
-    // カードの反転を受信する
-    useEffect(() => {
-      const handleFlipCard = ({
-        cardId,
-        nextFrontSide,
-      }: {
-        cardId: number;
-        nextFrontSide: 'front' | 'back';
-      }) => {
-        if (cardId === part.id) {
-          reverseCard(nextFrontSide, false);
-        }
-      };
+  // カードの反転を受信する
+  useEffect(() => {
+    const handleFlipCard = ({
+      cardId,
+      nextFrontSide,
+    }: {
+      cardId: number;
+      nextFrontSide: 'front' | 'back';
+    }) => {
+      if (cardId === part.id) {
+        reverseCard(nextFrontSide, false);
+      }
+    };
 
-      socket.on('FLIP_CARD', handleFlipCard);
+    socket.on('FLIP_CARD', handleFlipCard);
 
-      // クリーンアップ関数を追加
-      return () => {
-        socket.off('FLIP_CARD', handleFlipCard);
-      };
-    }, [part.id, reverseCard, socket]);
+    // クリーンアップ関数を追加
+    return () => {
+      socket.off('FLIP_CARD', handleFlipCard);
+    };
+  }, [part.id, reverseCard, socket]);
 
-    // アニメーション用のエフェクト
-    useEffect(() => {
-      if (!isCard || !isReversing || !groupRef.current) return;
+  // アニメーション用のエフェクト
+  useEffect(() => {
+    if (!isCard || !isReversing || !groupRef.current) return;
 
-      // フリップアニメーション
-      const anim = new Konva.Animation((frame) => {
-        if (!frame || !groupRef.current) return;
+    // フリップアニメーション
+    const anim = new Konva.Animation((frame) => {
+      if (!frame || !groupRef.current) return;
 
-        const duration = 200; // アニメーション時間 (ミリ秒)
-        const timePassed = frame.time % duration;
-        const progress = timePassed / duration;
+      const duration = 200; // アニメーション時間 (ミリ秒)
+      const timePassed = frame.time % duration;
+      const progress = timePassed / duration;
 
-        if (progress < 0.5) {
-          // 最初の半分：縮小
-          setScaleX(1 - progress * 2);
-        } else {
-          // 後半：拡大
-          setScaleX((progress - 0.5) * 2);
-        }
+      if (progress < 0.5) {
+        // 最初の半分：縮小
+        setScaleX(1 - progress * 2);
+      } else {
+        // 後半：拡大
+        setScaleX((progress - 0.5) * 2);
+      }
 
-        // アニメーション終了
-        if (frame.time >= duration) {
-          anim.stop();
-          setScaleX(1);
-          setIsReversing(false);
-        }
-      }, groupRef.current.getLayer());
-
-      anim.start();
-
-      return () => {
+      // アニメーション終了
+      if (frame.time >= duration) {
         anim.stop();
-      };
-    }, [isReversing, isCard, setIsReversing]);
+        setScaleX(1);
+        setIsReversing(false);
+      }
+    }, groupRef.current.getLayer());
 
-    // 常に裏面を表示すべきカードか
-    const shouldAlwaysDisplayBackSide =
+    anim.start();
+
+    return () => {
+      anim.stop();
+    };
+  }, [isReversing, isCard, setIsReversing]);
+
+  // 常に裏面を表示すべきカードか
+  const shouldAlwaysDisplayBackSide =
+    gameBoardMode === GameBoardMode.PLAY &&
+    part.type === 'card' &&
+    isOtherPlayerCard;
+
+  // 表示する面を決定
+  const frontSide = shouldAlwaysDisplayBackSide ? 'back' : part.frontSide;
+
+  // 対象面（表or裏）のプロパティを取得 (ローカルの isFlipped 状態を使用)
+  const targetProperty = useMemo(() => {
+    return properties.find((p) => p.side === frontSide);
+  }, [frontSide, properties]);
+
+  // 有効な画像URLの値を取得する関数
+  const getValidImageURL = (imageId?: string | null) => {
+    if (!imageId) return null;
+    const targetImage = images.find((image) => image[imageId]);
+    return targetImage ? targetImage[imageId] : null;
+  };
+
+  // 有効な画像URLの値
+  const validImageURL = getValidImageURL(targetProperty?.imageId);
+
+  // 画像をロード
+  const [image] = useImage(validImageURL || '');
+
+  // ロードされた画像の状態を追跡
+  const imageLoaded = !!image && validImageURL;
+
+  const handleDoubleClick = () => {
+    const isInteractivePart = isCard || isDeck;
+    if (!isInteractivePart) return;
+
+    if (isDeck) {
+      shuffleDeck();
+      return;
+    }
+
+    if (isCard && !shouldAlwaysDisplayBackSide) {
+      reverseCard(part.frontSide === 'front' ? 'back' : 'front', true);
+      return;
+    }
+  };
+
+  // 中央を軸にして反転させるための設定
+  const offsetX = part.width / 2;
+
+  const handleDragStart = (e: Konva.KonvaEventObject<DragEvent>) => {
+    // プレイモード時にカードまたはトークンがドラッグされたら最前面に移動
+    if (
       gameBoardMode === GameBoardMode.PLAY &&
-      part.type === 'card' &&
-      isOtherPlayerCard;
+      (part.type === 'card' || part.type === 'token')
+    ) {
+      onChangePartOrder('frontmost');
+    }
+    onDragStart(e);
+  };
 
-    // 表示する面を決定
-    const frontSide = shouldAlwaysDisplayBackSide ? 'back' : part.frontSide;
+  // コンテキストメニュー用ハンドラー
+  const handleContextMenu = (e: Konva.KonvaEventObject<PointerEvent>) => {
+    e.evt.preventDefault();
+    onContextMenu(e, part.id);
+  };
 
-    // 対象面（表or裏）のプロパティを取得 (ローカルの isFlipped 状態を使用)
-    const targetProperty = useMemo(() => {
-      return properties.find((p) => p.side === frontSide);
-    }, [frontSide, properties]);
-
-    // 有効な画像URLの値を取得する関数
-    const getValidImageURL = (imageId?: string | null) => {
-      if (!imageId) return null;
-      const targetImage = images.find((image) => image[imageId]);
-      return targetImage ? targetImage[imageId] : null;
-    };
-
-    // 有効な画像URLの値
-    const validImageURL = getValidImageURL(targetProperty?.imageId);
-
-    // 画像をロード
-    const [image] = useImage(validImageURL || '');
-
-    // ロードされた画像の状態を追跡
-    const imageLoaded = !!image && validImageURL;
-
-    const handleDoubleClick = () => {
-      const isInteractivePart = isCard || isDeck;
-      if (!isInteractivePart) return;
-
-      if (isDeck) {
-        shuffleDeck();
-        return;
-      }
-
-      if (isCard && !shouldAlwaysDisplayBackSide) {
-        reverseCard(part.frontSide === 'front' ? 'back' : 'front', true);
-        return;
-      }
-    };
-
-    // 中央を軸にして反転させるための設定
-    const offsetX = part.width / 2;
-
-    const handleDragStart = (e: Konva.KonvaEventObject<DragEvent>) => {
-      // プレイモード時にカードまたはトークンがドラッグされたら最前面に移動
-      if (
-        gameBoardMode === GameBoardMode.PLAY &&
-        (part.type === 'card' || part.type === 'token')
-      ) {
-        onChangePartOrder('frontmost');
-      }
-      onDragStart(e);
-    };
-
-    // コンテキストメニュー用ハンドラー
-    const handleContextMenu = (e: Konva.KonvaEventObject<PointerEvent>) => {
-      e.evt.preventDefault();
-      onContextMenu(e, part.id);
-    };
-
-    return (
-      <Group
-        ref={groupRef}
-        name={`part-${part.id}`}
-        x={part.position.x + offsetX}
-        y={part.position.y}
+  return (
+    <Group
+      ref={groupRef}
+      name={`part-${part.id}`}
+      x={part.position.x + offsetX}
+      y={part.position.y}
+      width={part.width}
+      height={part.height}
+      offsetX={offsetX}
+      draggable
+      scaleX={scaleX}
+      onDragStart={handleDragStart}
+      onDragMove={(e) => onDragMove(e, part.id)}
+      onDragEnd={(e) => onDragEnd(e, part.id)}
+      onClick={onClick}
+      onDblClick={handleDoubleClick}
+      onContextMenu={handleContextMenu}
+    >
+      {/* パーツの背景 */}
+      <Rect
         width={part.width}
         height={part.height}
-        offsetX={offsetX}
-        draggable
-        scaleX={scaleX}
-        onDragStart={handleDragStart}
-        onDragMove={(e) => onDragMove(e, part.id)}
-        onDragEnd={(e) => onDragEnd(e, part.id)}
-        onClick={onClick}
-        onDblClick={handleDoubleClick}
-        onContextMenu={handleContextMenu}
-      >
-        {/* パーツの背景 */}
-        <Rect
+        fill={imageLoaded ? 'white' : targetProperty?.color || 'white'}
+        stroke={'grey'}
+        strokeWidth={1}
+        cornerRadius={isCard ? 10 : 4}
+        opacity={part.type === 'area' ? 0.6 : 1}
+        dash={part.type === 'area' ? [4, 4] : undefined}
+        shadowColor={isActive ? 'rgba(59, 130, 246, 1)' : 'transparent'}
+        shadowBlur={isActive ? 10 : 0}
+        shadowOffsetX={0}
+        shadowOffsetY={0}
+      />
+
+      {/* 画像があれば表示 */}
+      {imageLoaded && (
+        <Image
+          image={image}
           width={part.width}
           height={part.height}
-          fill={imageLoaded ? 'white' : targetProperty?.color || 'white'}
-          stroke={'grey'}
-          strokeWidth={1}
           cornerRadius={isCard ? 10 : 4}
           opacity={part.type === 'area' ? 0.6 : 1}
-          dash={part.type === 'area' ? [4, 4] : undefined}
-          shadowColor={isActive ? 'rgba(59, 130, 246, 1)' : 'transparent'}
-          shadowBlur={isActive ? 10 : 0}
-          shadowOffsetX={0}
-          shadowOffsetY={0}
+          alt={targetProperty?.name || 'Game part'}
         />
+      )}
 
-        {/* 画像があれば表示 */}
-        {imageLoaded && (
-          <Image
-            image={image}
-            width={part.width}
-            height={part.height}
-            cornerRadius={isCard ? 10 : 4}
-            opacity={part.type === 'area' ? 0.6 : 1}
-            alt={targetProperty?.name || 'Game part'}
-          />
-        )}
+      {/* パーツの名前 */}
+      <Text
+        text={targetProperty?.name || ''}
+        fontSize={part.type === 'token' ? 12 : 14}
+        fontStyle="bold"
+        fill={targetProperty?.textColor || 'black'}
+        width={part.width}
+        align="center"
+        padding={10}
+        y={5}
+      />
 
-        {/* パーツの名前 */}
+      {/* 説明文 */}
+      {targetProperty?.description && (
         <Text
-          text={targetProperty?.name || ''}
-          fontSize={part.type === 'token' ? 12 : 14}
-          fontStyle="bold"
-          fill={targetProperty?.textColor || 'black'}
-          width={part.width}
+          text={targetProperty.description}
+          fontSize={10}
+          fill={targetProperty.textColor || '#666'}
+          width={part.width - 20}
           align="center"
-          padding={10}
-          y={5}
+          y={part.height / 2}
+          x={10}
+          wrap="word"
+          ellipsis={true}
         />
+      )}
 
-        {/* 説明文 */}
-        {targetProperty?.description && (
-          <Text
-            text={targetProperty.description}
-            fontSize={10}
-            fill={targetProperty.textColor || '#666'}
-            width={part.width - 20}
-            align="center"
-            y={part.height / 2}
-            x={10}
-            wrap="word"
-            ellipsis={true}
-          />
-        )}
-
-        {/* タイプを示す小さなアイコン */}
-        <Group x={part.width - 30} y={part.height - 25}>
-          {isDeck && <ShuffleIcon size={20} color="#666" />}
-          {isCard && <FlipIcon size={20} color="#666" />}
-        </Group>
-
-        {/* デバッグ情報: ID と順序（order） - showDebugInfoがtrueの場合のみ表示 */}
-        {showDebugInfo && (
-          <Group x={5} y={5}>
-            <Rect
-              width={85}
-              height={25}
-              fill="rgba(0, 0, 0, 0.7)"
-              cornerRadius={4}
-            />
-            <Text
-              text={`ID:${part.id}\nO:${typeof part.order === 'number' ? part.order : 'N/A'}`}
-              fontSize={10}
-              fill="white"
-              width={85}
-              align="left"
-              x={5}
-              y={3}
-            />
-          </Group>
-        )}
+      {/* タイプを示す小さなアイコン */}
+      <Group x={part.width - 30} y={part.height - 25}>
+        {isDeck && <ShuffleIcon size={20} color="#666" />}
+        {isCard && <FlipIcon size={20} color="#666" />}
       </Group>
-    );
-  }
-);
-PartOnGameBoard.displayName = 'Part';
 
-export default PartOnGameBoard;
+      {/* デバッグ情報: ID と順序（order） - showDebugInfoがtrueの場合のみ表示 */}
+      {showDebugInfo && (
+        <Group x={5} y={5}>
+          <Rect
+            width={85}
+            height={25}
+            fill="rgba(0, 0, 0, 0.7)"
+            cornerRadius={4}
+          />
+          <Text
+            text={`ID:${part.id}\nO:${typeof part.order === 'number' ? part.order : 'N/A'}`}
+            fontSize={10}
+            fill="white"
+            width={85}
+            align="left"
+            x={5}
+            y={3}
+          />
+        </Group>
+      )}
+    </Group>
+  );
+}

--- a/frontend/src/features/prototype/hooks/useCard.ts
+++ b/frontend/src/features/prototype/hooks/useCard.ts
@@ -1,9 +1,8 @@
-import { useImperativeHandle, useState, useCallback } from 'react';
+import { useState, useCallback } from 'react';
 
 import { Part } from '@/api/types';
 import { usePartReducer } from '@/features/prototype/hooks/usePartReducer';
 import { usePerformanceTracker } from '@/features/prototype/hooks/usePerformanceTracker';
-import { PartHandle } from '@/features/prototype/type';
 
 /**
  * カードの状態を管理するフック
@@ -11,7 +10,7 @@ import { PartHandle } from '@/features/prototype/type';
  * @param ref - Partコンポーネントのref
  * @returns カードの状態
  */
-export const useCard = (part: Part, ref: React.ForwardedRef<PartHandle>) => {
+export const useCard = (part: Part) => {
   const { dispatch } = usePartReducer();
   const { measureOperation } = usePerformanceTracker();
   // カードが反転中かどうか
@@ -44,16 +43,16 @@ export const useCard = (part: Part, ref: React.ForwardedRef<PartHandle>) => {
     [part.type, part.frontSide, part.id, measureOperation, dispatch]
   );
 
-  // 外部から呼び出せる関数を定義    // 外部から呼び出せる関数を定義
-  useImperativeHandle(ref, () => ({
-    reverseCard: (nextFrontSide: 'front' | 'back', needsSocketEmit = false) => {
-      handleReverseCard(nextFrontSide, needsSocketEmit);
-    },
-  }));
+  const reverseCard = (
+    nextFrontSide: 'front' | 'back',
+    needsSocketEmit = false
+  ) => {
+    handleReverseCard(nextFrontSide, needsSocketEmit);
+  };
 
   return {
     isReversing,
     setIsReversing,
-    reverseCard: handleReverseCard,
+    reverseCard,
   };
 };

--- a/frontend/src/features/prototype/type.ts
+++ b/frontend/src/features/prototype/type.ts
@@ -1,13 +1,5 @@
 import { Part, PartProperty, Image } from '@/api/types';
 
-// Partコンポーネントの外部から呼び出せる関数のインターフェース
-export interface PartHandle {
-  reverseCard: (
-    nextFrontSide: 'front' | 'back',
-    needsSocketEmit?: boolean
-  ) => void;
-}
-
 // パーツのデフォルト設定
 export interface PartDefaultConfig {
   type: 'card' | 'token' | 'hand' | 'deck' | 'area';


### PR DESCRIPTION
…ify API

# 事前確認(共通)

- [ ] PR 前に動作確認をしたか
- [ ] 機密情報を含んでいないか

# やったこと<!-- このプルリクエストでやったことを書く -->
PartOnGameBoard の ref は内部でも外部でも使われていないため、forwardRef をやめて通常の関数コンポーネントに修正しました。
useCard からも ref 関連の引数・useImperativeHandle を削除することで、コードがシンプルにし、不要な依存を減らしました。

# やらないこと<!-- このプルリクエストでやってもおかしくないけどやらなかったことを書く -->

特になし

# 懸念点や注意点<!-- このプルリクエストにおける懸念点や注意点を書く -->

特になし

# その他<!-- このプルリクエストで上記の項目以外に伝えるべきことを書く -->

特になし
