### PR TITLE
feat(users): add optional limit parameter for user search results

### DIFF
--- a/backend/src/routes/user.ts
+++ b/backend/src/routes/user.ts
@@ -63,10 +63,16 @@ router.get(
     const { username } = req.query;
 
     try {
-      // 10件まで取得
+      // allow optional limit param (default to 100) to avoid truncating search results
+      const rawLimit = req.query.limit;
+      const parsedLimit = rawLimit ? parseInt(String(rawLimit), 10) : 100;
+      const limit =
+        Number.isFinite(parsedLimit) && parsedLimit > 0 ? parsedLimit : 100;
+
       const suggestedUsers = await UserModel.findAll({
         where: { username: { [Op.iLike]: `%${username}%` } },
-        limit: 10,
+        limit,
+        order: [['username', 'ASC']],
       });
 
       res.json(suggestedUsers);


### PR DESCRIPTION
# 事前確認(共通)

- [x] PR 前に動作確認をしたか
- [x] 機密情報を含んでいないか

# やったこと<!-- このプルリクエストでやったことを書く -->

This pull request updates the user suggestion endpoint to be more flexible and user-friendly. The main change is allowing clients to specify the maximum number of results returned, with a sensible default and improved ordering for consistency.

User search improvements:

* Added support for an optional `limit` query parameter to control the number of user suggestions returned; defaults to 100 if not specified or invalid.
* Results are now ordered alphabetically by `username` to provide predictable and user-friendly search results.

# やらないこと<!-- このプルリクエストでやってもおかしくないけどやらなかったことを書く -->

特になし

# 懸念点や注意点<!-- このプルリクエストにおける懸念点や注意点を書く -->

特になし

# その他<!-- このプルリクエストで上記の項目以外に伝えるべきことを書く -->

特になし
