### PR TITLE
fix: prevent area movement during play-mode group drag

### DIFF
--- a/frontend/src/features/prototype/hooks/usePartDragSystem.ts
+++ b/frontend/src/features/prototype/hooks/usePartDragSystem.ts
@@ -159,7 +159,12 @@ export const usePartDragSystem = ({
           origPos: originalPositions[id],
           part: parts.find((p) => p.id === id),
         }))
-        .filter(({ node, origPos, part }) => node && origPos && part);
+        .filter(({ node, origPos, part }) => {
+          if (!(node && origPos && part)) return false;
+          if (gameBoardMode === GameBoardMode.PLAY && part.type === 'area')
+            return false;
+          return true;
+        });
 
       // ドラッグ中以外の他パーツの位置更新（各パーツごとに制約を適用）
       const otherPartsWithNewPosition = otherParts.map(
@@ -191,7 +196,7 @@ export const usePartDragSystem = ({
       // 更新処理の実行
       stage.batchDraw();
     },
-    [getConstrainedPosition, parts, selectedPartIds, stageRef]
+    [gameBoardMode, getConstrainedPosition, parts, selectedPartIds, stageRef]
   );
 
   /**
@@ -231,6 +236,7 @@ export const usePartDragSystem = ({
           const id = Number(idStr);
           const part = parts.find((p) => p.id === id);
           if (!part) return;
+          if (gameBoardMode === GameBoardMode.PLAY && part.type === 'area') return;
 
           // 各パーツごとに元の移動量で制約を適用
           const newPosition = getConstrainedPosition(

--- a/frontend/src/features/prototype/hooks/usePartDragSystem.ts
+++ b/frontend/src/features/prototype/hooks/usePartDragSystem.ts
@@ -145,10 +145,22 @@ export const usePartDragSystem = ({
         originalDy
       );
       // ドラッグ中のパーツの位置更新
-      e.target.position({
-        x: constrainedPos.x + offsetX,
-        y: constrainedPos.y,
-      });
+      // PLAYモードで複数選択かつ対象がareaの場合は移動させない
+      if (
+        gameBoardMode === GameBoardMode.PLAY &&
+        selectedPartIds.length > 1 &&
+        targetPart?.type === 'area'
+      ) {
+        e.target.position({
+          x: partOriginalPosition.x + offsetX,
+          y: partOriginalPosition.y,
+        });
+      } else {
+        e.target.position({
+          x: constrainedPos.x + offsetX,
+          y: constrainedPos.y,
+        });
+      }
 
       // ドラッグ中以外の他パーツ
       const otherParts = selectedPartIds
@@ -161,7 +173,12 @@ export const usePartDragSystem = ({
         }))
         .filter(({ node, origPos, part }) => {
           if (!(node && origPos && part)) return false;
-          if (gameBoardMode === GameBoardMode.PLAY && part.type === 'area')
+          // PLAYモードで複数選択時のみ area を除外
+          if (
+            gameBoardMode === GameBoardMode.PLAY &&
+            selectedPartIds.length > 1 &&
+            part.type === 'area'
+          )
             return false;
           return true;
         });


### PR DESCRIPTION
## Summary
- avoid moving `area` parts in play mode when multiple parts are dragged

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1a12f35ac8326987d3cd1dea9ab72

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Area-type parts no longer move or update when dragging in PLAY mode with multiple selections, preventing accidental repositioning.
  - Drag interactions now respond correctly when the board mode or selection changes, avoiding stale behavior after mode switches.

- Behavior
  - During multi-selection drags in PLAY mode, area parts remain anchored while other part types follow expected drag constraints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->