### PR TITLE
fix: clear selection when choosing hand in play mode

### DIFF
--- a/frontend/src/features/prototype/components/molecules/PlaySidebar.tsx
+++ b/frontend/src/features/prototype/components/molecules/PlaySidebar.tsx
@@ -8,6 +8,7 @@ import React, { useState, useMemo, useEffect } from 'react';
 import { GiPokerHand } from 'react-icons/gi';
 
 import { Part } from '@/api/types';
+import { useSelectedParts } from '@/features/prototype/contexts/SelectedPartsContext';
 import { usePartReducer } from '@/features/prototype/hooks/usePartReducer';
 import { useUser } from '@/hooks/useUser';
 
@@ -30,6 +31,7 @@ export default function PlaySidebar({
 }: PlaySidebarProps) {
   const { dispatch } = usePartReducer();
   const { user } = useUser();
+  const { clearSelection } = useSelectedParts();
 
   // 選択中の手札ID
   const [selectedHandId, setSelectedHandId] = useState<number | null>(null);
@@ -124,6 +126,7 @@ export default function PlaySidebar({
                     : 'border-gray-200 hover:border-gray-300'
                 }`}
                 onClick={() => {
+                  clearSelection();
                   setSelectedHandId(hand.id);
                   onSelectPart(hand.id);
                 }}


### PR DESCRIPTION
## Summary
- clear previous selected parts when choosing a hand from the play sidebar to prevent multiple selection

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b1a353c97c832685a08ff1c37b364d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Selecting a new hand now automatically clears any previous part selections, ensuring the sidebar reflects only the current choice.
  - Prevents outdated selections from influencing new actions, reducing confusion and accidental operations.
  - Users will notice that switching between hands resets highlights/choices immediately, providing a clean, predictable starting point for the next interaction and improving overall consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->