### PR TITLE
fix: restore devIndicators setting in next.config.js

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -10,6 +10,7 @@ const nextConfig = {
     };
     return config;
   },
+  devIndicators: false,
 };
 
 module.exports = nextConfig;


### PR DESCRIPTION
# 事前確認(共通)

- [x] PR 前に動作確認をしたか
- [x] 機密情報を含んでいないか

# やったこと<!-- このプルリクエストでやったことを書く -->

This pull request includes a small change to the `frontend/next.config.js` file. The change disables development build indicators by setting `devIndicators` to `false`.

# やらないこと<!-- このプルリクエストでやってもおかしくないけどやらなかったことを書く -->

特になし

# 懸念点や注意点<!-- このプルリクエストにおける懸念点や注意点を書く -->

特になし

# その他<!-- このプルリクエストで上記の項目以外に伝えるべきことを書く -->

特になし
