### PR TITLE
fix: resolve backend lint warnings

### DIFF
--- a/backend/src/scripts/cleanUpUnusedImages.ts
+++ b/backend/src/scripts/cleanUpUnusedImages.ts
@@ -25,7 +25,7 @@ async function cleanUpUnusedImages() {
       await deleteImageFromS3(image.storagePath);
       await ImageModel.destroy({ where: { id: image.id } });
     } catch (error) {
-      console.error(`Failed to delete image ${image.id}`);
+      console.error(`Failed to delete image ${image.id}`, error);
     }
   }
 

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -7,7 +7,7 @@ import http from 'http';
 import cors from 'cors';
 import { Server, Socket } from 'socket.io';
 import type { DisconnectReason } from 'socket.io';
-import swaggerUi from 'swagger-ui-express';
+import swaggerUi, { type JsonObject } from 'swagger-ui-express';
 import swaggerJsdoc from 'swagger-jsdoc';
 import fs from 'fs';
 import pgSession from 'connect-pg-simple';
@@ -90,7 +90,11 @@ if (process.env.NODE_ENV === 'development') {
     JSON.stringify(swaggerSpec, null, 2)
   );
 
-  app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerSpec));
+  app.use(
+    '/api-docs',
+    swaggerUi.serve,
+    swaggerUi.setup(swaggerSpec as JsonObject)
+  );
 }
 
 // Socket.ioの設定

--- a/backend/src/services/imageDeleteService.ts
+++ b/backend/src/services/imageDeleteService.ts
@@ -26,7 +26,7 @@ export const deleteImageFromS3 = async (key: string): Promise<void> => {
     }
     // S3からの削除が成功した場合、何も返さない
     return;
-  } catch (error: any) {
+  } catch (error: unknown) {
     // AWS SDKのエラーをハンドリング
     handleAWSError(error);
   }

--- a/backend/src/services/imageFetchService.ts
+++ b/backend/src/services/imageFetchService.ts
@@ -26,7 +26,7 @@ export const fetchImageFromS3 = async (key: string): Promise<Readable> => {
     }
 
     return response.Body as Readable;
-  } catch (error: any) {
+  } catch (error: unknown) {
     // AWS SDKのエラーをハンドリング
     handleAWSError(error);
     throw error; // ここに到達することはないが、TypeScriptの型チェックを通すために必要

--- a/backend/src/services/imageUploadService.ts
+++ b/backend/src/services/imageUploadService.ts
@@ -67,7 +67,7 @@ export const uploadImageToS3 = async (
       contentType: mime,
       fileSize: file.size,
     };
-  } catch (error: any) {
+  } catch (error: unknown) {
     // AWS SDKのエラーをハンドリング
     handleAWSError(error);
     throw error; // ここに到達することはないが、TypeScriptの型チェックを通すために必要

--- a/backend/src/types/connect-pg-simple.d.ts
+++ b/backend/src/types/connect-pg-simple.d.ts
@@ -1,3 +1,7 @@
+import session from 'express-session';
+
 declare module 'connect-pg-simple' {
-  export default function connectPgSimple(session: typeof session): any;
+  export default function connectPgSimple(
+    session: typeof session
+  ): new (options: unknown) => session.Store;
 }

--- a/backend/src/types/sequelize-erd.d.ts
+++ b/backend/src/types/sequelize-erd.d.ts
@@ -1,6 +1,8 @@
+import { Sequelize } from 'sequelize';
+
 declare module 'sequelize-erd' {
-  export default function sequelizeErd(
-    source: any,
+  interface ErdOptions {
+    source: Sequelize;
     format?:
       | 'svg'
       | 'dot'
@@ -10,17 +12,19 @@ declare module 'sequelize-erd' {
       | 'ps'
       | 'ps2'
       | 'json'
-      | 'json0',
-    engine?: 'circo' | 'dot' | 'fdp' | 'neato' | 'osage' | 'twopi',
+      | 'json0';
+    engine?: 'circo' | 'dot' | 'fdp' | 'neato' | 'osage' | 'twopi';
     arrowShapes?: {
       BelongsToMany: ['crow', 'crow'];
       BelongsTo: ['inv', 'crow'];
       HasMany: ['crow', 'inv'];
       HasOne: ['dot', 'dot'];
-    },
-    arrowSize?: number,
-    lineWidth?: number,
-    color?: string,
-    include?: string[]
-  ): Promise<string>;
+    };
+    arrowSize?: number;
+    lineWidth?: number;
+    color?: string;
+    include?: string[];
+  }
+
+  export default function sequelizeErd(options: ErdOptions): Promise<string>;
 }

--- a/backend/src/types/swagger-jsdoc.d.ts
+++ b/backend/src/types/swagger-jsdoc.d.ts
@@ -1,4 +1,5 @@
 declare module 'swagger-jsdoc' {
-  const swaggerJSDoc: (options: any) => any;
+  // Minimal type definition for swagger-jsdoc to satisfy linting and compilation
+  const swaggerJSDoc: (options: unknown) => Record<string, unknown>;
   export default swaggerJSDoc;
 }

--- a/backend/src/utils/awsErrorHandler.ts
+++ b/backend/src/utils/awsErrorHandler.ts
@@ -10,8 +10,9 @@ import {
  * AWS SDKのエラーをハンドリングして適切なCustomErrorをスローする
  * @param error - AWS SDKがスローしたエラー
  */
-export const handleAWSError = (error: any): never => {
-  switch (error.name) {
+export const handleAWSError = (error: unknown): never => {
+  const { name, message } = error as { name?: string; message?: string };
+  switch (name) {
     case 'NoSuchKey':
       throw new NotFoundError('指定されたリソースが存在しません');
     case 'AccessDenied':
@@ -24,7 +25,7 @@ export const handleAWSError = (error: any): never => {
       throw new ServiceUnavailableError('S3サービスが一時的に利用できません');
     default:
       throw new InternalServerError(
-        `AWS処理中にエラーが発生しました: ${error.message}`
+        `AWS処理中にエラーが発生しました: ${message ?? '不明なエラー'}`
       );
   }
 };


### PR DESCRIPTION
## Summary
- improve AWS error handling and service catch clauses with `unknown` types
- tighten third-party module declarations and Swagger generation typing
- cast Swagger spec for `swagger-ui-express`

## Testing
- `npm run lint`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b17e3d67208326bc873f2b4c86de69