### PR TITLE
fix: adjust dimensions and colors for debug info display

### DIFF
--- a/frontend/src/features/prototype/components/molecules/PartOnGameBoard.tsx
+++ b/frontend/src/features/prototype/components/molecules/PartOnGameBoard.tsx
@@ -398,9 +398,9 @@ export default function PartOnGameBoard({
       {showDebugInfo && (
         <Group x={5} y={5} listening={false}>
           <Rect
-            width={85}
-            height={25}
-            fill="rgba(0, 0, 0, 0.7)"
+            width={90}
+            height={20}
+            fill="rgba(200, 200, 200, 0.8)"
             cornerRadius={4}
             perfectDrawEnabled={false}
             hitStrokeWidth={0}
@@ -408,8 +408,8 @@ export default function PartOnGameBoard({
           />
           <Text
             text={`ID:${part.id}\nO:${typeof part.order === 'number' ? part.order : 'N/A'}`}
-            fontSize={10}
-            fill="white"
+            fontSize={7}
+            fill="black"
             width={85}
             align="left"
             x={5}


### PR DESCRIPTION
# 事前確認(共通)

- [x] PR 前に動作確認をしたか
- [x] 機密情報を含んでいないか

# やったこと<!-- このプルリクエストでやったことを書く -->

This pull request updates the debug info display in the `PartOnGameBoard` component to improve its appearance and readability. The changes mainly adjust the styling of the debug overlay.

UI/UX improvements to debug info overlay:

* Changed the debug info background rectangle to be slightly wider, shorter, and use a lighter, more opaque color (`fill="rgba(200, 200, 200, 0.8)"`, `width={90}`, `height={20}`) for better visibility.
* Updated the debug text to use a smaller font size and black color (`fontSize={7}`, `fill="black"`) to improve contrast and fit within the new rectangle size.

# やらないこと<!-- このプルリクエストでやってもおかしくないけどやらなかったことを書く -->

特になし

# 懸念点や注意点<!-- このプルリクエストにおける懸念点や注意点を書く -->

特になし

# その他<!-- このプルリクエストで上記の項目以外に伝えるべきことを書く -->

特になし
