### PR TITLE
feat: allow editing prototype name from sidebar

### DIFF
--- a/frontend/src/features/prototype/components/atoms/PrototypeNameEditor.tsx
+++ b/frontend/src/features/prototype/components/atoms/PrototypeNameEditor.tsx
@@ -6,8 +6,11 @@ import { usePrototypes } from '@/api/hooks/usePrototypes';
 import useInlineEdit from '@/hooks/useInlineEdit';
 
 interface PrototypeNameEditorProps {
+  /** プロトタイプID */
   prototypeId: string;
+  /** 表示用のプロトタイプ名 */
   name: string;
+  /** 名前更新完了時に親へ新しい名前を通知するコールバック */
   onUpdated: (newName: string) => void;
 }
 
@@ -34,11 +37,16 @@ export default function PrototypeNameEditor({
     // 変更がない場合は何もしない
     if (newName.trim() === name) return;
 
-    await updatePrototypeMutation.mutateAsync({
-      prototypeId,
-      data: { name: newName.trim() },
-    });
-    onUpdated(newName.trim());
+    try {
+      await updatePrototypeMutation.mutateAsync({
+        prototypeId,
+        data: { name: newName.trim() },
+      });
+      onUpdated(newName.trim());
+    } catch (e) {
+      alert('名前の更新に失敗しました。時間をおいて再度お試しください。');
+      throw e;
+    }
   };
 
   const validate = (value: string): string | null => {
@@ -77,4 +85,3 @@ export default function PrototypeNameEditor({
     </div>
   );
 }
-

--- a/frontend/src/features/prototype/components/atoms/PrototypeNameEditor.tsx
+++ b/frontend/src/features/prototype/components/atoms/PrototypeNameEditor.tsx
@@ -1,0 +1,80 @@
+'use client';
+
+import React from 'react';
+
+import { usePrototypes } from '@/api/hooks/usePrototypes';
+import useInlineEdit from '@/hooks/useInlineEdit';
+
+interface PrototypeNameEditorProps {
+  prototypeId: string;
+  name: string;
+  onUpdated: (newName: string) => void;
+}
+
+export default function PrototypeNameEditor({
+  prototypeId,
+  name,
+  onUpdated,
+}: PrototypeNameEditorProps) {
+  const { useUpdatePrototype } = usePrototypes();
+  const updatePrototypeMutation = useUpdatePrototype();
+  const {
+    editedValue,
+    setEditedValue,
+    isEditing,
+    startEditing,
+    handleKeyDown,
+    handleSubmit,
+    handleBlur,
+  } = useInlineEdit();
+
+  const isNameEditing = isEditing(prototypeId);
+
+  const handleComplete = async (newName: string) => {
+    // 変更がない場合は何もしない
+    if (newName.trim() === name) return;
+
+    await updatePrototypeMutation.mutateAsync({
+      prototypeId,
+      data: { name: newName.trim() },
+    });
+    onUpdated(newName.trim());
+  };
+
+  const validate = (value: string): string | null => {
+    if (!value.trim()) {
+      return 'プロトタイプ名を入力してください';
+    }
+    return null;
+  };
+
+  return (
+    <div className="w-full">
+      {isNameEditing ? (
+        <form
+          onSubmit={(e) => handleSubmit(e, handleComplete, validate)}
+          className="w-full"
+        >
+          <input
+            type="text"
+            value={editedValue}
+            onChange={(e) => setEditedValue(e.target.value)}
+            onBlur={() => handleBlur(handleComplete, validate)}
+            onKeyDown={(e) => handleKeyDown(e, handleComplete, validate)}
+            className="w-full text-wood-darkest font-medium bg-transparent border border-transparent rounded-md px-1 -mx-1 focus:outline-none focus:bg-white focus:border-header focus:shadow-sm transition-all text-xs"
+            autoFocus
+          />
+        </form>
+      ) : (
+        <h2
+          className="text-xs font-medium truncate text-wood-darkest cursor-pointer px-1 -mx-1 rounded-md hover:bg-wood-lightest transition-colors"
+          title={name}
+          onClick={() => startEditing(prototypeId, name)}
+        >
+          {name}
+        </h2>
+      )}
+    </div>
+  );
+}
+

--- a/frontend/src/features/prototype/components/molecules/LeftSidebar.tsx
+++ b/frontend/src/features/prototype/components/molecules/LeftSidebar.tsx
@@ -16,19 +16,26 @@ import { GameBoardMode } from '@/features/prototype/types';
 import { useUser } from '@/hooks/useUser';
 import formatDate from '@/utils/dateFormat';
 
+type LeftSidebarProps = {
+  /** プロトタイプ名（表示用） */
+  prototypeName: string;
+  /** プロトタイプID（編集やソケット同期に使用） */
+  prototypeId: string;
+  /** ゲームボードの現在モード */
+  gameBoardMode: GameBoardMode;
+  /** プロジェクトID（APIリクエスト等で使用） */
+  projectId: string;
+  /** プロトタイプ名変更を親コンポーネントへ通知するコールバック */
+  onPrototypeNameChange: (name: string) => void;
+};
+
 export default function LeftSidebar({
   prototypeName,
   prototypeId,
   gameBoardMode,
   projectId,
   onPrototypeNameChange,
-}: {
-  prototypeName: string;
-  prototypeId: string;
-  gameBoardMode: GameBoardMode;
-  projectId: string;
-  onPrototypeNameChange: (name: string) => void;
-}) {
+}: LeftSidebarProps) {
   const router = useRouter();
   const { user } = useUser();
   const { getProject, createPrototypeVersion, deletePrototypeVersion } =

--- a/frontend/src/features/prototype/components/molecules/LeftSidebar.tsx
+++ b/frontend/src/features/prototype/components/molecules/LeftSidebar.tsx
@@ -8,6 +8,7 @@ import { MdMeetingRoom, MdDelete } from 'react-icons/md';
 
 import { useProject } from '@/api/hooks/useProject';
 import { Prototype, ProjectsDetailData } from '@/api/types';
+import PrototypeNameEditor from '@/features/prototype/components/atoms/PrototypeNameEditor';
 import GameBoardHelpPanel from '@/features/prototype/components/molecules/GameBoardHelpPanel';
 import { MAX_DISPLAY_USERS } from '@/features/prototype/constants';
 import { useProjectSocket } from '@/features/prototype/hooks/useProjectSocket';
@@ -17,12 +18,16 @@ import formatDate from '@/utils/dateFormat';
 
 export default function LeftSidebar({
   prototypeName,
+  prototypeId,
   gameBoardMode,
   projectId,
+  onPrototypeNameChange,
 }: {
   prototypeName: string;
+  prototypeId: string;
   gameBoardMode: GameBoardMode;
   projectId: string;
+  onPrototypeNameChange: (name: string) => void;
 }) {
   const router = useRouter();
   const { user } = useUser();
@@ -148,6 +153,18 @@ export default function LeftSidebar({
     setIsLeftSidebarMinimized(!isLeftSidebarMinimized);
   };
 
+  // プロトタイプ名の更新完了時の処理
+  const handlePrototypeNameUpdated = (newName: string) => {
+    // プロトタイプリストを更新
+    updatePrototypes(
+      prototypes.map((p) =>
+        p.id === prototypeId ? { ...p, name: newName } : p
+      )
+    );
+    // 親コンポーネントに通知
+    onPrototypeNameChange(newName);
+  };
+
   // サイドバーのルームリスト部分のみを表示する
   const renderSidebarContent = () => {
     return (
@@ -258,12 +275,11 @@ export default function LeftSidebar({
           <IoArrowBack className="h-5 w-5 text-wood-dark hover:text-header transition-colors" />
         </button>
         <div className="flex items-center gap-1 flex-grow ml-1 min-w-0">
-          <h2
-            className="text-xs font-medium truncate text-wood-darkest"
-            title={prototypeName}
-          >
-            {prototypeName}
-          </h2>
+          <PrototypeNameEditor
+            prototypeId={prototypeId}
+            name={prototypeName}
+            onUpdated={handlePrototypeNameUpdated}
+          />
         </div>
         {/* ルームを開いている時は開閉ボタンを非表示 */}
         {gameBoardMode !== GameBoardMode.PLAY && (

--- a/frontend/src/features/prototype/components/organisms/GameBoard.tsx
+++ b/frontend/src/features/prototype/components/organisms/GameBoard.tsx
@@ -52,6 +52,7 @@ import { isInputFieldFocused } from '@/utils/inputFocus';
 
 interface GameBoardProps {
   prototypeName: string;
+  prototypeId: string;
   projectId: string;
   partsMap: Map<number, Part>;
   propertiesMap: Map<number, PartProperty[]>;
@@ -64,7 +65,8 @@ interface GameBoardProps {
 }
 
 export default function GameBoard({
-  prototypeName,
+  prototypeName: initialPrototypeName,
+  prototypeId,
   projectId,
   partsMap,
   propertiesMap,
@@ -72,6 +74,10 @@ export default function GameBoard({
   gameBoardMode,
   connectedUsers,
 }: GameBoardProps) {
+  const [prototypeName, setPrototypeName] = useState(initialPrototypeName);
+  useEffect(() => {
+    setPrototypeName(initialPrototypeName);
+  }, [initialPrototypeName]);
   const stageRef = useRef<Konva.Stage | null>(null);
   // 前回のレンダリング時の画像IDを保持するref
   const prevImageRef = useRef<string[]>([]);
@@ -596,8 +602,10 @@ export default function GameBoard({
 
       <LeftSidebar
         prototypeName={prototypeName}
+        prototypeId={prototypeId}
         gameBoardMode={gameBoardMode}
         projectId={projectId}
+        onPrototypeNameChange={setPrototypeName}
       />
 
       {/* ロールメニュー - CREATEモードとPLAYモードで表示 */}

--- a/frontend/src/features/prototype/components/organisms/SocketGameBoard.tsx
+++ b/frontend/src/features/prototype/components/organisms/SocketGameBoard.tsx
@@ -34,6 +34,7 @@ const SocketGameBoard: React.FC<SocketGameBoardProps> = ({
   return (
     <GameBoard
       prototypeName={prototypeName}
+      prototypeId={prototypeId}
       partsMap={partsMap}
       propertiesMap={propertiesMap}
       cursors={cursors}


### PR DESCRIPTION
## Summary
- make prototype name editable via new `PrototypeNameEditor` component
- update game board and socket wrapper to pass prototype id and handle name updates
- add hover highlight and pointer cursor to indicate the name is clickable when not editing

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af9612fba88326a912b58b1fbc44f1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Inline editing of prototype names directly in the sidebar with click-to-edit and immediate save.
  * Name changes propagate instantly across the board view without page refresh.
  * Validation prevents empty names and displays: 「プロトタイプ名を入力してください」.
  * State syncing keeps the displayed prototype name current across related views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->