### PR TITLE
refactor: remove onChangePartOrder prop and handle part order in drag system for improved logic

### DIFF
--- a/frontend/src/features/prototype/components/molecules/PartOnGameBoard.tsx
+++ b/frontend/src/features/prototype/components/molecules/PartOnGameBoard.tsx
@@ -35,9 +35,6 @@ interface PartOnGameBoardProps {
     e: Konva.KonvaEventObject<PointerEvent>,
     partId: number
   ) => void;
-  onChangePartOrder: (
-    type: 'front' | 'back' | 'frontmost' | 'backmost'
-  ) => void;
   isActive: boolean;
   // ユーザー情報
   userRoles?: Array<{
@@ -58,7 +55,6 @@ export default function PartOnGameBoard({
   onDragEnd,
   onClick,
   onContextMenu,
-  onChangePartOrder,
   isActive = false,
   userRoles = [],
 }: PartOnGameBoardProps) {
@@ -222,13 +218,6 @@ export default function PartOnGameBoard({
       setGrabbingCursor(stage);
     }
 
-    // プレイモード時にカードまたはトークンがドラッグされたら最前面に移動
-    if (
-      gameBoardMode === GameBoardMode.PLAY &&
-      (part.type === 'card' || part.type === 'token')
-    ) {
-      onChangePartOrder('frontmost');
-    }
     onDragStart(e);
   };
 

--- a/frontend/src/features/prototype/components/organisms/GameBoard.tsx
+++ b/frontend/src/features/prototype/components/organisms/GameBoard.tsx
@@ -565,9 +565,6 @@ export default function GameBoard({
                   onDragMove={(e) => handlePartDragMove(e, part.id)}
                   onDragEnd={(e, partId) => handlePartDragEnd(e, partId)}
                   onContextMenu={(e) => handlePartContextMenu(e, part.id)}
-                  onChangePartOrder={(type) =>
-                    handleChangePartOrder(type, part.id)
-                  }
                 />
               );
             })}

--- a/frontend/src/features/prototype/hooks/usePartDragSystem.ts
+++ b/frontend/src/features/prototype/hooks/usePartDragSystem.ts
@@ -79,6 +79,21 @@ export const usePartDragSystem = ({
         : [partId];
       selectMultipleParts(newSelected);
 
+      // プレイモード時の単一選択カード/トークンのfrontmost処理
+      // 複数選択時はfrontmost処理をスキップ
+      if (gameBoardMode === GameBoardMode.PLAY && newSelected.length === 1) {
+        const draggedPart = parts.find((pt) => pt.id === partId);
+        if (
+          draggedPart &&
+          (draggedPart.type === 'card' || draggedPart.type === 'token')
+        ) {
+          dispatch({
+            type: 'CHANGE_ORDER',
+            payload: { partId, type: 'frontmost' },
+          });
+        }
+      }
+
       // 元位置の記録
       /**
        * NOTE: reduceだと手続き的な書き方にはならないが、計算量がO(n2)になるので、
@@ -93,7 +108,7 @@ export const usePartDragSystem = ({
       });
       originalPositionsRef.current = newOriginalPositions;
     },
-    [gameBoardMode, selectedPartIds, selectMultipleParts, parts]
+    [gameBoardMode, selectedPartIds, selectMultipleParts, parts, dispatch]
   );
 
   /**


### PR DESCRIPTION
# 事前確認(共通)

- [x] PR 前に動作確認をしたか
- [x] 機密情報を含んでいないか

# やったこと<!-- このプルリクエストでやったことを書く -->

This pull request refactors how parts (such as cards and tokens) are moved to the frontmost layer during drag operations in play mode. The logic for changing the part order has been moved from the `PartOnGameBoard` component to the `usePartDragSystem` hook, resulting in a cleaner separation of concerns and improved maintainability.

**Refactoring of part order logic:**

* Removed the `onChangePartOrder` prop and related usage from the `PartOnGameBoard` component, simplifying its interface and responsibilities. [[1]](diffhunk://#diff-b7dd8bee92d30bb9c0fa6eab349f97f09d27f5e6f2d2b81488ae8bf110cdddd1L38-L40) [[2]](diffhunk://#diff-b7dd8bee92d30bb9c0fa6eab349f97f09d27f5e6f2d2b81488ae8bf110cdddd1L61) [[3]](diffhunk://#diff-b7dd8bee92d30bb9c0fa6eab349f97f09d27f5e6f2d2b81488ae8bf110cdddd1L225-L231) [[4]](diffhunk://#diff-c744a3a422bf8c68f3e3d51476160645ffd164a9fcc857182f844ff58c1def51L568-L570)
* Moved the logic for bringing a dragged card or token to the frontmost layer in play mode into the `usePartDragSystem` hook. This logic now only triggers for single selections, skipping the operation when multiple parts are selected.

**Hook dependency update:**

* Updated the dependency array of the `usePartDragSystem` hook to include `dispatch`, ensuring correct behavior when dispatch changes.

# やらないこと<!-- このプルリクエストでやってもおかしくないけどやらなかったことを書く -->

特になし

# 懸念点や注意点<!-- このプルリクエストにおける懸念点や注意点を書く -->

特になし

# その他<!-- このプルリクエストで上記の項目以外に伝えるべきことを書く -->

特になし


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * プレイモードでカードやトークンをドラッグ開始した際、該当パーツが正しく最前面に移動するよう改善されました。  
* **リファクタ**
  * 一部の不要なプロパティやロジックが削除され、内部処理が整理されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->