### PR TITLE
chore: update backend pre-commit behavior

### DIFF
--- a/backend/.husky/pre-commit
+++ b/backend/.husky/pre-commit
@@ -1,10 +1,11 @@
 #!/usr/bin/env bash
 
-cd backend
+# Run only when backend files are staged
+if ! git diff --cached --name-only | grep -q '^backend/'; then
+  exit 0
+fi
 
-# Auto-fix formatting and lint issues before generating artifacts
-npm run format
-npm run lint:fix
+cd backend
 
 # ERDとRedocを生成
 npm run generate-erd && npm run redoc && npm run generate-api-types

--- a/backend/.husky/pre-commit
+++ b/backend/.husky/pre-commit
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# Fail fast: exit on error, unset vars, and failed pipes
+set -euo pipefail
+
 # Run only when backend files are staged
 if ! git diff --cached --name-only | grep -q '^backend/'; then
   exit 0
@@ -31,5 +34,5 @@ for file in frontend/src/api/types/*; do
   fi
 done
 
-# 正常終了
-exit 0
+# Ensure a clean success status when reached (failures exit earlier)
+true


### PR DESCRIPTION
## Summary
- run backend pre-commit steps only when backend files are staged
- remove lint and format commands from backend pre-commit hook

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b1c92d9b7c8326a4e300b3f93770ea

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Streamlined pre-commit workflow to run backend generation only when relevant changes are staged.
  * Removed unnecessary prior steps to reduce overhead and improve reliability.
  * Continues generating docs, diagrams, and API artifacts when applicable.
  * Automatically stages newly generated documentation, diagrams, and API types with clear user messages.
  * Ensures consistent commits without changing user-facing functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->