### PR TITLE
fix: update terminology from "プロトタイプ" to "プロジェクト" for consistency across components

### DIFF
--- a/frontend/src/app/projects/page.tsx
+++ b/frontend/src/app/projects/page.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import ProjectList from '@/features/prototype/components/organisms/ProjectList';
 
 export const metadata: Metadata = {
-  title: 'プロトタイプ一覧',
+  title: 'プロジェクト一覧',
 };
 
 const ProjectsPage: React.FC = () => {

--- a/frontend/src/components/organisms/Header.tsx
+++ b/frontend/src/components/organisms/Header.tsx
@@ -10,11 +10,11 @@ const Header: React.FC = () => {
   const pathname = usePathname();
 
   /**
-   * プロトタイプ一覧画面へ遷移する
-   * 現在すでにプロトタイプ一覧画面またはログイン画面にいる場合は何もしない
+   * プロジェクト一覧画面へ遷移する
+   * 現在すでにプロジェクト一覧画面またはログイン画面にいる場合は何もしない
    */
-  const goToPrototypes = () => {
-    // プロトタイプ一覧画面、またはログイン画面の場合
+  const goToProjects = () => {
+    // プロジェクト一覧画面、またはログイン画面の場合
     if (pathname === '/projects' || pathname === '/') return;
 
     router.push('/projects');
@@ -22,7 +22,7 @@ const Header: React.FC = () => {
 
   return (
     <header className="bg-kibako-primary text-white p-6 flex justify-between items-center h-20">
-      <button onClick={goToPrototypes}>
+      <button onClick={goToProjects}>
         <div className="flex gap-2">
           <GiWoodenCrate className="text-4xl drop-shadow-xl transform -rotate-6 text-kibako-white" />
           <span className="text-3xl tracking-wider font-medium text-kibako-white">

--- a/frontend/src/features/prototype/components/organisms/DeletePrototypeConfirmation.tsx
+++ b/frontend/src/features/prototype/components/organisms/DeletePrototypeConfirmation.tsx
@@ -92,14 +92,14 @@ const DeletePrototypeConfirmation = () => {
     return (
       <div className="max-w-3xl mx-auto mt-16 p-8 bg-white rounded-xl shadow-lg">
         <div className="text-center text-gray-600">
-          プロトタイプが見つかりません
+          プロジェクトが見つかりません
         </div>
         <div className="mt-4 text-center">
           <button
             onClick={() => router.push('/projects')}
             className="px-4 py-2 bg-gray-200 rounded-md hover:bg-gray-300 transition-colors"
           >
-            プロトタイプ一覧へ戻る
+            プロジェクト一覧へ戻る
           </button>
         </div>
       </div>
@@ -120,22 +120,20 @@ const DeletePrototypeConfirmation = () => {
 
       <div className="text-center mb-6">
         <h1 className="text-2xl font-bold text-red-600 mb-2">
-          プロトタイプを削除
+          プロジェクトを削除
         </h1>
         <div className="bg-red-50 rounded-lg p-4 text-red-800 mb-6">
           <p className="mb-2">
             <span className="font-bold">警告:</span> 削除操作は取り消せません。
           </p>
-          <p>
-            このプロトタイプの全てのバージョン、プレイルーム、関連するデータが完全に削除されます。
-          </p>
+          <p>このプロジェクトに関連する全てのデータが完全に削除されます。</p>
         </div>
       </div>
 
       <div className="bg-gray-50 p-6 rounded-lg mb-8 border border-gray-200">
-        <h2 className="text-xl font-semibold mb-4">削除するプロトタイプ</h2>
+        <h2 className="text-xl font-semibold mb-4">削除するプロジェクト</h2>
         <div className="mb-4">
-          <div className="text-sm text-gray-500">プロトタイプ名</div>
+          <div className="text-sm text-gray-500">プロジェクト名</div>
           <div className="text-lg font-medium">{masterPrototype?.name}</div>
         </div>
       </div>

--- a/frontend/src/features/prototype/components/organisms/ProjectList.tsx
+++ b/frontend/src/features/prototype/components/organisms/ProjectList.tsx
@@ -1,11 +1,7 @@
 'use client';
 
 import { useRouter } from 'next/navigation';
-import React, {
-  useState,
-  useEffect,
-  useCallback,
-} from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import { createPortal } from 'react-dom';
 import { FaPlus } from 'react-icons/fa';
 import { RiLoaderLine } from 'react-icons/ri';
@@ -24,8 +20,8 @@ import { deleteExpiredImagesFromIndexedDb } from '@/utils/db';
  * PrototypeListコンポーネントで使用される各種Stateの説明:
  *
  * @state isLoading - データ取得中のローディング状態を管理するState。
- * @state isCreating - プロトタイプ作成中のローディング状態を管理するState。
- * @state prototypeList - プロジェクトとプロトタイプのリストを保持するState。
+ * @state isCreating - プロジェクト作成中のローディング状態を管理するState。
+ * @state prototypeList - プロジェクトのリストを保持するState。
  * @state sort - プロトタイプのソート条件（キーと順序）を管理するState。
  *
  * 編集機能はuseInlineEditカスタムフックで管理されています。
@@ -116,8 +112,6 @@ const ProjectList: React.FC = () => {
 
     return `${randomAdjective}な${randomNoun}`;
   };
-
-
 
   /**
    * 新しいプロトタイプを作成する
@@ -231,7 +225,6 @@ const ProjectList: React.FC = () => {
     fetchProjects();
   }, [fetchProjects]);
 
-
   /**
    * 右クリック時の処理
    */
@@ -262,7 +255,10 @@ const ProjectList: React.FC = () => {
   /**
    * コンテキストメニューのアイテム定義
    */
-  const getContextMenuItems = (project: Project, masterPrototype: Prototype) => [
+  const getContextMenuItems = (
+    project: Project,
+    masterPrototype: Prototype
+  ) => [
     {
       id: 'rename',
       text: '名前の変更',
@@ -303,16 +299,16 @@ const ProjectList: React.FC = () => {
     <div className="max-w-6xl mx-auto py-16 relative px-4">
       {/* タイトル */}
       <h1 className="text-3xl text-wood-darkest font-bold mb-8 text-center bg-gradient-to-r from-header via-header-light to-header text-transparent bg-clip-text">
-        プロトタイプ一覧
+        プロジェクト一覧
       </h1>
 
-      {/* プロトタイプ一覧（カード形式） */}
+      {/* プロジェクト一覧（カード形式） */}
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mb-8">
         {prototypeList.map(({ masterPrototype, project }) => {
           if (!masterPrototype) return null;
           const { id } = masterPrototype;
           const isNameEditing = isEditing(id);
-          
+
           /**
            * カードクリック時の処理
            */
@@ -323,15 +319,17 @@ const ProjectList: React.FC = () => {
           /**
            * ProjectCard用のイベントハンドラー
            */
-          const handleProjectCardSubmit = (e: React.FormEvent<HTMLFormElement>) =>
-            handleSubmit(e, handleNameEditComplete, validatePrototypeName);
-          
+          const handleProjectCardSubmit = (
+            e: React.FormEvent<HTMLFormElement>
+          ) => handleSubmit(e, handleNameEditComplete, validatePrototypeName);
+
           const handleProjectCardBlur = () =>
             handleBlur(handleNameEditComplete, validatePrototypeName);
-          
-          const handleProjectCardKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) =>
-            handleKeyDown(e, handleNameEditComplete, validatePrototypeName);
-          
+
+          const handleProjectCardKeyDown = (
+            e: React.KeyboardEvent<HTMLInputElement>
+          ) => handleKeyDown(e, handleNameEditComplete, validatePrototypeName);
+
           return (
             <ProjectCard
               key={id}
@@ -349,8 +347,8 @@ const ProjectList: React.FC = () => {
           );
         })}
       </div>
-      
-      {/* 新規プロトタイプ作成ボタン（フローティングアクションボタン） */}
+
+      {/* 新規プロジェクト作成ボタン（フローティングアクションボタン） */}
       <button
         onClick={handleCreatePrototype}
         disabled={isCreating}
@@ -360,7 +358,7 @@ const ProjectList: React.FC = () => {
               ? 'opacity-80 cursor-not-allowed'
               : 'hover:shadow-xl hover:scale-110 hover:from-header-light hover:to-header'
           }`}
-        title={isCreating ? '作成中...' : '新しいプロトタイプを作成'}
+        title={isCreating ? '作成中...' : '新しいプロジェクトを作成'}
       >
         {isCreating ? (
           <RiLoaderLine className="w-6 h-6 animate-spin" />
@@ -370,19 +368,21 @@ const ProjectList: React.FC = () => {
       </button>
 
       {/* コンテキストメニュー */}
-      {contextMenu.targetProject && createPortal(
-        <ProjectContextMenu
-          visible={contextMenu.visible}
-          position={contextMenu.position}
-          width={140}
-          itemHeight={32}
-          items={getContextMenuItems(
-            contextMenu.targetProject.project,
-            contextMenu.targetProject.masterPrototype
-          )}
-          onClose={closeContextMenu}
-        />
-      , document.body)}
+      {contextMenu.targetProject &&
+        createPortal(
+          <ProjectContextMenu
+            visible={contextMenu.visible}
+            position={contextMenu.position}
+            width={140}
+            itemHeight={32}
+            items={getContextMenuItems(
+              contextMenu.targetProject.project,
+              contextMenu.targetProject.masterPrototype
+            )}
+            onClose={closeContextMenu}
+          />,
+          document.body
+        )}
     </div>
   );
 };

--- a/frontend/src/features/prototype/components/organisms/ProjectList.tsx
+++ b/frontend/src/features/prototype/components/organisms/ProjectList.tsx
@@ -110,7 +110,7 @@ const ProjectList: React.FC = () => {
       adjectives[Math.floor(Math.random() * adjectives.length)];
     const randomNoun = nouns[Math.floor(Math.random() * nouns.length)];
 
-    return `${randomAdjective}な${randomNoun}`;
+    return `${randomAdjective}${randomNoun}`;
   };
 
   /**


### PR DESCRIPTION
# 事前確認(共通)

- [x] PR 前に動作確認をしたか
- [x] 機密情報を含んでいないか

# やったこと<!-- このプルリクエストでやったことを書く -->

This pull request updates the terminology in the codebase by replacing references to "プロトタイプ" (prototype) with "プロジェクト" (project) to align with a new naming convention. Additionally, it includes minor code cleanup and formatting changes in the `ProjectList` component.

### Terminology Updates:
* [`frontend/src/app/projects/page.tsx`](diffhunk://#diff-7653e6c416baaff07d46916a1381b3ac6720d2d1a9cf25ad426206f38858fe35L7-R7): Updated the page title from "プロトタイプ一覧" to "プロジェクト一覧".
* [`frontend/src/components/organisms/Header.tsx`](diffhunk://#diff-cca4aef5debb24d9d6059c9b5caf89f27a47431a1d10329ff7a2029e1fa6958bL13-R25): Renamed the `goToPrototypes` function to `goToProjects` and updated related comments and button labels.
* [`frontend/src/features/prototype/components/organisms/DeletePrototypeConfirmation.tsx`](diffhunk://#diff-4215d176eab64807c3a5760c28d63aadb97631c175a19b36ee7751fc66de4eeaL95-R102): Replaced all references to "プロトタイプ" with "プロジェクト" in the deletion confirmation UI and related text. [[1]](diffhunk://#diff-4215d176eab64807c3a5760c28d63aadb97631c175a19b36ee7751fc66de4eeaL95-R102) [[2]](diffhunk://#diff-4215d176eab64807c3a5760c28d63aadb97631c175a19b36ee7751fc66de4eeaL123-R136)
* [`frontend/src/features/prototype/components/organisms/ProjectList.tsx`](diffhunk://#diff-9ab8639c1920bdd581fe6cab9d78ba5bbfad168c71bd0225a6846967587fbae5L27-R24): Updated comments, UI labels, and state descriptions to use "プロジェクト" instead of "プロトタイプ". [[1]](diffhunk://#diff-9ab8639c1920bdd581fe6cab9d78ba5bbfad168c71bd0225a6846967587fbae5L27-R24) [[2]](diffhunk://#diff-9ab8639c1920bdd581fe6cab9d78ba5bbfad168c71bd0225a6846967587fbae5L306-R305) [[3]](diffhunk://#diff-9ab8639c1920bdd581fe6cab9d78ba5bbfad168c71bd0225a6846967587fbae5L353-R351) [[4]](diffhunk://#diff-9ab8639c1920bdd581fe6cab9d78ba5bbfad168c71bd0225a6846967587fbae5L363-R361)

### Code Cleanup:
* [`frontend/src/features/prototype/components/organisms/ProjectList.tsx`](diffhunk://#diff-9ab8639c1920bdd581fe6cab9d78ba5bbfad168c71bd0225a6846967587fbae5L4-R4): Consolidated imports into a single line.
* [`frontend/src/features/prototype/components/organisms/ProjectList.tsx`](diffhunk://#diff-9ab8639c1920bdd581fe6cab9d78ba5bbfad168c71bd0225a6846967587fbae5L117-L121): Removed unnecessary blank lines and reformatted function definitions for better readability. [[1]](diffhunk://#diff-9ab8639c1920bdd581fe6cab9d78ba5bbfad168c71bd0225a6846967587fbae5L117-L121) [[2]](diffhunk://#diff-9ab8639c1920bdd581fe6cab9d78ba5bbfad168c71bd0225a6846967587fbae5L234) [[3]](diffhunk://#diff-9ab8639c1920bdd581fe6cab9d78ba5bbfad168c71bd0225a6846967587fbae5L265-R261) [[4]](diffhunk://#diff-9ab8639c1920bdd581fe6cab9d78ba5bbfad168c71bd0225a6846967587fbae5L326-R331) [[5]](diffhunk://#diff-9ab8639c1920bdd581fe6cab9d78ba5bbfad168c71bd0225a6846967587fbae5L373-R372) [[6]](diffhunk://#diff-9ab8639c1920bdd581fe6cab9d78ba5bbfad168c71bd0225a6846967587fbae5L384-R385)

# やらないこと<!-- このプルリクエストでやってもおかしくないけどやらなかったことを書く -->

特になし

# 懸念点や注意点<!-- このプルリクエストにおける懸念点や注意点を書く -->

特になし

# その他<!-- このプルリクエストで上記の項目以外に伝えるべきことを書く -->

特になし


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **スタイル**
  * UI上の用語を「プロトタイプ」から「プロジェクト」へ統一しました。
  * ページタイトルを「プロジェクト一覧」に変更しました。
  * ラベルやボタン、エラーメッセージ等の文言を「プロジェクト」に修正しました。
  * UIコメントやツールチップも同様に修正しました。

* **リファクタ**
  * コードのインデントやコメント、関数名のリネーミング（例：goToPrototypes→goToProjects）を実施しました。
  * 無駄な日本語助詞を削除し、命名規則を整理しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->