### PR TITLE
chore: update workflow files to clarify execution conditions and improve comments

### DIFF
--- a/.github/workflows/backend-lint.yml
+++ b/.github/workflows/backend-lint.yml
@@ -1,20 +1,20 @@
 name: Backend Lint
 
+# このワークフローが実行される条件:
+# 1. developブランチをターゲットとするPR時（feature→backend PR）
+# 2. mainブランチをターゲットとするPR時（develop→main PR）
+# 
+# 開発フロー想定:
+# feature branch → develop (PR) → main (PR)
+# developへの直接pushは行わないため、pull_requestイベントのみで十分
 on:
-  push:
-    branches:
-      - main
-      - develop
-    paths:
-      - 'backend/**'
-      - '.github/workflows/backend-lint.yml'
   pull_request:
     branches:
-      - main
-      - develop
+      - develop  # developをターゲットとするPR時に実行（feature→develop PR）
+      - main     # mainブランチをターゲットとするPR時に実行（develop→main PR）
     paths:
-      - 'backend/**'
-      - '.github/workflows/backend-lint.yml'
+      - 'backend/**'  # バックエンドディレクトリ内のファイル変更時のみ
+      - '.github/workflows/backend-lint.yml'  # このワークフローファイル自体の変更時
 
 jobs:
   backend-lint:

--- a/.github/workflows/backend-lint.yml
+++ b/.github/workflows/backend-lint.yml
@@ -1,7 +1,7 @@
 name: Backend Lint
 
 # このワークフローが実行される条件:
-# 1. developブランチをターゲットとするPR時（feature→backend PR）
+# 1. developブランチをターゲットとするPR時（feature→develop PR）
 # 2. mainブランチをターゲットとするPR時（develop→main PR）
 # 
 # 開発フロー想定:

--- a/.github/workflows/create_develop_to_main.yml
+++ b/.github/workflows/create_develop_to_main.yml
@@ -23,13 +23,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Check if PR exists
         id: check_pr
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.PAT_GITHUB_TOKEN }}
           result-encoding: string
@@ -51,7 +51,7 @@ jobs:
 
       - name: Create Pull Request
         if: steps.check_pr.outputs.result == 'false'
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.PAT_GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/create_develop_to_main.yml
+++ b/.github/workflows/create_develop_to_main.yml
@@ -1,9 +1,14 @@
 name: Create develop to main PR
 
+# このワークフローが実行される条件:
+# 1. developブランチへのpush時に自動実行
+# 2. 手動実行（workflow_dispatch）も可能
+# 目的：developブランチの変更を自動的にmainブランチへのPRとして作成
+# 既存のPRがある場合は重複作成を防ぐロジックが組み込まれている
 on:
   push:
     branches:
-      - develop
+      - develop  # developブランチへのpush時に自動でPR作成
   workflow_dispatch: # Allow manual triggering for maintenance and debugging
 
 permissions:

--- a/.github/workflows/frontend-lint.yml
+++ b/.github/workflows/frontend-lint.yml
@@ -1,20 +1,20 @@
 name: Frontend Lint
 
+# このワークフローが実行される条件:
+# 1. developブランチをターゲットとするPR時（feature→develop PR）
+# 2. mainブランチをターゲットとするPR時（develop→main PR）
+# 
+# 開発フロー想定:
+# feature branch → develop (PR) → main (PR)
+# developへの直接pushは行わないため、pull_requestイベントのみで十分
 on:
-  push:
-    branches:
-      - main
-      - develop
-    paths:
-      - 'frontend/**'
-      - '.github/workflows/frontend-lint.yml'
   pull_request:
     branches:
-      - main
-      - develop
+      - develop  # developをターゲットとするPR時に実行（feature→develop PR）
+      - main     # mainブランチをターゲットとするPR時に実行（develop→main PR）
     paths:
-      - 'frontend/**'
-      - '.github/workflows/frontend-lint.yml'
+      - 'frontend/**'  # フロントエンドディレクトリ内のファイル変更時のみ
+      - '.github/workflows/frontend-lint.yml'  # このワークフローファイル自体の変更時
 
 jobs:
   frontend-lint:

--- a/.github/workflows/frontend-test.yml
+++ b/.github/workflows/frontend-test.yml
@@ -19,7 +19,7 @@ on:
 jobs:
   frontend-test:
     runs-on: ubuntu-latest
-    
+
     strategy:
       matrix:
         node-version: [20.x]

--- a/.github/workflows/frontend-test.yml
+++ b/.github/workflows/frontend-test.yml
@@ -1,20 +1,20 @@
 name: Frontend Test
 
+# このワークフローが実行される条件:
+# 1. developブランチをターゲットとするPR時（feature→develop PR）
+# 2. mainブランチをターゲットとするPR時（develop→main PR）
+# 
+# 開発フロー想定:
+# feature branch → develop (PR) → main (PR)
+# developへの直接pushは行わないため、pull_requestイベントのみで十分
 on:
-  push:
-    branches:
-      - main
-      - develop
-    paths:
-      - 'frontend/**'
-      - '.github/workflows/frontend-test.yml'
   pull_request:
     branches:
-      - main
-      - develop
+      - develop  # developをターゲットとするPR時に実行（feature→develop PR）
+      - main     # mainブランチをターゲットとするPR時に実行（develop→main PR）
     paths:
-      - 'frontend/**'
-      - '.github/workflows/frontend-test.yml'
+      - 'frontend/**'  # フロントエンドディレクトリ内のファイル変更時のみ
+      - '.github/workflows/frontend-test.yml'  # このワークフローファイル自体の変更時
 
 jobs:
   frontend-test:

--- a/.github/workflows/issue_notifications.yml
+++ b/.github/workflows/issue_notifications.yml
@@ -1,9 +1,14 @@
 # .github/workflows/issue_notifications.yml
 name: Issue Notifications
 
+# このワークフローが実行される条件:
+# GitHubのIssueに対する以下のアクション時に実行される
+# - opened: 新しいIssueが作成された時
+# - closed: Issueがクローズされた時
+# 目的：Issue の状態変更をDiscordに自動通知する
 on:
   issues:
-    types: [opened, closed]
+    types: [opened, closed]  # Issue作成時とクローズ時にDiscord通知
 
 permissions:
   issues: read


### PR DESCRIPTION


# 事前確認(共通)

~~- [ ] PR 前に動作確認をしたか~~
- [x] 機密情報を含んでいないか

# やったこと<!-- このプルリクエストでやったことを書く -->

This pull request updates several GitHub Actions workflow files to clarify and document their triggers and intended usage, as well as to simplify event conditions. The changes mainly add explanatory comments (in Japanese) and remove unnecessary push triggers, focusing workflows on the pull request or issue events that match the team's development flow.

**Workflow trigger and documentation improvements:**

* Added detailed comments explaining when each workflow should run, the intended development flow, and the reasoning for using specific GitHub Actions triggers in `.github/workflows/backend-lint.yml`, `.github/workflows/frontend-lint.yml`, `.github/workflows/frontend-test.yml`, `.github/workflows/create_develop_to_main.yml`, and `.github/workflows/issue_notifications.yml`. [[1]](diffhunk://#diff-d1836c9e27a56587a10191b9264d5c8e19cdfd0c22744eff951769083843a698R3-R17) [[2]](diffhunk://#diff-9d842324f08ec30f144896391dbc94cec01f7b351cb561d8611f7ae3925ad41eR3-R17) [[3]](diffhunk://#diff-d22169a7c6c731bec23b57f47d83133207cdcd0b496b8588ffb7eaf9f61a8aabR3-R17) [[4]](diffhunk://#diff-984e03cbd82640f75c2299a273576646c2097ce374a44c4ff5a6afd95e761fa9R3-R11) [[5]](diffhunk://#diff-945e7f1b5af8a1763c9b68be3def2b63cfbf0fa9551229ea16975eb222cf50b3R4-R11)

**Workflow event simplification and restriction:**

* Removed `push` triggers from the backend and frontend lint/test workflows, ensuring they only run on pull requests targeting `develop` or `main`, and restricted their path filters to relevant directories or workflow files. [[1]](diffhunk://#diff-d1836c9e27a56587a10191b9264d5c8e19cdfd0c22744eff951769083843a698R3-R17) [[2]](diffhunk://#diff-9d842324f08ec30f144896391dbc94cec01f7b351cb561d8611f7ae3925ad41eR3-R17) [[3]](diffhunk://#diff-d22169a7c6c731bec23b57f47d83133207cdcd0b496b8588ffb7eaf9f61a8aabR3-R17)
* Updated the PR creation workflow to clarify that it runs automatically on `develop` branch pushes and can be triggered manually, with comments explaining duplicate PR prevention logic.
* Clarified the issue notification workflow triggers, specifying that notifications are sent to Discord only when issues are opened or closed.

# やらないこと<!-- このプルリクエストでやってもおかしくないけどやらなかったことを書く -->

特になし

# 懸念点や注意点<!-- このプルリクエストにおける懸念点や注意点を書く -->

特になし

# その他<!-- このプルリクエストで上記の項目以外に伝えるべきことを書く -->

特になし


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added and updated comments (including Japanese explanations) in workflow files to clarify trigger conditions, development flow, and notification behavior.

* **Chores**
  * Adjusted workflow triggers to run only on pull requests targeting specific branches, removing direct push triggers for greater control and alignment with the intended development process. No changes to workflow logic or permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->