### PR TITLE
feat(PartPropertyMenu): add clampToViewport functionality for draggable menu

### DIFF
--- a/frontend/src/features/prototype/components/molecules/PartPropertyMenu.tsx
+++ b/frontend/src/features/prototype/components/molecules/PartPropertyMenu.tsx
@@ -110,8 +110,38 @@ export default function PartPropertyMenu({
     }
   }, [currentProperty]);
 
-  const { containerRef, position, isDragging, handleDragStart } =
-    useDraggablePartPropertyMenu();
+  const {
+    containerRef,
+    position,
+    isDragging,
+    handleDragStart,
+    clampToViewport,
+  } = useDraggablePartPropertyMenu();
+
+  // メニューが表示されるとき、または選択中パーツが変更されたときにクランプする（マージ版）
+  const prevSelectedPartIdRef = useRef<number | undefined>(undefined);
+  const prevShowMenuRef = useRef<boolean | undefined>(undefined);
+  useEffect(() => {
+    // showMenu が false の場合は履歴だけ更新して終了
+    if (!showMenu) {
+      prevSelectedPartIdRef.current = selectedPartId;
+      prevShowMenuRef.current = showMenu;
+      return;
+    }
+
+    const becameVisible = prevShowMenuRef.current !== true;
+    const selectedChanged =
+      prevSelectedPartIdRef.current !== undefined &&
+      prevSelectedPartIdRef.current !== selectedPartId;
+
+    if (becameVisible || selectedChanged) {
+      clampToViewport();
+    }
+
+    prevSelectedPartIdRef.current = selectedPartId;
+    prevShowMenuRef.current = showMenu;
+  }, [selectedPartId, showMenu, clampToViewport]);
+
   /**
    * パーツを複製する
    */

--- a/frontend/src/features/prototype/constants/partPropertyMenu.ts
+++ b/frontend/src/features/prototype/constants/partPropertyMenu.ts
@@ -1,8 +1,8 @@
-// デフォルトのメニュー幅（Tailwind の w-[240px] 相当）
-export const DEFAULT_MENU_WIDTH = 240;
+// メニュー幅（Tailwind の w-[240px] 相当）
+export const PART_PROPERTY_MENU_WIDTH = 240;
 // デフォルトのメニュー上辺オフセット（tailwind top-20 -> 5rem -> 80px）
 export const DEFAULT_MENU_TOP = 80;
-// 右マージン（tailwind right-4 -> 1rem -> 16px）
+// デフォルトの右マージン（tailwind right-4 -> 1rem -> 16px）
 export const DEFAULT_RIGHT_OFFSET = 16;
 // デフォルトのメニュー高さ（オフセット計算のフォールバック）
 export const DEFAULT_MENU_HEIGHT = 200;

--- a/frontend/src/features/prototype/hooks/useDraggablePartPropertyMenu.ts
+++ b/frontend/src/features/prototype/hooks/useDraggablePartPropertyMenu.ts
@@ -140,11 +140,16 @@ export default function useDraggablePartPropertyMenu(): {
       const newX = startPosRef.current.x + dx;
       const newY = startPosRef.current.y + dy;
       const container = containerRef.current;
-      const maxX =
+      // ビューポートよりメニューが大きい場合にも上限を0以上にする
+      const maxX = Math.max(
+        0,
         window.innerWidth -
-        (container?.offsetWidth ?? PART_PROPERTY_MENU_WIDTH);
-      const maxY =
-        window.innerHeight - (container?.offsetHeight ?? DEFAULT_MENU_HEIGHT);
+          (container?.offsetWidth ?? PART_PROPERTY_MENU_WIDTH)
+      );
+      const maxY = Math.max(
+        0,
+        window.innerHeight - (container?.offsetHeight ?? DEFAULT_MENU_HEIGHT)
+      );
       setPosition({ x: clamp(newX, 0, maxX), y: clamp(newY, 0, maxY) });
     };
 

--- a/frontend/src/features/prototype/hooks/useDraggablePartPropertyMenu.ts
+++ b/frontend/src/features/prototype/hooks/useDraggablePartPropertyMenu.ts
@@ -7,7 +7,7 @@ import {
 } from 'react';
 
 import {
-  DEFAULT_MENU_WIDTH,
+  PART_PROPERTY_MENU_WIDTH,
   DEFAULT_MENU_TOP,
   DEFAULT_RIGHT_OFFSET,
   DEFAULT_MENU_HEIGHT,
@@ -32,6 +32,7 @@ export default function useDraggablePartPropertyMenu(): {
       | React.MouseEvent<HTMLDivElement, MouseEvent>
       | React.TouchEvent<HTMLDivElement>
   ) => void;
+  clampToViewport: () => void;
 } {
   const [position, setPosition] = useState<{ x: number; y: number } | null>(
     () => {
@@ -39,7 +40,7 @@ export default function useDraggablePartPropertyMenu(): {
       if (typeof window === 'undefined') return null;
       const left = Math.max(
         0,
-        window.innerWidth - DEFAULT_RIGHT_OFFSET - DEFAULT_MENU_WIDTH
+        window.innerWidth - DEFAULT_RIGHT_OFFSET - PART_PROPERTY_MENU_WIDTH
       );
       return { x: left, y: DEFAULT_MENU_TOP };
     }
@@ -58,6 +59,28 @@ export default function useDraggablePartPropertyMenu(): {
     (v: number, a: number, b: number) => Math.min(Math.max(v, a), b),
     []
   );
+
+  /** 外部から呼べるように、現在位置をビューポート内にクランプする関数を用意 */
+  const clampToViewport = useCallback(() => {
+    if (typeof window === 'undefined') return;
+    const container = containerRef.current;
+    const width = container?.offsetWidth ?? PART_PROPERTY_MENU_WIDTH;
+    const height = container?.offsetHeight ?? DEFAULT_MENU_HEIGHT;
+    const maxX = Math.max(0, window.innerWidth - width);
+    const maxY = Math.max(0, window.innerHeight - height);
+
+    setPosition((prev) => {
+      if (!prev) {
+        const left = Math.max(
+          0,
+          window.innerWidth - DEFAULT_RIGHT_OFFSET - width
+        );
+        const top = DEFAULT_MENU_TOP;
+        return { x: clamp(left, 0, maxX), y: clamp(top, 0, maxY) };
+      }
+      return { x: clamp(prev.x, 0, maxX), y: clamp(prev.y, 0, maxY) };
+    });
+  }, [clamp]);
 
   /** イベント（マウス or タッチ）からクライアント座標を取り出す */
   const getClientCoords = (
@@ -87,7 +110,7 @@ export default function useDraggablePartPropertyMenu(): {
         startPosRef.current = position;
       } else if (typeof window !== 'undefined') {
         const container = containerRef.current;
-        const width = container?.offsetWidth ?? DEFAULT_MENU_WIDTH;
+        const width = container?.offsetWidth ?? PART_PROPERTY_MENU_WIDTH;
         const left = Math.max(
           0,
           window.innerWidth - DEFAULT_RIGHT_OFFSET - width
@@ -118,7 +141,8 @@ export default function useDraggablePartPropertyMenu(): {
       const newY = startPosRef.current.y + dy;
       const container = containerRef.current;
       const maxX =
-        window.innerWidth - (container?.offsetWidth ?? DEFAULT_MENU_WIDTH);
+        window.innerWidth -
+        (container?.offsetWidth ?? PART_PROPERTY_MENU_WIDTH);
       const maxY =
         window.innerHeight - (container?.offsetHeight ?? DEFAULT_MENU_HEIGHT);
       setPosition({ x: clamp(newX, 0, maxX), y: clamp(newY, 0, maxY) });
@@ -152,7 +176,7 @@ export default function useDraggablePartPropertyMenu(): {
 
     const clampCurrentPosition = () => {
       const container = containerRef.current;
-      const width = container?.offsetWidth ?? DEFAULT_MENU_WIDTH;
+      const width = container?.offsetWidth ?? PART_PROPERTY_MENU_WIDTH;
       const height = container?.offsetHeight ?? DEFAULT_MENU_HEIGHT;
       const maxX = Math.max(0, window.innerWidth - width);
       const maxY = Math.max(0, window.innerHeight - height);
@@ -192,5 +216,11 @@ export default function useDraggablePartPropertyMenu(): {
     };
   }, [clamp]);
 
-  return { containerRef, position, isDragging, handleDragStart } as const;
+  return {
+    containerRef,
+    position,
+    isDragging,
+    handleDragStart,
+    clampToViewport,
+  } as const;
 }


### PR DESCRIPTION
# 事前確認(共通)

- [x] PR 前に動作確認をしたか
- [x] 機密情報を含んでいないか

# やったこと<!-- このプルリクエストでやったことを書く -->

This pull request improves the usability and robustness of the draggable part property menu in the prototype editor by ensuring the menu remains fully visible within the viewport, even after changes in selection or visibility. It also refactors constant naming for clarity and consistency.

**Enhancements to menu positioning and viewport clamping:**

* Added a `clampToViewport` function to `useDraggablePartPropertyMenu`, which ensures the menu stays within the visible area of the browser window. This function is called whenever the menu is shown or the selected part changes, preventing the menu from being rendered off-screen. [[1]](diffhunk://#diff-fd0ab6b271e6d42ca0606978e830c30cb1608ab9fc2ea5a3932bb021f1f283a9R63-R84) [[2]](diffhunk://#diff-493837f6db55365783d81332e241cf4ee54f6d1c1462503f2235358c25e0b67eL113-R144)
* Updated all references from `DEFAULT_MENU_WIDTH` to `PART_PROPERTY_MENU_WIDTH` for clarity and consistency in both the constants and hook logic. [[1]](diffhunk://#diff-fd0ab6b271e6d42ca0606978e830c30cb1608ab9fc2ea5a3932bb021f1f283a9L10-R10) [[2]](diffhunk://#diff-fd0ab6b271e6d42ca0606978e830c30cb1608ab9fc2ea5a3932bb021f1f283a9L90-R113) [[3]](diffhunk://#diff-fd0ab6b271e6d42ca0606978e830c30cb1608ab9fc2ea5a3932bb021f1f283a9L155-R184) [[4]](diffhunk://#diff-fd0ab6b271e6d42ca0606978e830c30cb1608ab9fc2ea5a3932bb021f1f283a9L120-R152) [[5]](diffhunk://#diff-f0750a1cd696edf41dff0908d54830d052e2921933e9f08ff8b8061d0a3c974fL1-R5)
* Refactored the constants in `partPropertyMenu.ts` for improved naming and documentation, clarifying the purpose of each value used in menu positioning.

**API improvements:**

* Exposed the `clampToViewport` function from the hook so it can be called externally, supporting responsive menu repositioning when relevant UI changes occur. [[1]](diffhunk://#diff-fd0ab6b271e6d42ca0606978e830c30cb1608ab9fc2ea5a3932bb021f1f283a9R35-R43) [[2]](diffhunk://#diff-fd0ab6b271e6d42ca0606978e830c30cb1608ab9fc2ea5a3932bb021f1f283a9L195-R230)

These changes collectively ensure a better user experience by preventing the draggable menu from appearing off-screen and making the codebase easier to maintain.

# やらないこと<!-- このプルリクエストでやってもおかしくないけどやらなかったことを書く -->

特になし

# 懸念点や注意点<!-- このプルリクエストにおける懸念点や注意点を書く -->

特になし

# その他<!-- このプルリクエストで上記の項目以外に伝えるべきことを書く -->

特になし


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Part Property Menu now auto-adjusts to stay within the visible area when it appears or when the selected part changes, preventing off-screen placement.
  - Dragging behavior more consistently respects viewport bounds.
  - Improved initial positioning to keep the menu accessible on smaller screens.

- Refactor
  - Internal naming alignment for a menu width constant; no user-facing impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->