### PR TITLE
refactor: extract part type icon component

### DIFF
--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -7,9 +7,7 @@
     "prettier"
   ],
   "plugins": ["import", "@typescript-eslint", "react"],
-  "ignorePatterns": [
-    "src/api/types/**/*"
-  ],
+  "ignorePatterns": ["src/api/types/**/*"],
   "rules": {
     "react/react-in-jsx-scope": "off",
     "react/prop-types": "off",

--- a/frontend/src/api/endpoints/users.ts
+++ b/frontend/src/api/endpoints/users.ts
@@ -34,9 +34,7 @@ export const usersService = {
   /**
    * チュートリアル表示が必要かどうかを確認する
    */
-  checkNeedTutorial: async (
-    userId: string
-  ): Promise<UsersNeedTutorialData> => {
+  checkNeedTutorial: async (userId: string): Promise<UsersNeedTutorialData> => {
     const response = await axiosInstance.get(
       `/api/users/${userId}/need-tutorial`
     );

--- a/frontend/src/api/hooks/useProject.ts
+++ b/frontend/src/api/hooks/useProject.ts
@@ -30,12 +30,15 @@ export const useProject = () => {
   /**
    * プロジェクト作成
    */
-  const createProject = useCallback(async (data: ProjectsCreatePayload) => {
-    const result = await projectService.createProject(data);
-    // 作成成功時にキャッシュを無効化して、戻ってきた時に最新データを取得
-    queryClient.invalidateQueries({ queryKey: ['projects'] });
-    return result;
-  }, [queryClient]);
+  const createProject = useCallback(
+    async (data: ProjectsCreatePayload) => {
+      const result = await projectService.createProject(data);
+      // 作成成功時にキャッシュを無効化して、戻ってきた時に最新データを取得
+      queryClient.invalidateQueries({ queryKey: ['projects'] });
+      return result;
+    },
+    [queryClient]
+  );
 
   /**
    * プロトタイプバージョン作成

--- a/frontend/src/api/hooks/usePrototypes.ts
+++ b/frontend/src/api/hooks/usePrototypes.ts
@@ -12,8 +12,13 @@ export const usePrototypes = () => {
    */
   const useUpdatePrototype = () => {
     return useMutation({
-      mutationFn: ({ prototypeId, data }: { prototypeId: string; data: PrototypesUpdatePayload }) =>
-        prototypesService.updatePrototype(prototypeId, data),
+      mutationFn: ({
+        prototypeId,
+        data,
+      }: {
+        prototypeId: string;
+        data: PrototypesUpdatePayload;
+      }) => prototypesService.updatePrototype(prototypeId, data),
       onSuccess: () => {
         // 成功時にプロジェクト一覧のキャッシュを無効化して再取得
         queryClient.invalidateQueries({ queryKey: ['projects'] });
@@ -27,8 +32,6 @@ export const usePrototypes = () => {
   const getPrototype = useCallback(async (prototypeId: string) => {
     return await prototypesService.getPrototype(prototypeId);
   }, []);
-
-
 
   /**
    * プロトタイプ削除

--- a/frontend/src/api/types/User.ts
+++ b/frontend/src/api/types/User.ts
@@ -1,4 +1,3 @@
 export interface UsersNeedTutorialData {
   needTutorial: boolean;
 }
-

--- a/frontend/src/features/prototype/components/atoms/DebugInfo.tsx
+++ b/frontend/src/features/prototype/components/atoms/DebugInfo.tsx
@@ -109,7 +109,6 @@ const DebugInfo: React.FC<DebugInfoProps> = ({
             </div>
             <div>Name: {prototypeName}</div>
             <div>Project ID: {projectId}</div>
-
           </div>
         );
 

--- a/frontend/src/features/prototype/components/atoms/KonvaPartContextMenu.tsx
+++ b/frontend/src/features/prototype/components/atoms/KonvaPartContextMenu.tsx
@@ -64,7 +64,9 @@ export const KonvaPartContextMenu: React.FC<KonvaPartContextMenuProps> = ({
   width = 120,
   itemHeight = 25,
 }) => {
-  const [hoveredMenuItem, setHoveredMenuItem] = useState<string | number | null>(null);
+  const [hoveredMenuItem, setHoveredMenuItem] = useState<
+    string | number | null
+  >(null);
 
   if (!visible) {
     return null;

--- a/frontend/src/features/prototype/components/atoms/PartPropertyMenuButton.tsx
+++ b/frontend/src/features/prototype/components/atoms/PartPropertyMenuButton.tsx
@@ -11,7 +11,12 @@ type Props = {
   onClick?: () => void;
 };
 
-const PartPropertyMenuButton = ({ text, icon, disabled = false, onClick }: Props) => {
+const PartPropertyMenuButton = ({
+  text,
+  icon,
+  disabled = false,
+  onClick,
+}: Props) => {
   return (
     <button
       className="flex items-center gap-2 rounded px-2 py-1 text-xs text-kibako-white bg-kibako-primary/30 hover:bg-kibako-primary"

--- a/frontend/src/features/prototype/components/atoms/PartTypeIcon.tsx
+++ b/frontend/src/features/prototype/components/atoms/PartTypeIcon.tsx
@@ -1,6 +1,11 @@
 import React from 'react';
 import { BiArea } from 'react-icons/bi';
-import { Gi3dMeeple, GiCard10Clubs, GiPokerHand, GiStoneBlock } from 'react-icons/gi';
+import {
+  Gi3dMeeple,
+  GiCard10Clubs,
+  GiPokerHand,
+  GiStoneBlock,
+} from 'react-icons/gi';
 
 import { Part } from '@/api/types';
 
@@ -18,9 +23,11 @@ export type PartTypeIconProps = {
  * パーツ種別に応じて対応するアイコンを返すコンポーネント
  * - 装飾目的の場合は ariaHidden を true にする
  */
-export default function PartTypeIcon(
-  { type, className, ariaHidden = true }: PartTypeIconProps
-): JSX.Element | null {
+export default function PartTypeIcon({
+  type,
+  className,
+  ariaHidden = true,
+}: PartTypeIconProps): React.ReactElement | null {
   switch (type) {
     case 'token':
       return <Gi3dMeeple className={className} aria-hidden={ariaHidden} />;

--- a/frontend/src/features/prototype/components/atoms/PartTypeIcon.tsx
+++ b/frontend/src/features/prototype/components/atoms/PartTypeIcon.tsx
@@ -4,23 +4,34 @@ import { Gi3dMeeple, GiCard10Clubs, GiPokerHand, GiStoneBlock } from 'react-icon
 
 import { Part } from '@/api/types';
 
+/** パーツ種別に応じたアイコンを表示するためのプロパティ */
 export type PartTypeIconProps = {
+  /** パーツの種類 */
   type: Part['type'];
+  /** アイコンに適用するクラス名 */
   className?: string;
+  /** アクセシビリティ: 装飾アイコンとして非表示にする場合に指定（既定: true） */
+  ariaHidden?: boolean;
 };
 
-export default function PartTypeIcon({ type, className }: PartTypeIconProps) {
+/**
+ * パーツ種別に応じて対応するアイコンを返すコンポーネント
+ * - 装飾目的の場合は ariaHidden を true にする
+ */
+export default function PartTypeIcon(
+  { type, className, ariaHidden = true }: PartTypeIconProps
+): JSX.Element | null {
   switch (type) {
     case 'token':
-      return <Gi3dMeeple className={className} />;
+      return <Gi3dMeeple className={className} aria-hidden={ariaHidden} />;
     case 'card':
-      return <GiCard10Clubs className={className} />;
+      return <GiCard10Clubs className={className} aria-hidden={ariaHidden} />;
     case 'hand':
-      return <GiPokerHand className={className} />;
+      return <GiPokerHand className={className} aria-hidden={ariaHidden} />;
     case 'deck':
-      return <GiStoneBlock className={className} />;
+      return <GiStoneBlock className={className} aria-hidden={ariaHidden} />;
     case 'area':
-      return <BiArea className={className} />;
+      return <BiArea className={className} aria-hidden={ariaHidden} />;
     default:
       return null;
   }

--- a/frontend/src/features/prototype/components/atoms/PartTypeIcon.tsx
+++ b/frontend/src/features/prototype/components/atoms/PartTypeIcon.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { BiArea } from 'react-icons/bi';
+import { Gi3dMeeple, GiCard10Clubs, GiPokerHand, GiStoneBlock } from 'react-icons/gi';
+
+import { Part } from '@/api/types';
+
+export type PartTypeIconProps = {
+  type: Part['type'];
+  className?: string;
+};
+
+export default function PartTypeIcon({ type, className }: PartTypeIconProps) {
+  switch (type) {
+    case 'token':
+      return <Gi3dMeeple className={className} />;
+    case 'card':
+      return <GiCard10Clubs className={className} />;
+    case 'hand':
+      return <GiPokerHand className={className} />;
+    case 'deck':
+      return <GiStoneBlock className={className} />;
+    case 'area':
+      return <BiArea className={className} />;
+    default:
+      return null;
+  }
+}

--- a/frontend/src/features/prototype/components/atoms/ProjectContextMenu.tsx
+++ b/frontend/src/features/prototype/components/atoms/ProjectContextMenu.tsx
@@ -93,9 +93,7 @@ export const ProjectContextMenu: React.FC<ProjectContextMenuProps> = ({
         <button
           key={item.id}
           className={`w-full px-4 text-left flex items-center gap-2 transition-colors ${
-            hoveredMenuItem === item.id
-              ? 'bg-gray-100'
-              : 'hover:bg-gray-100'
+            hoveredMenuItem === item.id ? 'bg-gray-100' : 'hover:bg-gray-100'
           } ${
             item.danger
               ? 'text-red-600 hover:text-red-700'
@@ -118,4 +116,4 @@ export const ProjectContextMenu: React.FC<ProjectContextMenuProps> = ({
       ))}
     </div>
   );
-}; 
+};

--- a/frontend/src/features/prototype/components/molecules/EmptyProjectState.tsx
+++ b/frontend/src/features/prototype/components/molecules/EmptyProjectState.tsx
@@ -48,4 +48,4 @@ export const EmptyProjectState: React.FC<EmptyProjectStateProps> = ({
       </button>
     </div>
   );
-}; 
+};

--- a/frontend/src/features/prototype/components/molecules/PartCreateMenu.tsx
+++ b/frontend/src/features/prototype/components/molecules/PartCreateMenu.tsx
@@ -5,6 +5,7 @@
 'use client';
 
 import { useState } from 'react';
+import type { ReactElement } from 'react';
 
 import { Part, PartProperty } from '@/api/types';
 import PartTypeIcon from '@/features/prototype/components/atoms/PartTypeIcon';
@@ -31,8 +32,10 @@ export default function PartCreateMenu({
   camera: { x: number; y: number; scale: number };
   viewportSize: { width: number; height: number };
   parts: Part[];
-}) {
-  const [creatingPartType, setCreatingPartType] = useState<string | null>(null);
+}): ReactElement {
+  const [creatingPartType, setCreatingPartType] = useState<Part['type'] | null>(
+    null
+  );
 
   /**
    * 新しいパーツを作成し、中央に配置して追加します。
@@ -245,6 +248,7 @@ export default function PartCreateMenu({
                 <PartTypeIcon
                   type={partType.type}
                   className="h-5 w-5 text-white"
+                  ariaHidden
                 />
               )}
               <div className="absolute -top-10 left-1/2 transform -translate-x-1/2 bg-header text-white text-xs px-2 py-1 rounded whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity duration-200 pointer-events-none">

--- a/frontend/src/features/prototype/components/molecules/PartCreateMenu.tsx
+++ b/frontend/src/features/prototype/components/molecules/PartCreateMenu.tsx
@@ -5,15 +5,9 @@
 'use client';
 
 import { useState } from 'react';
-import { BiArea } from 'react-icons/bi';
-import {
-  Gi3dMeeple,
-  GiCard10Clubs,
-  GiPokerHand,
-  GiStoneBlock,
-} from 'react-icons/gi';
 
 import { Part, PartProperty } from '@/api/types';
+import PartTypeIcon from '@/features/prototype/components/atoms/PartTypeIcon';
 import {
   PART_DEFAULT_CONFIG,
   GAME_BOARD_SIZE,
@@ -209,27 +203,22 @@ export default function PartCreateMenu({
     {
       type: 'token' as const,
       name: PART_DEFAULT_CONFIG.TOKEN.name,
-      icon: <Gi3dMeeple className="h-5 w-5 text-white" />,
     },
     {
       type: 'card' as const,
       name: PART_DEFAULT_CONFIG.CARD.name,
-      icon: <GiCard10Clubs className="h-5 w-5 text-white" />,
     },
     {
       type: 'hand' as const,
       name: PART_DEFAULT_CONFIG.HAND.name,
-      icon: <GiPokerHand className="h-5 w-5 text-white" />,
     },
     {
       type: 'deck' as const,
       name: PART_DEFAULT_CONFIG.DECK.name,
-      icon: <GiStoneBlock className="h-5 w-5 text-white" />,
     },
     {
       type: 'area' as const,
       name: PART_DEFAULT_CONFIG.AREA.name,
-      icon: <BiArea className="h-5 w-5 text-white" />,
     },
   ];
 
@@ -253,7 +242,10 @@ export default function PartCreateMenu({
               {creatingPartType === partType.type ? (
                 <div className="w-5 h-5 border-2 border-white border-t-transparent rounded-full animate-spin" />
               ) : (
-                partType.icon
+                <PartTypeIcon
+                  type={partType.type}
+                  className="h-5 w-5 text-white"
+                />
               )}
               <div className="absolute -top-10 left-1/2 transform -translate-x-1/2 bg-header text-white text-xs px-2 py-1 rounded whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity duration-200 pointer-events-none">
                 {creatingPartType === partType.type

--- a/frontend/src/features/prototype/components/molecules/PartPropertyMenu.tsx
+++ b/frontend/src/features/prototype/components/molecules/PartPropertyMenu.tsx
@@ -270,10 +270,7 @@ export default function PartPropertyMenu({
             onTouchStart={handleDragStart}
           >
             <div className="flex items-center select-none">
-              <PartTypeIcon
-                type={selectedPart.type}
-                className="h-4 w-4 mr-2"
-              />
+              <PartTypeIcon type={selectedPart.type} className="h-4 w-4 mr-2" />
               <span className="text-[12px] font-medium">プロパティ編集</span>
             </div>
             {/* fixed move icon at top-right of the header */}

--- a/frontend/src/features/prototype/components/molecules/PartPropertyMenu.tsx
+++ b/frontend/src/features/prototype/components/molecules/PartPropertyMenu.tsx
@@ -6,14 +6,7 @@
 
 import axios from 'axios';
 import React, { useState, useMemo, useEffect, useRef } from 'react';
-import { BiArea } from 'react-icons/bi';
 import { FaRegCopy, FaRegTrashAlt, FaImage, FaSpinner } from 'react-icons/fa';
-import {
-  Gi3dMeeple,
-  GiCard10Clubs,
-  GiPokerHand,
-  GiStoneBlock,
-} from 'react-icons/gi';
 import { IoMdMove } from 'react-icons/io';
 
 import { useImages } from '@/api/hooks/useImages';
@@ -22,6 +15,7 @@ import NumberInput from '@/components/atoms/NumberInput';
 import TextInput from '@/components/atoms/TextInput';
 import ColorPicker from '@/features/prototype/components/atoms/ColorPicker';
 import PartPropertyMenuButton from '@/features/prototype/components/atoms/PartPropertyMenuButton';
+import PartTypeIcon from '@/features/prototype/components/atoms/PartTypeIcon';
 import { COLORS } from '@/features/prototype/constants';
 import useDraggablePartPropertyMenu from '@/features/prototype/hooks/useDraggablePartPropertyMenu';
 import { usePartReducer } from '@/features/prototype/hooks/usePartReducer';
@@ -276,17 +270,10 @@ export default function PartPropertyMenu({
             onTouchStart={handleDragStart}
           >
             <div className="flex items-center select-none">
-              {selectedPart.type === 'card' ? (
-                <GiCard10Clubs className="h-4 w-4 mr-2" />
-              ) : selectedPart.type === 'token' ? (
-                <Gi3dMeeple className="h-4 w-4 mr-2" />
-              ) : selectedPart.type === 'hand' ? (
-                <GiPokerHand className="h-4 w-4 mr-2" />
-              ) : selectedPart.type === 'deck' ? (
-                <GiStoneBlock className="h-4 w-4 mr-2" />
-              ) : selectedPart.type === 'area' ? (
-                <BiArea className="h-4 w-4 mr-2" />
-              ) : null}
+              <PartTypeIcon
+                type={selectedPart.type}
+                className="h-4 w-4 mr-2"
+              />
               <span className="text-[12px] font-medium">プロパティ編集</span>
             </div>
             {/* fixed move icon at top-right of the header */}

--- a/frontend/src/features/prototype/components/molecules/PlaySidebar.tsx
+++ b/frontend/src/features/prototype/components/molecules/PlaySidebar.tsx
@@ -5,7 +5,7 @@
 'use client';
 
 import React, { useState, useMemo, useEffect } from 'react';
-import { GiPokerHand } from 'react-icons/gi';
+import PartTypeIcon from '@/features/prototype/components/atoms/PartTypeIcon';
 
 import { Part } from '@/api/types';
 import { useSelectedParts } from '@/features/prototype/contexts/SelectedPartsContext';
@@ -101,7 +101,7 @@ export default function PlaySidebar({
       {/* ヘッダー */}
       <div className="border-b border-wood-lightest/60 rounded-t-lg bg-gradient-to-r from-wood-light/30 to-wood-light/20 py-2 px-4">
         <div className="flex items-center">
-          <GiPokerHand className="h-4 w-4 text-wood-dark mr-2" />
+          <PartTypeIcon type="hand" className="h-4 w-4 text-wood-dark mr-2" ariaHidden />
           <span className="text-[12px] font-medium text-wood-darkest">
             Play モード設定
           </span>

--- a/frontend/src/features/prototype/components/molecules/PlaySidebar.tsx
+++ b/frontend/src/features/prototype/components/molecules/PlaySidebar.tsx
@@ -4,10 +4,10 @@
 
 'use client';
 
-import React, { useState, useMemo, useEffect } from 'react';
-import PartTypeIcon from '@/features/prototype/components/atoms/PartTypeIcon';
+import React, { useEffect, useMemo, useState } from 'react';
 
 import { Part } from '@/api/types';
+import PartTypeIcon from '@/features/prototype/components/atoms/PartTypeIcon';
 import { useSelectedParts } from '@/features/prototype/contexts/SelectedPartsContext';
 import { usePartReducer } from '@/features/prototype/hooks/usePartReducer';
 import { useUser } from '@/hooks/useUser';

--- a/frontend/src/features/prototype/constants/helpInfo.ts
+++ b/frontend/src/features/prototype/constants/helpInfo.ts
@@ -86,6 +86,7 @@ export const OPERATIONS_INFO: OperationInfo[] = [
   {
     id: 'drag-drop-other',
     operation: 'ドラッグ&ドロップ(パーツ以外)',
-    description: '矩形選択またはボードを移動する。左下でモードを切り替えられる。',
+    description:
+      '矩形選択またはボードを移動する。左下でモードを切り替えられる。',
   },
 ];

--- a/frontend/src/features/prototype/hooks/useDraggablePartPropertyMenu.ts
+++ b/frontend/src/features/prototype/hooks/useDraggablePartPropertyMenu.ts
@@ -143,8 +143,7 @@ export default function useDraggablePartPropertyMenu(): {
       // ビューポートよりメニューが大きい場合にも上限を0以上にする
       const maxX = Math.max(
         0,
-        window.innerWidth -
-          (container?.offsetWidth ?? PART_PROPERTY_MENU_WIDTH)
+        window.innerWidth - (container?.offsetWidth ?? PART_PROPERTY_MENU_WIDTH)
       );
       const maxY = Math.max(
         0,

--- a/frontend/src/features/top/components/contexts/GameBoardContext.tsx
+++ b/frontend/src/features/top/components/contexts/GameBoardContext.tsx
@@ -3,9 +3,8 @@
 import React, { createContext, useContext } from 'react';
 
 // ゲームボード要素の参照を共有するためのContext
-const GameBoardContext = createContext<React.RefObject<HTMLDivElement | null> | null>(
-  null
-);
+const GameBoardContext =
+  createContext<React.RefObject<HTMLDivElement | null> | null>(null);
 
 // 使いやすいようにカスタムフックを提供
 export const useGameBoard = () => useContext(GameBoardContext);

--- a/frontend/src/features/top/components/contexts/GamePieceContext.tsx
+++ b/frontend/src/features/top/components/contexts/GamePieceContext.tsx
@@ -9,7 +9,10 @@ import React, {
 } from 'react';
 
 // ゲームピース要素の参照を動的に管理するためのContext
-export type GamePieceRefMap = Map<string, React.RefObject<HTMLDivElement | null>>;
+export type GamePieceRefMap = Map<
+  string,
+  React.RefObject<HTMLDivElement | null>
+>;
 
 export interface GamePieceContextType {
   refs: GamePieceRefMap;

--- a/frontend/src/utils/db.ts
+++ b/frontend/src/utils/db.ts
@@ -136,7 +136,7 @@ export const deleteExpiredImagesFromIndexedDb = async (): Promise<void> => {
     );
 
     // 期限切れレコードのURLとキャッシュをクリーンアップ
-    const expiredIds = expiredRecords.map(record => record.id);
+    const expiredIds = expiredRecords.map((record) => record.id);
     revokeMultipleObjectURLsAndCleanCache(expiredIds);
 
     // IndexedDBからレコードを削除


### PR DESCRIPTION
## Summary
- extract part type icons into a shared `PartTypeIcon` component
- use `PartTypeIcon` in `PartCreateMenu` and `PartPropertyMenu`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2192c88b08326b4033e6028768f8e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Replaced scattered per-type icons with a single shared PartTypeIcon used across creation, property, and sidebar UIs.
- Style
  - Icons for part types (token, card, hand, deck, area) now render consistently with unified styling.
  - No behavioral changes to creation or editing flows.
- Accessibility
  - Icons default to aria-hidden for improved screen-reader behavior.
- Chores
  - Minor formatting/whitespace fixes across multiple frontend files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->