### PR TITLE
feat: show help panel for new users

### DIFF
--- a/frontend/src/api/endpoints/users.ts
+++ b/frontend/src/api/endpoints/users.ts
@@ -4,6 +4,7 @@ import {
   UsersSearchListParams,
   User,
   UsersUpdatePayload,
+  UsersNeedTutorialData,
 } from '@/api/types';
 
 export const usersService = {
@@ -27,6 +28,18 @@ export const usersService = {
     data: UsersUpdatePayload
   ): Promise<User> => {
     const response = await axiosInstance.put(`/api/users/${userId}`, data);
+    return response.data;
+  },
+
+  /**
+   * チュートリアル表示が必要かどうかを確認する
+   */
+  checkNeedTutorial: async (
+    userId: string
+  ): Promise<UsersNeedTutorialData> => {
+    const response = await axiosInstance.get(
+      `/api/users/${userId}/need-tutorial`
+    );
     return response.data;
   },
 };

--- a/frontend/src/api/hooks/useUsers.ts
+++ b/frontend/src/api/hooks/useUsers.ts
@@ -1,7 +1,11 @@
 import { useCallback } from 'react';
 
 import { usersService } from '@/api/endpoints/users';
-import { UsersSearchListParams, UsersUpdatePayload } from '@/api/types';
+import {
+  UsersSearchListParams,
+  UsersUpdatePayload,
+  UsersNeedTutorialData,
+} from '@/api/types';
 
 export const useUsers = () => {
   /**
@@ -21,8 +25,19 @@ export const useUsers = () => {
     []
   );
 
+  /**
+   * チュートリアル表示が必要かどうかを確認する
+   */
+  const checkNeedTutorial = useCallback(
+    async (userId: string): Promise<UsersNeedTutorialData> => {
+      return await usersService.checkNeedTutorial(userId);
+    },
+    []
+  );
+
   return {
     searchUsers,
     updateUser,
+    checkNeedTutorial,
   };
 };

--- a/frontend/src/api/types/User.ts
+++ b/frontend/src/api/types/User.ts
@@ -1,0 +1,4 @@
+export interface UsersNeedTutorialData {
+  needTutorial: boolean;
+}
+

--- a/frontend/src/api/types/index.ts
+++ b/frontend/src/api/types/index.ts
@@ -3,3 +3,4 @@ export * from './Api';
 export * from './Auth';
 export * from './data-contracts';
 export * from './http-client';
+export * from './User';

--- a/frontend/src/features/prototype/components/molecules/GameBoardHelpPanel.tsx
+++ b/frontend/src/features/prototype/components/molecules/GameBoardHelpPanel.tsx
@@ -14,8 +14,17 @@ import {
 } from '@/features/prototype/constants/helpInfo';
 import { isInputFieldFocused } from '@/utils/inputFocus';
 
-export default function GameBoardHelpPanel() {
-  const [isExpanded, setIsExpanded] = useState(false);
+interface GameBoardHelpPanelProps {
+  defaultExpanded?: boolean;
+}
+
+export default function GameBoardHelpPanel({
+  defaultExpanded = false,
+}: GameBoardHelpPanelProps) {
+  const [isExpanded, setIsExpanded] = useState(defaultExpanded);
+  useEffect(() => {
+    setIsExpanded(defaultExpanded);
+  }, [defaultExpanded]);
   const [activeTab, setActiveTab] = useState<
     'shortcuts' | 'parts' | 'operations'
   >('parts');


### PR DESCRIPTION
## Summary
- rename new-user check to `needTutorial` and expose `/api/users/{userId}/need-tutorial` endpoint
- open GameBoard help panel by default when `needTutorial` is true

## Testing
- `npm run lint` (backend)
- `npm test` (frontend)
- `npm run lint` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68af0ada63c08326ae4ae2322c15d1e4