### PR TITLE
Use overlap detection for hand-card visibility

### DIFF
--- a/frontend/src/features/prototype/hooks/useHandVisibility.ts
+++ b/frontend/src/features/prototype/hooks/useHandVisibility.ts
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 
 import { Part } from '@/api/types';
 import { GameBoardMode } from '@/features/prototype/types';
+import { isRectOverlap } from '@/features/prototype/utils/overlap';
 import { useUser } from '@/hooks/useUser';
 
 // グリッドセルのサイズ（ピクセル）
@@ -72,20 +73,23 @@ class GridManager {
   }
 
   /**
-   * カードが手札の上にあるかチェック（グリッド最適化版）
+   * カードが手札と少しでも重なっているかチェック（グリッド最適化版）
    */
   isCardOnHand(card: Part, hand: Part): boolean {
-    // カードの中心座標
-    const cardCenterX = card.position.x + card.width / 2;
-    const cardCenterY = card.position.y + card.height / 2;
+    const cardRect = {
+      x: card.position.x,
+      y: card.position.y,
+      width: card.width,
+      height: card.height,
+    };
+    const handRect = {
+      x: hand.position.x,
+      y: hand.position.y,
+      width: hand.width,
+      height: hand.height,
+    };
 
-    // 手札の範囲内にあるかチェック
-    return (
-      hand.position.x <= cardCenterX &&
-      cardCenterX <= hand.position.x + hand.width &&
-      hand.position.y <= cardCenterY &&
-      cardCenterY <= hand.position.y + hand.height
-    );
+    return isRectOverlap(cardRect, handRect);
   }
 
   /**


### PR DESCRIPTION
## Summary
- show a card's back when it overlaps any part of a hand by using rectangle overlap instead of center check

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ad0245266883268f94e8a72f0087c4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of when a card is considered “in hand,” now recognizing partial overlaps near edges.
  * Reduces cases where cards at the boundary were incorrectly ignored or counted, leading to more consistent hand visibility.
  * No changes to settings or controls; behavior is more accurate without user action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->