### PR TITLE
feat(GameBoard): integrate usePartContextMenu hook for context menu management

### DIFF
--- a/frontend/src/features/prototype/hooks/usePartContextMenu.ts
+++ b/frontend/src/features/prototype/hooks/usePartContextMenu.ts
@@ -1,0 +1,150 @@
+import Konva from 'konva';
+import React, { useCallback, useState } from 'react';
+
+import { ContextMenuItem } from '@/features/prototype/types/contextMenu';
+import { Position } from '@/features/prototype/types/gameBoard';
+import {
+  ChangeOrderType,
+  PartDispatch,
+} from '@/features/prototype/types/socket';
+
+/**
+ * Hook に渡すパラメータ
+ */
+type UsePartContextMenuParams = {
+  stageRef: React.RefObject<Konva.Stage | null>;
+  dispatch: PartDispatch;
+};
+
+/**
+ * Hook が返す値の型
+ */
+type UsePartContextMenuReturn = {
+  showContextMenu: boolean;
+  menuPosition: Position;
+  contextMenuPartId: number | null;
+  handlePartContextMenu: (
+    e: Konva.KonvaEventObject<PointerEvent>,
+    partId: number
+  ) => void;
+  handleCloseContextMenu: () => void;
+  handleStageClickFromHook: (e: Konva.KonvaEventObject<MouseEvent>) => void;
+  getContextMenuItems: (partId: number) => ContextMenuItem[];
+};
+
+/**
+ * Konva の Stage と連携して、パーツのコンテキストメニューの表示制御を行う Hook
+ *
+ * @param params.stageRef Konva.Stage の ref
+ * @param params.dispatch コンテキストメニューからのアクションを dispatch する関数（任意）
+ * @returns 表示制御用のハンドラや状態
+ */
+export function usePartContextMenu({
+  stageRef,
+  dispatch,
+}: UsePartContextMenuParams): UsePartContextMenuReturn {
+  const [showContextMenu, setVisible] = useState(false);
+  const [menuPosition, setPosition] = useState<Position>({ x: 0, y: 0 });
+  const [contextMenuPartId, setActivePartId] = useState<number | null>(null);
+
+  const handlePartContextMenu = useCallback(
+    (e: Konva.KonvaEventObject<PointerEvent>, partId: number) => {
+      // Konva のクリック伝播を止め、ブラウザのデフォルトコンテキストメニューを抑止する
+      e.cancelBubble = true;
+      try {
+        // evt が存在しないケースがあるため保護
+        e.evt.preventDefault();
+      } catch (err) {
+        // evt が無い、または preventDefault に失敗した場合は無視する
+      }
+
+      // ステージからマウス位置を取得してメニュー位置を設定
+      const stage = stageRef?.current;
+      if (stage) {
+        const pointerPosition = stage.getPointerPosition();
+        if (pointerPosition) {
+          // メニューが要素と被らないように少しオフセットする
+          setPosition({ x: pointerPosition.x + 5, y: pointerPosition.y + 5 });
+        }
+      }
+
+      setActivePartId(partId);
+      setVisible(true);
+    },
+    [stageRef]
+  );
+
+  const handleCloseContextMenu = useCallback(() => {
+    setVisible(false);
+    setActivePartId(null);
+  }, []);
+
+  /**
+   * コンテキストメニューの項目を生成して返す
+   * @param partId 対象のパーツID
+   */
+
+  const getContextMenuItems = useCallback(
+    (partId: number): ContextMenuItem[] => {
+      const changeOrder = (type: ChangeOrderType) => {
+        dispatch({ type: 'CHANGE_ORDER', payload: { partId, type } });
+        handleCloseContextMenu();
+      };
+
+      return [
+        {
+          id: 'frontmost',
+          text: '最前面に移動',
+          action: () => {
+            changeOrder('frontmost');
+          },
+        },
+        {
+          id: 'front',
+          text: '前面に移動',
+          action: () => {
+            changeOrder('front');
+          },
+        },
+        {
+          id: 'back',
+          text: '背面に移動',
+          action: () => {
+            changeOrder('back');
+          },
+        },
+        {
+          id: 'backmost',
+          text: '最背面に移動',
+          action: () => {
+            changeOrder('backmost');
+          },
+        },
+      ];
+    },
+    [handleCloseContextMenu, dispatch]
+  );
+
+  const handleStageClickFromHook = useCallback(
+    (e: Konva.KonvaEventObject<MouseEvent>) => {
+      // クリック対象がコンテキストメニュー本体でない場合は閉じる
+      if (showContextMenu) {
+        // クリック対象がコンテキストメニュー本体でない場合は閉じる
+        if (!e.target.hasName('context-menu-component')) {
+          handleCloseContextMenu();
+        }
+      }
+    },
+    [showContextMenu, handleCloseContextMenu]
+  );
+
+  return {
+    showContextMenu,
+    menuPosition,
+    contextMenuPartId,
+    handlePartContextMenu,
+    handleCloseContextMenu,
+    handleStageClickFromHook,
+    getContextMenuItems,
+  };
+}

--- a/frontend/src/features/prototype/hooks/usePartReducer.ts
+++ b/frontend/src/features/prototype/hooks/usePartReducer.ts
@@ -3,64 +3,20 @@
  */
 import { useCallback } from 'react';
 
-import { Part, PartProperty } from '@/api/types';
 import { useSocket } from '@/features/prototype/contexts/SocketContext';
 import { usePerformanceTracker } from '@/features/prototype/hooks/usePerformanceTracker';
-import { PartPropertyUpdate } from '@/features/prototype/types';
+import { PartDispatch } from '@/features/prototype/types/socket';
 
-// パーツのプロパティの型定義(metadataを除いた型)
-type PartPropertiesWithoutMetadata = Omit<
-  PartProperty,
-  'partId' | 'createdAt' | 'updatedAt'
->;
+export type PartReducer = {
+  dispatch: PartDispatch;
+};
 
-// アクションの型定義
-export type PartAction =
-  // パーツの追加
-  | {
-      type: 'ADD_PART';
-      payload: {
-        part: Omit<
-          Part,
-          'id' | 'prototypeId' | 'order' | 'createdAt' | 'updatedAt'
-        >;
-        properties: PartPropertiesWithoutMetadata[];
-      };
-    }
-  // カードの裏返し
-  | {
-      type: 'FLIP_CARD';
-      payload: { cardId: number; nextFrontSide: 'front' | 'back' };
-    }
-  // パーツの更新
-  | {
-      type: 'UPDATE_PART';
-      payload: {
-        partId: number;
-        updatePart?: Partial<Part>;
-        updateProperties?: Partial<PartPropertyUpdate>[];
-        frontSide?: 'front' | 'back';
-      };
-    }
-  // パーツの削除
-  | { type: 'DELETE_PART'; payload: { partId: number } }
-  // パーツの順番の変更
-  | {
-      type: 'CHANGE_ORDER';
-      payload: {
-        partId: number;
-        type: 'front' | 'back' | 'backmost' | 'frontmost';
-      };
-    }
-  // デッキのシャッフル
-  | { type: 'SHUFFLE_DECK'; payload: { deckId: number } };
-
-export const usePartReducer = () => {
+export const usePartReducer = (): PartReducer => {
   const { socket } = useSocket();
   const { measureOperation } = usePerformanceTracker();
 
-  const dispatch = useCallback(
-    (action: PartAction) => {
+  const dispatch = useCallback<PartDispatch>(
+    (action) => {
       measureOperation('Part Operation', () => {
         switch (action.type) {
           // パーツの追加

--- a/frontend/src/features/prototype/types/contextMenu.ts
+++ b/frontend/src/features/prototype/types/contextMenu.ts
@@ -1,0 +1,8 @@
+/**
+ * コンテキストメニューの項目（UI側で実行されるアクションを保持）
+ */
+export type ContextMenuItem = {
+  id: string;
+  text: string;
+  action: () => void;
+};

--- a/frontend/src/features/prototype/types/gameBoard.ts
+++ b/frontend/src/features/prototype/types/gameBoard.ts
@@ -15,3 +15,8 @@ export enum GameBoardMode {
   /** プレイモード */
   PLAY = 'play',
 }
+
+export type Position = {
+  x: number;
+  y: number;
+};

--- a/frontend/src/features/prototype/types/socket.ts
+++ b/frontend/src/features/prototype/types/socket.ts
@@ -4,3 +4,83 @@ import { Part, PartProperty } from '@/api/types';
 export type PartsMap = Map<number, Part>;
 /** パーツのプロパティのマップ */
 export type PropertiesMap = Map<number, PartProperty[]>;
+
+/** パーツの Z 順を変更するためのアクション種別 */
+export type ChangeOrderType = 'front' | 'back' | 'frontmost' | 'backmost';
+
+/** CHANGE_ORDER のペイロード（ソケット送受信用） */
+export type ChangeOrderPayload = { partId: number; type: ChangeOrderType };
+
+/** パーツ追加のペイロード（ソケット送受信用） */
+export type AddPartPayload = {
+  part: Omit<Part, 'id' | 'prototypeId' | 'order' | 'createdAt' | 'updatedAt'>;
+  properties: Omit<PartProperty, 'partId' | 'createdAt' | 'updatedAt'>[];
+};
+
+/** カードの裏返し（ソケット送受信用） */
+export type FlipCardPayload = {
+  cardId: number;
+  nextFrontSide: 'front' | 'back';
+};
+
+/** パーツ更新のペイロード（ソケット送受信用） */
+export type UpdatePartPayload = {
+  partId: number;
+  updatePart?: Partial<Part>;
+  updateProperties?: Partial<PartProperty>[];
+  frontSide?: 'front' | 'back';
+};
+
+/** パーツ削除のペイロード（ソケット送受信用） */
+export type DeletePartPayload = { partId: number };
+
+/** デッキのシャッフル（ソケット送受信用） */
+export type ShuffleDeckPayload = { deckId: number };
+
+/** パーツ追加のアクション（ソケット送受信用） */
+export type AddPartAction = {
+  type: 'ADD_PART';
+  payload: AddPartPayload;
+};
+
+/** カードの裏返しのアクション（ソケット送受信用） */
+export type FlipCardAction = {
+  type: 'FLIP_CARD';
+  payload: FlipCardPayload;
+};
+
+/** パーツ更新のアクション（ソケット送受信用） */
+export type UpdatePartAction = {
+  type: 'UPDATE_PART';
+  payload: UpdatePartPayload;
+};
+
+/** パーツ削除のアクション（ソケット送受信用） */
+export type DeletePartAction = {
+  type: 'DELETE_PART';
+  payload: DeletePartPayload;
+};
+
+/** パーツの順番の変更のアクション（ソケット送受信用） */
+export type ChangeOrderAction = {
+  type: 'CHANGE_ORDER';
+  payload: ChangeOrderPayload;
+};
+
+/** デッキのシャッフルのアクション（ソケット送受信用） */
+export type ShuffleDeckAction = {
+  type: 'SHUFFLE_DECK';
+  payload: ShuffleDeckPayload;
+};
+
+/** PartAction: usePartReducer で使われるアクションの型（ソケット送受信用） */
+export type PartAction =
+  | AddPartAction
+  | FlipCardAction
+  | UpdatePartAction
+  | DeletePartAction
+  | ChangeOrderAction
+  | ShuffleDeckAction;
+
+/** dispatch 関数の型定義 */
+export type PartDispatch = (action: PartAction) => void;


### PR DESCRIPTION
# 事前確認(共通)

- [x] PR 前に動作確認をしたか
- [x] 機密情報を含んでいないか

# やったこと<!-- このプルリクエストでやったことを書く -->

This pull request refactors the context menu logic for parts on the game board by extracting it into a dedicated custom hook, improving modularity and maintainability. It also introduces new type definitions to clarify the structure of context menu items and socket actions, resulting in cleaner and more robust code.

**Context menu logic refactoring:**

* Extracted part context menu logic from `GameBoard.tsx` into a new custom hook `usePartContextMenu`, centralizing state and handlers for context menu visibility, position, and actions. (`frontend/src/features/prototype/components/organisms/GameBoard.tsx`, `frontend/src/features/prototype/hooks/usePartContextMenu.ts`) [[1]](diffhunk://#diff-c744a3a422bf8c68f3e3d51476160645ffd164a9fcc857182f844ff58c1def51L137-R149) [[2]](diffhunk://#diff-c744a3a422bf8c68f3e3d51476160645ffd164a9fcc857182f844ff58c1def51L165-L233) [[3]](diffhunk://#diff-2d2ec6125d28819e5603e3e25eb11dbeccf330d736696cdb298b45339a9dbf50R1-R150)
* Updated `GameBoard.tsx` to use the new hook, removing local state and handler definitions related to the context menu, and delegating context menu actions to the hook. (`frontend/src/features/prototype/components/organisms/GameBoard.tsx`) [[1]](diffhunk://#diff-c744a3a422bf8c68f3e3d51476160645ffd164a9fcc857182f844ff58c1def51L137-R149) [[2]](diffhunk://#diff-c744a3a422bf8c68f3e3d51476160645ffd164a9fcc857182f844ff58c1def51L165-L233) [[3]](diffhunk://#diff-c744a3a422bf8c68f3e3d51476160645ffd164a9fcc857182f844ff58c1def51L501-R443)

**Type and action definitions:**

* Added a new type `ContextMenuItem` to define context menu items with an id, display text, and action callback. (`frontend/src/features/prototype/types/contextMenu.ts`)
* Added a reusable `Position` type for representing x/y coordinates. (`frontend/src/features/prototype/types/gameBoard.ts`)
* Refactored and expanded socket action types, including `PartAction`, `PartDispatch`, and payload types for various actions, making the reducer and dispatch logic more type-safe and explicit. (`frontend/src/features/prototype/types/socket.ts`, `frontend/src/features/prototype/hooks/usePartReducer.ts`) [[1]](diffhunk://#diff-e24bebb6084503709ba15d1ebd1908a8770b3c26d20e8f599a13ec0b145f715eR7-R86) [[2]](diffhunk://#diff-a858bb3d1874c9b190d3d1b98d0696efe807a2c96b7b426f358288ff6bde9909L6-R19)

# やらないこと<!-- このプルリクエストでやってもおかしくないけどやらなかったことを書く -->

特になし

# 懸念点や注意点<!-- このプルリクエストにおける懸念点や注意点を書く -->

特になし

# その他<!-- このプルリクエストで上記の項目以外に伝えるべきことを書く -->

特になし


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Adds a context menu on game board parts to change stacking order (move to front/frontmost/back/backmost), with localized Japanese labels.
- Bug Fixes
  - Context menu now closes reliably when clicking on the stage or outside the menu.
  - Prevents the browser’s default context menu from appearing on right‑click.
- Refactor
  - Streamlined context‑menu logic into a dedicated module for improved reliability and maintainability without altering existing workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->