### PR TITLE
feat: enable turbopack in dev server

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -3,13 +3,6 @@ const nextConfig = {
   images: {
     domains: ['developers.google.com'],
   },
-  webpack: (config) => {
-    config.resolve.fallback = {
-      ...(config.resolve.fallback || {}),
-      canvas: false,
-    };
-    return config;
-  },
   devIndicators: false,
 };
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev --turbopack",
+    "dev": "next dev --turbo",
     "build": "next build",
     "start": "next start",
     "lint": "tsc --noEmit && eslint . --ext .ts,.tsx --ignore-path .eslintignore",


### PR DESCRIPTION
## Summary
- run frontend dev server with Turbopack
- remove custom webpack override incompatible with Turbopack

## Testing
- `npm run lint`
- `npm test`
- `npm run dev`


------
https://chatgpt.com/codex/tasks/task_e_68b1a17ada188326b912d481be4919e1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Chores
  * Updated development script to use the Turbo bundler for the Next.js dev server, targeting faster startup and more reliable local builds.
* Refactor
  * Simplified the Next.js configuration by removing an obsolete custom Webpack override, reducing maintenance overhead and potential bundling edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->