### PR TITLE
Fix selection rectangle not updating over parts

### DIFF
--- a/frontend/src/features/prototype/components/organisms/GameBoard.tsx
+++ b/frontend/src/features/prototype/components/organisms/GameBoard.tsx
@@ -494,7 +494,22 @@ export default function GameBoard({
         onWheel={handleWheel}
         onClick={handleStageClick}
         onContextMenu={handleCloseContextMenu}
-        {...grabbingHandlers}
+        // パーツ上でもドラッグを検知できるよう Stage にハンドラを設定
+        onMouseMove={(e: Konva.KonvaEventObject<MouseEvent>) =>
+          handleSelectionMove(e, camera)
+        }
+        onPointerMove={(e: Konva.KonvaEventObject<PointerEvent>) =>
+          handleSelectionMove(e, camera)
+        }
+        onMouseUp={(e: Konva.KonvaEventObject<MouseEvent>) => {
+          handleSelectionEnd(e);
+          grabbingHandlers.onMouseUp?.();
+        }}
+        onPointerUp={(e: Konva.KonvaEventObject<PointerEvent>) =>
+          handleSelectionEnd(e)
+        }
+        onMouseDown={grabbingHandlers.onMouseDown}
+        onMouseLeave={grabbingHandlers.onMouseLeave}
         style={{
           cursor: cursorStyle,
         }}
@@ -518,15 +533,13 @@ export default function GameBoard({
               onDragMove={handleDragMove}
               onClick={handleBackgroundClick}
               hitStrokeWidth={0}
-              // 矩形選択用イベントを背景Rectに直接バインド
+              // 矩形選択の開始のみ背景Rectで検知する
               {...(isSelectionMode
                 ? {
                     onMouseDown: (e: Konva.KonvaEventObject<MouseEvent>) =>
                       handleSelectionStart(e, camera),
-                    onMouseMove: (e: Konva.KonvaEventObject<MouseEvent>) =>
-                      handleSelectionMove(e, camera),
-                    onMouseUp: (e: Konva.KonvaEventObject<MouseEvent>) =>
-                      handleSelectionEnd(e),
+                    onPointerDown: (e: Konva.KonvaEventObject<PointerEvent>) =>
+                      handleSelectionStart(e, camera),
                   }
                 : {})}
             />

--- a/frontend/src/features/prototype/components/organisms/GameBoard.tsx
+++ b/frontend/src/features/prototype/components/organisms/GameBoard.tsx
@@ -505,9 +505,10 @@ export default function GameBoard({
           handleSelectionEnd(e);
           grabbingHandlers.onMouseUp?.();
         }}
-        onPointerUp={(e: Konva.KonvaEventObject<PointerEvent>) =>
-          handleSelectionEnd(e)
-        }
+        onPointerUp={(e: Konva.KonvaEventObject<PointerEvent>) => {
+          handleSelectionEnd(e);
+          grabbingHandlers.onMouseUp?.();
+        }}
         onMouseDown={grabbingHandlers.onMouseDown}
         onMouseLeave={grabbingHandlers.onMouseLeave}
         style={{


### PR DESCRIPTION
## Summary
- ensure selection rectangle updates even when dragging across parts by binding drag handlers to Stage
- start rectangle selection only on background to avoid interference with parts

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad4d3c9d8083269abb56f3802e03e4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Selection and drag behave consistently across mouse, touch, and pen inputs.
  * Reduced missed or stuck selections when releasing after a drag.
  * Rectangle selection reliably starts from the background area via unified pointer handling.
  * Movement and completion of selection are now smoother and more consistent across the canvas.
  * Improved interaction responsiveness by consolidating input handling, reducing edge-case glitches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->