### PR TITLE
fix: update disconnect event logging to ensure error is logged on unexpected disconnections

### DIFF
--- a/frontend/src/features/prototype/hooks/__tests__/useSocketConnection.test.ts
+++ b/frontend/src/features/prototype/hooks/__tests__/useSocketConnection.test.ts
@@ -118,9 +118,7 @@ describe('useSocketConnection', () => {
       jest.clearAllMocks();
       consoleSpy.mockClear();
       disconnectCallback!('io client disconnect');
-      expect(consoleSpy).toHaveBeenCalledWith('Socket接続が切断されました:', {
-        reason: 'io client disconnect',
-      });
+      expect(consoleSpy).not.toHaveBeenCalled();
       expect(mockSocket.connect).not.toHaveBeenCalled();
     });
   });

--- a/frontend/src/features/prototype/hooks/useSocketConnection.ts
+++ b/frontend/src/features/prototype/hooks/useSocketConnection.ts
@@ -78,9 +78,9 @@ export const useSocketConnection = ({
 
     // 切断時の処理
     socket.on('disconnect', (reason) => {
-      console.error('Socket接続が切断されました:', { reason });
       // 予期しない切断の場合は再接続を試行
       if (reason === 'io server disconnect' || reason === 'transport error') {
+        console.error('Socket接続が切断されました:', { reason });
         socket.connect();
       }
     });


### PR DESCRIPTION
# 事前確認(共通)

- [x] PR 前に動作確認をしたか
- [x] 機密情報を含んでいないか

# やったこと<!-- このプルリクエストでやったことを書く -->

This pull request updates the socket connection logic and its associated test to only log disconnect errors and attempt reconnection when the disconnect is unexpected. The main changes are:

**Socket disconnect handling:**

* Moved the `console.error` log statement in `useSocketConnection.ts` so it only logs when the disconnect reason is `'io server disconnect'` or `'transport error'`, and not for all disconnects.

**Test adjustments:**

* Updated the test in `useSocketConnection.test.ts` to expect that `console.error` is not called when the disconnect reason is `'io client disconnect'`, reflecting the new logic.

# やらないこと<!-- このプルリクエストでやってもおかしくないけどやらなかったことを書く -->

特になし

# 懸念点や注意点<!-- このプルリクエストにおける懸念点や注意点を書く -->

特になし

# その他<!-- このプルリクエストで上記の項目以外に伝えるべきことを書く -->

特になし
