### PR TITLE
refactor: simplify Tailwind palette to core kibako colors

### DIFF
--- a/frontend/src/components/atoms/Button.tsx
+++ b/frontend/src/components/atoms/Button.tsx
@@ -4,7 +4,7 @@ import { twMerge } from 'tailwind-merge';
 
 interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   children: ReactNode;
-  variant?: 'primary' | 'accent' | 'outline';
+  variant?: 'primary' | 'outline';
   size?: 'sm' | 'md' | 'lg';
   type?: 'button' | 'submit' | 'reset';
   href?: string;
@@ -27,7 +27,6 @@ export default function Button({
 
   const variants = {
     primary: 'bg-kibako-primary text-kibako-white hover:bg-kibako-primary/80',
-    accent: 'bg-kibako-accent text-kibako-white hover:bg-kibako-accent/80',
     outline:
       'bg-transparent text-kibako-primary/70 hover:text-kibako-primary border border-kibako-primary/30 hover:border-kibako-primary/50',
   };

--- a/frontend/src/components/molecules/Login.tsx
+++ b/frontend/src/components/molecules/Login.tsx
@@ -49,7 +49,7 @@ function Login() {
         <div className="flex items-center justify-center gap-2 sm:gap-4 mt-8 sm:mt-12">
           <FaDice className="text-4xl sm:text-6xl text-kibako-primary/60 transform rotate-12" />
           <GiCardAceSpades className="text-4xl sm:text-6xl text-kibako-primary/60 transform -rotate-12" />
-          <GiWoodenCrate className="text-5xl sm:text-7xl drop-shadow-lg text-kibako-accent" />
+          <GiWoodenCrate className="text-5xl sm:text-7xl drop-shadow-lg text-kibako-secondary" />
           <GiPuzzle className="text-4xl sm:text-6xl text-kibako-primary/60 transform rotate-6" />
           <FaChessBoard className="text-4xl sm:text-6xl text-kibako-primary/60 transform -rotate-6" />
         </div>
@@ -57,7 +57,7 @@ function Login() {
         {/* 認証ボタン */}
         <div className="flex flex-col gap-4 items-center mt-12 sm:mt-16">
           <Button
-            variant="accent"
+            variant="primary"
             className="!px-6 !py-4 !text-lg"
             onClick={() => {
               window.location.href = `${process.env.NEXT_PUBLIC_API_URL}/auth/google`;

--- a/frontend/src/components/molecules/MaintenanceReloadButton.tsx
+++ b/frontend/src/components/molecules/MaintenanceReloadButton.tsx
@@ -43,7 +43,7 @@ const MaintenanceReloadButton: React.FC<MaintenanceReloadButtonProps> = ({
   };
 
   return (
-    <div className="mt-6 pt-4 border-t border-wood-light">
+    <div className="mt-6 pt-4 border-t border-kibako-secondary">
       <button
         onClick={handleReload}
         className="text-kibako-accent hover:text-kibako-primary text-sm transition-colors duration-200 font-medium"

--- a/frontend/src/components/molecules/MaintenanceReloadButton.tsx
+++ b/frontend/src/components/molecules/MaintenanceReloadButton.tsx
@@ -46,7 +46,7 @@ const MaintenanceReloadButton: React.FC<MaintenanceReloadButtonProps> = ({
     <div className="mt-6 pt-4 border-t border-kibako-secondary">
       <button
         onClick={handleReload}
-        className="text-kibako-accent hover:text-kibako-primary text-sm transition-colors duration-200 font-medium"
+        className="text-kibako-secondary hover:text-kibako-primary text-sm transition-colors duration-200 font-medium"
       >
         ページを再読み込み
       </button>

--- a/frontend/src/components/organisms/Loading.tsx
+++ b/frontend/src/components/organisms/Loading.tsx
@@ -10,7 +10,7 @@ export default function Loading() {
       className={`flex items-center justify-center ${isGameBoardPath ? 'min-h-screen' : 'min-h-[calc(100vh-80px)]'}`}
     >
       <div className="flex items-center gap-3 animate-pulse">
-        <GiWoodenCrate className="text-6xl drop-shadow-lg transform -rotate-6 text-kibako-accent" />
+        <GiWoodenCrate className="text-6xl drop-shadow-lg transform -rotate-6 text-kibako-secondary" />
         <h1 className="text-5xl font-bold tracking-wider text-kibako-primary">
           KIBAKO
         </h1>

--- a/frontend/src/components/templates/Maintenance.tsx
+++ b/frontend/src/components/templates/Maintenance.tsx
@@ -34,7 +34,7 @@ const Maintenance: React.FC<MaintenanceProps> = ({
         <div className="mb-6">
           {/* KIBAKOロゴ（木箱アイコン）とタイトル */}
           <div className="flex items-center justify-center gap-4 mb-4">
-            <GiWoodenCrate className="text-5xl sm:text-7xl drop-shadow-lg text-kibako-accent" />
+            <GiWoodenCrate className="text-5xl sm:text-7xl drop-shadow-lg text-kibako-secondary" />
             <h2 className="text-3xl sm:text-4xl font-bold tracking-wider text-kibako-primary">
               KIBAKO
             </h2>
@@ -60,7 +60,7 @@ const Maintenance: React.FC<MaintenanceProps> = ({
 
         {/* ステータスインジケーター */}
         <div className="flex items-center justify-center space-x-2 text-sm text-kibako-secondary">
-          <div className="w-2 h-2 bg-kibako-accent rounded-full animate-pulse"></div>
+          <div className="w-2 h-2 bg-kibako-secondary rounded-full animate-pulse"></div>
           <span>システム復旧作業中...</span>
         </div>
 

--- a/frontend/src/components/templates/Maintenance.tsx
+++ b/frontend/src/components/templates/Maintenance.tsx
@@ -27,9 +27,9 @@ const Maintenance: React.FC<MaintenanceProps> = ({
   const endTime = getMaintenanceEndTime();
 
   return (
-    <div className="min-h-[calc(100vh-80px)] bg-gradient-to-br from-content-secondary to-content-DEFAULT flex items-center justify-center p-4">
+    <div className="min-h-[calc(100vh-80px)] bg-gradient-to-br from-kibako-tertiary to-kibako-white flex items-center justify-center p-4">
       {/* メンテナンス情報カード */}
-      <div className="max-w-md w-full bg-kibako-white rounded-lg shadow-xl p-8 text-center border border-wood-light">
+      <div className="max-w-md w-full bg-kibako-white rounded-lg shadow-xl p-8 text-center border border-kibako-secondary">
         {/* ヘッダー部分：ロゴとタイトル */}
         <div className="mb-6">
           {/* KIBAKOロゴ（木箱アイコン）とタイトル */}
@@ -50,7 +50,7 @@ const Maintenance: React.FC<MaintenanceProps> = ({
         </div>
 
         {/* メンテナンス詳細情報 */}
-        <div className="bg-kibako-tertiary rounded-lg p-4 mb-6 border border-wood-light">
+        <div className="bg-kibako-tertiary rounded-lg p-4 mb-6 border border-kibako-secondary">
           <p className="text-sm text-kibako-primary mb-2">{message}</p>
           {/* 終了予定時刻が設定されている場合 */}
           {endTime && (

--- a/frontend/src/features/profile/components/ProfileEdit.tsx
+++ b/frontend/src/features/profile/components/ProfileEdit.tsx
@@ -98,20 +98,20 @@ const ProfileEdit: React.FC = () => {
       <div className="flex items-center gap-4 mb-8">
         <button
           onClick={handleBack}
-          className="p-2 hover:bg-content-secondary rounded-full transition-colors"
+          className="p-2 hover:bg-kibako-tertiary rounded-full transition-colors"
           title="前のページに戻る"
         >
-          <IoArrowBack className="h-5 w-5 text-wood-dark hover:text-header transition-colors" />
+          <IoArrowBack className="h-5 w-5 text-kibako-primary hover:text-kibako-primary transition-colors" />
         </button>
         <div className="flex-grow flex items-center justify-center">
-          <h1 className="text-4xl font-bold text-center bg-gradient-to-r from-header via-header-light to-header text-transparent bg-clip-text">
+          <h1 className="text-4xl font-bold text-center bg-gradient-to-r from-kibako-primary via-kibako-secondary to-kibako-primary text-transparent bg-clip-text">
             プロフィール編集
           </h1>
         </div>
       </div>
 
-      <div className="mb-6 p-6 overflow-visible rounded-xl bg-gradient-to-r from-content via-content to-content-secondary shadow-lg border border-wood-lightest/30">
-        <h2 className="text-xl font-bold text-wood-darkest mb-4 border-b border-wood-light/30 pb-2">
+      <div className="mb-6 p-6 overflow-visible rounded-xl bg-gradient-to-r from-kibako-white via-kibako-white to-kibako-tertiary shadow-lg border border-kibako-tertiary/30">
+        <h2 className="text-xl font-bold text-kibako-primary mb-4 border-b border-kibako-secondary/30 pb-2">
           ユーザー情報
         </h2>
 
@@ -119,7 +119,7 @@ const ProfileEdit: React.FC = () => {
           <div>
             <label
               htmlFor="username"
-              className="block text-sm uppercase tracking-wide text-wood-dark/70 mb-2 font-medium"
+              className="block text-sm uppercase tracking-wide text-kibako-primary/70 mb-2 font-medium"
             >
               ユーザー名
             </label>
@@ -129,7 +129,7 @@ const ProfileEdit: React.FC = () => {
               value={username}
               onChange={(e) => setUsername(e.target.value)}
               placeholder="ユーザー名を入力"
-              className="py-2 px-3 border border-wood-light/30 rounded-lg bg-white w-full"
+              className="py-2 px-3 border border-kibako-secondary/30 rounded-lg bg-white w-full"
               maxLength={50}
               autoFocus
             />
@@ -138,7 +138,7 @@ const ProfileEdit: React.FC = () => {
           <div className="flex justify-end">
             <button
               type="submit"
-              className="flex items-center gap-1 px-4 py-2 rounded-md bg-wood hover:bg-wood-dark text-white hover:shadow-md transition-all font-medium"
+              className="flex items-center gap-1 px-4 py-2 rounded-md bg-kibako-secondary hover:bg-kibako-primary text-white hover:shadow-md transition-all font-medium"
             >
               <FaCheck className="w-4 h-4" />
               更新する

--- a/frontend/src/features/profile/components/ProfileEditSkeleton.tsx
+++ b/frontend/src/features/profile/components/ProfileEditSkeleton.tsx
@@ -10,9 +10,9 @@ const ProfileEditSkeleton: React.FC = () => {
         </div>
       </div>
 
-      <div className="mb-6 p-6 overflow-visible rounded-xl bg-gradient-to-r from-content via-content to-content-secondary shadow-lg border border-wood-lightest/30">
+      <div className="mb-6 p-6 overflow-visible rounded-xl bg-gradient-to-r from-kibako-white via-kibako-white to-kibako-tertiary shadow-lg border border-kibako-tertiary/30">
         <div className="h-8 bg-slate-200 rounded w-1/4 mb-4 animate-pulse"></div>
-        <div className="border-b border-wood-light/30 pb-2 mb-4"></div>
+        <div className="border-b border-kibako-secondary/30 pb-2 mb-4"></div>
 
         <div className="space-y-6">
           <div>

--- a/frontend/src/features/prototype/components/atoms/ColorPicker.tsx
+++ b/frontend/src/features/prototype/components/atoms/ColorPicker.tsx
@@ -36,7 +36,7 @@ export default function ColorPicker({
         <div
           className={`w-4 h-4 rounded ${
             isCustomColor(palette, value || '')
-              ? 'ring-2 ring-kibako-accent'
+              ? 'ring-2 ring-kibako-secondary'
               : ''
           }`}
           style={{ backgroundColor: value || '#FFFFFF' }}

--- a/frontend/src/features/prototype/components/atoms/ModeToggleButton.tsx
+++ b/frontend/src/features/prototype/components/atoms/ModeToggleButton.tsx
@@ -31,7 +31,7 @@ export default function ModeToggleButton({
           />
         </button>
         {/* ツールチップ */}
-        <div className="absolute left-0 bottom-full mb-1 bg-header text-kibako-white text-[10px] px-1.5 py-0.5 rounded whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity duration-200 pointer-events-none z-[200]">
+        <div className="absolute left-0 bottom-full mb-1 bg-kibako-primary text-kibako-white text-[10px] px-1.5 py-0.5 rounded whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity duration-200 pointer-events-none z-[200]">
           {!isSelectionMode
             ? 'ボードをドラッグ&ドロップで移動できるモードをオフにする'
             : 'ボードをドラッグ&ドロップで移動できるモードをオンにする'}

--- a/frontend/src/features/prototype/components/atoms/ModeToggleButton.tsx
+++ b/frontend/src/features/prototype/components/atoms/ModeToggleButton.tsx
@@ -16,7 +16,7 @@ export default function ModeToggleButton({
         <button
           className={`relative p-3 rounded-full shadow-md transition-all duration-300 ${
             !isSelectionMode
-              ? 'bg-kibako-primary text-kibako-white ring-2 ring-kibako-accent ring-offset-2 shadow-lg'
+              ? 'bg-kibako-primary text-kibako-white ring-2 ring-kibako-secondary ring-offset-2 shadow-lg'
               : 'bg-gray-300 text-gray-500 hover:bg-gray-400'
           }`}
           onClick={onToggle}

--- a/frontend/src/features/prototype/components/atoms/PrototypeNameEditor.tsx
+++ b/frontend/src/features/prototype/components/atoms/PrototypeNameEditor.tsx
@@ -69,13 +69,13 @@ export default function PrototypeNameEditor({
             onChange={(e) => setEditedValue(e.target.value)}
             onBlur={() => handleBlur(handleComplete, validate)}
             onKeyDown={(e) => handleKeyDown(e, handleComplete, validate)}
-            className="w-full text-wood-darkest font-medium bg-transparent border border-transparent rounded-md px-1 -mx-1 focus:outline-none focus:bg-white focus:border-header focus:shadow-sm transition-all text-xs"
+            className="w-full text-kibako-primary font-medium bg-transparent border border-transparent rounded-md px-1 -mx-1 focus:outline-none focus:bg-white focus:border-kibako-primary focus:shadow-sm transition-all text-xs"
             autoFocus
           />
         </form>
       ) : (
         <h2
-          className="text-xs font-medium truncate text-wood-darkest cursor-pointer px-1 -mx-1 rounded-md hover:bg-wood-lightest transition-colors"
+          className="text-xs font-medium truncate text-kibako-primary cursor-pointer px-1 -mx-1 rounded-md hover:bg-kibako-tertiary transition-colors"
           title={name}
           onClick={() => startEditing(prototypeId, name)}
         >

--- a/frontend/src/features/prototype/components/molecules/EmptyProjectState.tsx
+++ b/frontend/src/features/prototype/components/molecules/EmptyProjectState.tsx
@@ -24,20 +24,20 @@ export const EmptyProjectState: React.FC<EmptyProjectStateProps> = ({
       <button
         onClick={onCreatePrototype}
         disabled={isCreating}
-        className={`absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 flex flex-row items-center justify-center gap-4 px-14 py-8 rounded-3xl shadow-[0_10px_40px_0_rgba(0,0,0,0.45),0_2px_8px_0_rgba(0,0,0,0.25)] bg-kibako-primary text-kibako-white text-2xl font-bold transition-all duration-200 border-4 border-kibako-accent hover:bg-kibako-accent hover:text-kibako-primary hover:scale-105 hover:shadow-[0_16px_56px_0_rgba(0,0,0,0.55),0_4px_16px_0_rgba(0,0,0,0.30)] active:scale-95 focus:outline-none focus:ring-4 focus:ring-kibako-accent/40 select-none ${isCreating ? 'opacity-80 cursor-not-allowed' : ''}`}
+          className={`absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 flex flex-row items-center justify-center gap-4 px-14 py-8 rounded-3xl shadow-[0_10px_40px_0_rgba(0,0,0,0.45),0_2px_8px_0_rgba(0,0,0,0.25)] bg-kibako-primary text-kibako-white text-2xl font-bold transition-all duration-200 border-4 border-kibako-secondary hover:bg-kibako-secondary hover:text-kibako-primary hover:scale-105 hover:shadow-[0_16px_56px_0_rgba(0,0,0,0.55),0_4px_16px_0_rgba(0,0,0,0.30)] active:scale-95 focus:outline-none focus:ring-4 focus:ring-kibako-secondary/40 select-none ${isCreating ? 'opacity-80 cursor-not-allowed' : ''}`}
         style={{ minWidth: 360, minHeight: 100 }}
         title="新規プロトタイプを作成する"
       >
         {/* ローディング状態のアイコン */}
         {isCreating ? (
           <RiLoaderLine
-            className="w-14 h-14 animate-spin text-kibako-primary bg-kibako-accent rounded-full p-2 shadow-lg"
+            className="w-14 h-14 animate-spin text-kibako-primary bg-kibako-secondary rounded-full p-2 shadow-lg"
             aria-hidden="true"
           />
         ) : (
           /* 通常状態のアイコン */
           <GiWoodenCrate
-            className="w-20 h-20 text-kibako-accent drop-shadow-xl transform -rotate-6 bg-white rounded-2xl p-2 shadow-lg border-2 border-kibako-accent"
+            className="w-20 h-20 text-kibako-secondary drop-shadow-xl transform -rotate-6 bg-white rounded-2xl p-2 shadow-lg border-2 border-kibako-secondary"
             aria-hidden="true"
           />
         )}

--- a/frontend/src/features/prototype/components/molecules/GameBoardHelpPanel.tsx
+++ b/frontend/src/features/prototype/components/molecules/GameBoardHelpPanel.tsx
@@ -56,7 +56,7 @@ export default function GameBoardHelpPanel({
       <div className="relative">
         <button
           onClick={() => setIsExpanded(!isExpanded)}
-          className="flex items-center justify-center rounded-full bg-wood-dark p-1.5 shadow-md hover:bg-wood-darkest transition-all"
+          className="flex items-center justify-center rounded-full bg-kibako-primary p-1.5 shadow-md hover:bg-kibako-primary transition-all"
           aria-label={isExpanded ? 'ヘルプを閉じる' : 'ヘルプを開く'}
           title="操作ヘルプ (Shift+?)"
         >
@@ -64,19 +64,19 @@ export default function GameBoardHelpPanel({
         </button>
 
         {isExpanded && (
-          <div className="absolute left-0 top-9 w-96 rounded-xl border border-wood-lightest/40 bg-gradient-to-r from-content to-content-secondary shadow-md z-50">
+          <div className="absolute left-0 top-9 w-96 rounded-xl border border-kibako-tertiary/40 bg-gradient-to-r from-kibako-white to-kibako-tertiary shadow-md z-50">
             <div className="relative px-3 py-2">
               <div className="flex items-center justify-between mb-2">
-                <h3 className="text-xs font-semibold text-wood-darkest">
+                <h3 className="text-xs font-semibold text-kibako-primary">
                   ヘルプ
                 </h3>
                 <div className="flex items-center gap-1">
                   <button
                     onClick={() => setIsExpanded(false)}
-                    className="rounded-md p-1 hover:bg-wood-lightest/20 transition-colors"
+                    className="rounded-md p-1 hover:bg-kibako-tertiary/20 transition-colors"
                     aria-label="ヘルプを閉じる"
                   >
-                    <IoClose className="h-3.5 w-3.5 text-wood-dark hover:text-header transition-colors" />
+                    <IoClose className="h-3.5 w-3.5 text-kibako-primary hover:text-kibako-primary transition-colors" />
                   </button>
                 </div>
               </div>
@@ -85,8 +85,8 @@ export default function GameBoardHelpPanel({
                   onClick={() => setActiveTab('parts')}
                   className={`flex-1 rounded-md py-1 text-center text-xs font-medium transition-all ${
                     activeTab === 'parts'
-                      ? 'bg-wood-lightest text-wood-dark'
-                      : 'text-wood-darkest hover:bg-wood-lightest/20'
+                      ? 'bg-kibako-tertiary text-kibako-primary'
+                      : 'text-kibako-primary hover:bg-kibako-tertiary/20'
                   }`}
                   aria-label="パーツタブを開く"
                 >
@@ -96,8 +96,8 @@ export default function GameBoardHelpPanel({
                   onClick={() => setActiveTab('operations')}
                   className={`flex-1 rounded-md py-1 text-center text-xs font-medium transition-all ${
                     activeTab === 'operations'
-                      ? 'bg-wood-lightest text-wood-dark'
-                      : 'text-wood-darkest hover:bg-wood-lightest/20'
+                      ? 'bg-kibako-tertiary text-kibako-primary'
+                      : 'text-kibako-primary hover:bg-kibako-tertiary/20'
                   }`}
                   aria-label="操作方法タブを開く"
                 >
@@ -107,8 +107,8 @@ export default function GameBoardHelpPanel({
                   onClick={() => setActiveTab('shortcuts')}
                   className={`flex-1 rounded-md py-1 text-center text-xs font-medium transition-all ${
                     activeTab === 'shortcuts'
-                      ? 'bg-wood-lightest text-wood-dark'
-                      : 'text-wood-darkest hover:bg-wood-lightest/20'
+                      ? 'bg-kibako-tertiary text-kibako-primary'
+                      : 'text-kibako-primary hover:bg-kibako-tertiary/20'
                   }`}
                   aria-label="ショートカットタブを開く"
                 >
@@ -117,12 +117,12 @@ export default function GameBoardHelpPanel({
               </div>
               {activeTab === 'parts' && (
                 <table className="w-full text-xs">
-                  <thead className="border-b border-wood-light/30">
+                  <thead className="border-b border-kibako-secondary/30">
                     <tr>
-                      <th className="py-1 px-2 text-left font-medium text-wood-dark w-1/4">
+                      <th className="py-1 px-2 text-left font-medium text-kibako-primary w-1/4">
                         パーツ
                       </th>
-                      <th className="py-1 px-2 text-left font-medium text-wood-dark">
+                      <th className="py-1 px-2 text-left font-medium text-kibako-primary">
                         説明
                       </th>
                     </tr>
@@ -131,12 +131,12 @@ export default function GameBoardHelpPanel({
                     {PARTS_INFO.map((part) => (
                       <tr
                         key={part.id}
-                        className="border-b border-wood-light/10 last:border-b-0"
+                        className="border-b border-kibako-secondary/10 last:border-b-0"
                       >
-                        <td className="py-1.5 px-2 font-medium text-wood-dark">
+                        <td className="py-1.5 px-2 font-medium text-kibako-primary">
                           {part.name}
                         </td>
-                        <td className="py-1.5 px-2 text-wood-darkest">
+                        <td className="py-1.5 px-2 text-kibako-primary">
                           {part.description}
                         </td>
                       </tr>
@@ -146,12 +146,12 @@ export default function GameBoardHelpPanel({
               )}
               {activeTab === 'operations' && (
                 <table className="w-full text-xs">
-                  <thead className="border-b border-wood-light/30">
+                  <thead className="border-b border-kibako-secondary/30">
                     <tr>
-                      <th className="py-1 px-2 text-left font-medium text-wood-dark w-1/3">
+                      <th className="py-1 px-2 text-left font-medium text-kibako-primary w-1/3">
                         操作
                       </th>
-                      <th className="py-1 px-2 text-left font-medium text-wood-dark">
+                      <th className="py-1 px-2 text-left font-medium text-kibako-primary">
                         説明
                       </th>
                     </tr>
@@ -160,12 +160,12 @@ export default function GameBoardHelpPanel({
                     {OPERATIONS_INFO.map((operation) => (
                       <tr
                         key={operation.id}
-                        className="border-b border-wood-light/10 last:border-b-0"
+                        className="border-b border-kibako-secondary/10 last:border-b-0"
                       >
-                        <td className="py-1.5 px-2 font-medium text-wood-dark">
+                        <td className="py-1.5 px-2 font-medium text-kibako-primary">
                           {operation.operation}
                         </td>
-                        <td className="py-1.5 px-2 text-wood-darkest">
+                        <td className="py-1.5 px-2 text-kibako-primary">
                           {operation.description}
                         </td>
                       </tr>
@@ -175,12 +175,12 @@ export default function GameBoardHelpPanel({
               )}
               {activeTab === 'shortcuts' && (
                 <table className="w-full text-xs">
-                  <thead className="border-b border-wood-light/30">
+                  <thead className="border-b border-kibako-secondary/30">
                     <tr>
-                      <th className="py-1 px-2 text-left font-medium text-wood-dark w-1/3">
+                      <th className="py-1 px-2 text-left font-medium text-kibako-primary w-1/3">
                         操作
                       </th>
-                      <th className="py-1 px-2 text-left font-medium text-wood-dark">
+                      <th className="py-1 px-2 text-left font-medium text-kibako-primary">
                         説明
                       </th>
                     </tr>
@@ -189,12 +189,12 @@ export default function GameBoardHelpPanel({
                     {SHORTCUTS.map((shortcut) => (
                       <tr
                         key={shortcut.id}
-                        className="border-b border-wood-light/10 last:border-b-0"
+                        className="border-b border-kibako-secondary/10 last:border-b-0"
                       >
-                        <td className="py-1.5 px-2 font-medium text-wood-dark">
+                        <td className="py-1.5 px-2 font-medium text-kibako-primary">
                           {shortcut.key}
                         </td>
-                        <td className="py-1.5 px-2 text-wood-darkest">
+                        <td className="py-1.5 px-2 text-kibako-primary">
                           {shortcut.description}
                         </td>
                       </tr>

--- a/frontend/src/features/prototype/components/molecules/LeftSidebar.tsx
+++ b/frontend/src/features/prototype/components/molecules/LeftSidebar.tsx
@@ -289,17 +289,17 @@ export default function LeftSidebar({
 
   return (
     <div
-      className={`fixed left-4 top-4 flex flex-col rounded-xl border border-wood-lightest/40 bg-gradient-to-r from-content to-content-secondary shadow-md w-[18rem] ${
+      className={`fixed left-4 top-4 flex flex-col rounded-xl border border-kibako-tertiary/40 bg-gradient-to-r from-kibako-white to-kibako-tertiary shadow-md w-[18rem] ${
         !isLeftSidebarMinimized ? 'overflow-auto max-h-[90vh]' : 'h-[48px]'
       }`}
     >
       <div className="flex h-[48px] items-center justify-between p-2">
         <button
           onClick={handleBack}
-          className="p-1 hover:bg-wood-lightest/20 rounded-full transition-colors flex-shrink-0"
+          className="p-1 hover:bg-kibako-tertiary/20 rounded-full transition-colors flex-shrink-0"
           title="戻る"
         >
-          <IoArrowBack className="h-5 w-5 text-wood-dark hover:text-header transition-colors" />
+          <IoArrowBack className="h-5 w-5 text-kibako-primary hover:text-kibako-primary transition-colors" />
         </button>
         <div className="flex items-center gap-1 flex-grow ml-1 min-w-0">
           <PrototypeNameEditor
@@ -317,7 +317,7 @@ export default function LeftSidebar({
             }
             className="p-1 rounded-full transition-transform hover:scale-110"
           >
-            <IoMenu className="h-5 w-5 text-wood-dark hover:text-header transition-colors" />
+            <IoMenu className="h-5 w-5 text-kibako-primary hover:text-kibako-primary transition-colors" />
           </button>
         )}
       </div>

--- a/frontend/src/features/prototype/components/molecules/LeftSidebar.tsx
+++ b/frontend/src/features/prototype/components/molecules/LeftSidebar.tsx
@@ -201,10 +201,10 @@ export default function LeftSidebar({
           <button
             onClick={handleCreateRoom}
             disabled={isRoomCreating}
-            className="relative flex items-center bg-gradient-to-br from-kibako-tertiary to-kibako-white rounded-xl px-3 py-3 shadow-md min-w-[120px] text-left transition-all gap-2 border-2 border-dashed border-kibako-secondary hover:border-kibako-accent hover:border-solid mb-2 disabled:opacity-60 disabled:cursor-not-allowed"
+            className="relative flex items-center bg-gradient-to-br from-kibako-tertiary to-kibako-white rounded-xl px-3 py-3 shadow-md min-w-[120px] text-left transition-all gap-2 border-2 border-dashed border-kibako-secondary hover:border-kibako-secondary hover:border-solid mb-2 disabled:opacity-60 disabled:cursor-not-allowed"
             title="新しいルームを作る"
           >
-            <MdMeetingRoom className="h-7 w-7 text-kibako-accent flex-shrink-0 mr-1" />
+            <MdMeetingRoom className="h-7 w-7 text-kibako-secondary flex-shrink-0 mr-1" />
             <div className="flex flex-col min-w-0 flex-1">
               <span className="text-sm font-semibold text-kibako-primary truncate block max-w-[180px]">
                 新しいルームを作る
@@ -234,8 +234,8 @@ export default function LeftSidebar({
                     className="group"
                     title={`${instance.name}のルームを開く`}
                   >
-                    <div className="flex items-center bg-gradient-to-br from-kibako-tertiary to-kibako-white rounded-xl px-3 py-3 shadow-md min-w-[120px] text-left transition-all gap-2 group-hover:bg-kibako-accent/10 group-hover:border-kibako-accent border border-transparent">
-                      <MdMeetingRoom className="h-7 w-7 text-kibako-accent flex-shrink-0 mr-1" />
+                    <div className="flex items-center bg-gradient-to-br from-kibako-tertiary to-kibako-white rounded-xl px-3 py-3 shadow-md min-w-[120px] text-left transition-all gap-2 group-hover:bg-kibako-secondary/10 group-hover:border-kibako-secondary border border-transparent">
+                      <MdMeetingRoom className="h-7 w-7 text-kibako-secondary flex-shrink-0 mr-1" />
                       <div className="flex flex-col min-w-0 flex-1">
                         <span className="text-sm font-semibold text-kibako-primary truncate block max-w-[180px]">
                           {instance.name}
@@ -253,7 +253,7 @@ export default function LeftSidebar({
                                   .map((user, idx) => (
                                     <span
                                       key={user.userId}
-                                      className="flex items-center justify-center w-5 h-5 rounded-full bg-kibako-accent text-kibako-white font-bold text-xs border border-kibako-white"
+                                      className="flex items-center justify-center w-5 h-5 rounded-full bg-kibako-secondary text-kibako-white font-bold text-xs border border-kibako-white"
                                       style={{ zIndex: 10 - idx }}
                                       title={user.username}
                                     >
@@ -274,7 +274,7 @@ export default function LeftSidebar({
                   </Link>
                   <button
                     onClick={() => handleDeleteRoom(instance.id)}
-                    className="absolute right-2 top-1/2 -translate-y-1/2 p-1 rounded-full group/delete hover:bg-kibako-accent/20 focus:outline-none flex items-center justify-center"
+                    className="absolute right-2 top-1/2 -translate-y-1/2 p-1 rounded-full group/delete hover:bg-kibako-secondary/20 focus:outline-none flex items-center justify-center"
                     title="ルームを削除"
                   >
                     <MdDelete className="h-5 w-5 text-kibako-secondary transition-colors" />

--- a/frontend/src/features/prototype/components/molecules/PartCreateMenu.tsx
+++ b/frontend/src/features/prototype/components/molecules/PartCreateMenu.tsx
@@ -236,17 +236,17 @@ export default function PartCreateMenu({
   return (
     <div className="fixed bottom-4 left-1/2 transform -translate-x-1/2 z-50 flex items-center justify-center">
       {/* パーツ作成メニュー */}
-      <div className="rounded-xl bg-content shadow-lg border border-wood-light/30 p-3 flex flex-col items-center min-w-[140px]">
+      <div className="rounded-xl bg-kibako-white shadow-lg border border-kibako-secondary/30 p-3 flex flex-col items-center min-w-[140px]">
         <div className="flex items-center gap-2">
           {partTypes.map((partType) => (
             <button
               key={partType.type}
               onClick={() => handleCreatePart(partType.type)}
               disabled={creatingPartType !== null}
-              className={`group relative flex items-center justify-center w-12 h-12 bg-gradient-to-br from-wood to-wood-dark rounded-lg transition-all duration-200 ${
+              className={`group relative flex items-center justify-center w-12 h-12 bg-gradient-to-br from-kibako-secondary to-kibako-primary rounded-lg transition-all duration-200 ${
                 creatingPartType !== null
                   ? 'opacity-50 cursor-not-allowed scale-95'
-                  : 'hover:from-wood-dark hover:to-wood-darkest hover:scale-105 hover:shadow-md'
+                  : 'hover:from-kibako-primary hover:to-kibako-primary hover:scale-105 hover:shadow-md'
               }`}
               title={`${partType.name}を作成`}
             >
@@ -255,7 +255,7 @@ export default function PartCreateMenu({
               ) : (
                 partType.icon
               )}
-              <div className="absolute -top-10 left-1/2 transform -translate-x-1/2 bg-header text-white text-xs px-2 py-1 rounded whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity duration-200 pointer-events-none">
+              <div className="absolute -top-10 left-1/2 transform -translate-x-1/2 bg-kibako-primary text-white text-xs px-2 py-1 rounded whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity duration-200 pointer-events-none">
                 {creatingPartType === partType.type
                   ? '作成中...'
                   : partType.name}

--- a/frontend/src/features/prototype/components/molecules/PartPropertyMenu.tsx
+++ b/frontend/src/features/prototype/components/molecules/PartPropertyMenu.tsx
@@ -422,10 +422,10 @@ export default function PartPropertyMenu({
                     <button
                       key={textColor}
                       onClick={() => handleUpdateProperty({ textColor })}
-                      className={`w-5 h-5 rounded-full ${
-                        currentProperty?.textColor === textColor &&
-                        'border-2 border-kibako-accent'
-                      }`}
+                        className={`w-5 h-5 rounded-full ${
+                          currentProperty?.textColor === textColor &&
+                          'border-2 border-kibako-secondary'
+                        }`}
                       style={{ backgroundColor: textColor }}
                       title={textColor}
                     />
@@ -444,10 +444,10 @@ export default function PartPropertyMenu({
                     <button
                       key={color}
                       onClick={() => handleUpdateProperty({ color })}
-                      className={`w-5 h-5 rounded-full ${
-                        currentProperty?.color === color &&
-                        ' border-2 border-kibako-accent'
-                      }`}
+                        className={`w-5 h-5 rounded-full ${
+                          currentProperty?.color === color &&
+                          ' border-2 border-kibako-secondary'
+                        }`}
                       style={{ backgroundColor: color }}
                       title={color}
                     />

--- a/frontend/src/features/prototype/components/molecules/PlaySidebar.tsx
+++ b/frontend/src/features/prototype/components/molecules/PlaySidebar.tsx
@@ -95,12 +95,12 @@ export default function PlaySidebar({
   }, [selectedPartId, parts]);
 
   return (
-    <div className="fixed top-20 left-4 flex w-[240px] flex-col rounded-lg shadow-lg border border-wood-lightest/40 bg-gradient-to-r from-content to-content-secondary max-h-[calc(100vh-32px)] overflow-y-auto">
+    <div className="fixed top-20 left-4 flex w-[240px] flex-col rounded-lg shadow-lg border border-kibako-tertiary/40 bg-gradient-to-r from-kibako-white to-kibako-tertiary max-h-[calc(100vh-32px)] overflow-y-auto">
       {/* ヘッダー */}
-      <div className="border-b border-wood-lightest/60 rounded-t-lg bg-gradient-to-r from-wood-light/30 to-wood-light/20 py-2 px-4">
+      <div className="border-b border-kibako-tertiary/60 rounded-t-lg bg-gradient-to-r from-kibako-secondary/30 to-kibako-secondary/20 py-2 px-4">
         <div className="flex items-center">
-          <GiPokerHand className="h-4 w-4 text-wood-dark mr-2" />
-          <span className="text-[12px] font-medium text-wood-darkest">
+          <GiPokerHand className="h-4 w-4 text-kibako-primary mr-2" />
+          <span className="text-[12px] font-medium text-kibako-primary">
             Play モード設定
           </span>
         </div>

--- a/frontend/src/features/prototype/components/molecules/ProjectCard.tsx
+++ b/frontend/src/features/prototype/components/molecules/ProjectCard.tsx
@@ -68,7 +68,7 @@ export const ProjectCard: React.FC<ProjectCardProps> = ({
 
   return (
     <div
-      className="bg-content border border-wood-lightest/20 rounded-xl shadow-lg hover:shadow-2xl transition-all duration-300 overflow-hidden cursor-pointer"
+      className="bg-kibako-white border border-kibako-tertiary/20 rounded-xl shadow-lg hover:shadow-2xl transition-all duration-300 overflow-hidden cursor-pointer"
       onClick={onCardClick}
       onContextMenu={(e) => {
         e.preventDefault();
@@ -104,19 +104,19 @@ export const ProjectCard: React.FC<ProjectCardProps> = ({
                     alert(error.message || 'エラーが発生しました');
                   })
                 }
-                className="w-full text-wood-darkest font-semibold bg-transparent border border-transparent rounded-md p-1 -m-1 focus:outline-none focus:bg-white focus:border-header focus:shadow-sm transition-all text-base"
+                className="w-full text-kibako-primary font-semibold bg-transparent border border-transparent rounded-md p-1 -m-1 focus:outline-none focus:bg-white focus:border-kibako-primary focus:shadow-sm transition-all text-base"
                 autoFocus
               />
             </form>
           ) : (
-            <span className="text-wood-darkest font-semibold p-1 -m-1 rounded-md text-left text-base leading-tight">
+            <span className="text-kibako-primary font-semibold p-1 -m-1 rounded-md text-left text-base leading-tight">
               {name}
             </span>
           )}
         </div>
         {/* 詳細情報 */}
         <div className="flex justify-end">
-          <div className="text-right text-xs text-wood-light">
+          <div className="text-right text-xs text-kibako-secondary">
             <div>
               作成者:{' '}
               {userContext?.user?.id === project.userId

--- a/frontend/src/features/prototype/components/molecules/ProjectCard.tsx
+++ b/frontend/src/features/prototype/components/molecules/ProjectCard.tsx
@@ -77,7 +77,7 @@ export const ProjectCard: React.FC<ProjectCardProps> = ({
       title="クリックで編集 / 右クリックでメニュー表示"
     >
       {/* カード画像エリア */}
-      <div className="relative h-56 bg-gradient-to-br from-kibako-accent to-kibako-tertiary flex items-center justify-center">
+      <div className="relative h-56 bg-gradient-to-br from-kibako-secondary to-kibako-tertiary flex items-center justify-center">
         {getRandomIcon(id)}
         <div className="absolute inset-0 bg-black/10 rounded-t-xl"></div>
       </div>

--- a/frontend/src/features/prototype/components/molecules/RoleMenu.tsx
+++ b/frontend/src/features/prototype/components/molecules/RoleMenu.tsx
@@ -34,7 +34,7 @@ export default function RoleMenu({
 
   return (
     <div
-      className={`fixed top-4 right-4 z-50 flex flex-row items-center justify-between ${showRoleManagementButton ? 'max-w-[150px]' : 'max-w-[100px]'} h-[56px] bg-content p-2 rounded-lg`}
+      className={`fixed top-4 right-4 z-50 flex flex-row items-center justify-between ${showRoleManagementButton ? 'max-w-[150px]' : 'max-w-[100px]'} h-[56px] bg-kibako-white p-2 rounded-lg`}
     >
       {/* ユーザーアイコンリスト（左側・ホバーで全ユーザー名表示） */}
       <div className="relative group">
@@ -48,7 +48,7 @@ export default function RoleMenu({
               return (
                 <span
                   key={user.userId || `user-${idx}`}
-                  className="flex items-center justify-center w-7 h-7 rounded-full bg-wood-light text-wood-dark font-bold text-sm select-none border-2 border-content shadow-sm"
+                  className="flex items-center justify-center w-7 h-7 rounded-full bg-kibako-secondary text-kibako-primary font-bold text-sm select-none border-2 border-kibako-white shadow-sm"
                   style={{ zIndex: 10 - idx }}
                   title={user.username}
                 >
@@ -63,7 +63,7 @@ export default function RoleMenu({
             </span>
           )}
         </button>
-        <div className="absolute right-0 mt-2 max-w-xs bg-kibako-white border border-wood-light rounded shadow z-20 px-3 py-2 text-xs text-wood-dark opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto transition-opacity duration-200">
+        <div className="absolute right-0 mt-2 max-w-xs bg-kibako-white border border-kibako-secondary rounded shadow z-20 px-3 py-2 text-xs text-kibako-primary opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto transition-opacity duration-200">
           <ul>
             {connectedUsers.map((user) => (
               <li
@@ -81,11 +81,11 @@ export default function RoleMenu({
       {showRoleManagementButton && (
         <Link
           href={`/projects/${projectId}/roles`}
-          className="group flex items-center justify-center w-10 h-10 relative hover:bg-content-secondary rounded transition-colors ml-2"
+          className="group flex items-center justify-center w-10 h-10 relative hover:bg-kibako-tertiary rounded transition-colors ml-2"
           title="権限管理ページへ"
         >
-          <FaUsers className="h-5 w-5 text-wood-dark" />
-          <span className="absolute left-1/2 bottom-[-40px] transform -translate-x-1/2 bg-header text-kibako-white text-xs px-2 py-1 rounded whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity duration-200 pointer-events-none">
+          <FaUsers className="h-5 w-5 text-kibako-primary" />
+          <span className="absolute left-1/2 bottom-[-40px] transform -translate-x-1/2 bg-kibako-primary text-kibako-white text-xs px-2 py-1 rounded whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity duration-200 pointer-events-none">
             権限管理
           </span>
         </Link>

--- a/frontend/src/features/prototype/components/organisms/DeletePrototypeConfirmation.tsx
+++ b/frontend/src/features/prototype/components/organisms/DeletePrototypeConfirmation.tsx
@@ -114,7 +114,7 @@ const DeletePrototypeConfirmation = () => {
           className="p-2 hover:bg-gray-100 rounded-full transition-colors"
           title="戻る"
         >
-          <IoArrowBack className="h-5 w-5 text-wood-dark hover:text-header transition-colors" />
+          <IoArrowBack className="h-5 w-5 text-kibako-primary hover:text-kibako-primary transition-colors" />
         </button>
       </div>
 

--- a/frontend/src/features/prototype/components/organisms/ProjectList.tsx
+++ b/frontend/src/features/prototype/components/organisms/ProjectList.tsx
@@ -278,7 +278,7 @@ const ProjectList: React.FC = () => {
       {/* タイトルと作成ボタンを同じ行に表示（小さい画面では縦並び） */}
       <div className="sticky top-20 z-30 bg-transparent backdrop-blur-sm flex flex-col md:flex-row md:items-center md:justify-between mb-8 gap-4 py-4 rounded-lg">
         <div className="flex items-center gap-3">
-          <h1 className="text-3xl text-wood-darkest font-bold mb-0 bg-gradient-to-r from-header via-header-light to-header text-transparent bg-clip-text">
+          <h1 className="text-3xl text-kibako-primary font-bold mb-0 bg-gradient-to-r from-kibako-primary via-kibako-secondary to-kibako-primary text-transparent bg-clip-text">
             プロジェクト一覧
           </h1>
 

--- a/frontend/src/features/prototype/hooks/usePartTooltip.ts
+++ b/frontend/src/features/prototype/hooks/usePartTooltip.ts
@@ -94,13 +94,13 @@ export const usePartTooltip = ({
     try {
       tooltip.id = `tooltip-${part.id}`;
       tooltip.className =
-        'fixed z-[9999] pointer-events-none max-w-xs rounded-lg border border-wood-lightest/40 bg-gradient-to-r from-content to-content-secondary shadow-lg p-3';
+        'fixed z-[9999] pointer-events-none max-w-xs rounded-lg border border-kibako-tertiary/40 bg-gradient-to-r from-kibako-white to-kibako-tertiary shadow-lg p-3';
       tooltip.style.left = `${tooltipPosition.x + 10}px`;
       tooltip.style.top = `${tooltipPosition.y - 10}px`;
 
       tooltip.innerHTML = `
-        <div class="text-xs font-semibold text-wood-darkest mb-1">${partInfo.name}</div>
-        <div class="text-xs text-wood-dark leading-relaxed">${partInfo.description}</div>
+        <div class="text-xs font-semibold text-kibako-primary mb-1">${partInfo.name}</div>
+        <div class="text-xs text-kibako-primary leading-relaxed">${partInfo.description}</div>
       `;
 
       tooltipContainer.appendChild(tooltip);

--- a/frontend/src/features/role/components/molecules/RoleManagementForm.tsx
+++ b/frontend/src/features/role/components/molecules/RoleManagementForm.tsx
@@ -64,7 +64,7 @@ const RoleManagementForm: React.FC<RoleManagementFormProps> = ({
           <div className="flex items-center gap-2">
             {editMode.isEditing ? (
               <>
-                <h3 className="text-lg font-medium text-wood-dark">
+                <h3 className="text-lg font-medium text-kibako-primary">
                   {editMode.username} の権限を変更
                 </h3>
                 <button
@@ -76,7 +76,7 @@ const RoleManagementForm: React.FC<RoleManagementFormProps> = ({
                 </button>
               </>
             ) : (
-              <h3 className="text-lg font-medium text-wood-dark">
+              <h3 className="text-lg font-medium text-kibako-primary">
                 新しいユーザーを追加
               </h3>
             )}
@@ -120,7 +120,7 @@ const RoleManagementForm: React.FC<RoleManagementFormProps> = ({
                 <button
                   onClick={onUpdateRole}
                   disabled={loading}
-                  className="px-6 py-2 bg-wood-light hover:bg-wood text-white rounded-md transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
+                  className="px-6 py-2 bg-kibako-secondary hover:bg-kibako-secondary text-white rounded-md transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
                 >
                   {loading ? (
                     <>
@@ -136,7 +136,7 @@ const RoleManagementForm: React.FC<RoleManagementFormProps> = ({
               <button
                 onClick={onAddRole}
                 disabled={!selectedUser || loading}
-                className="px-6 py-2 bg-wood-light hover:bg-wood text-white rounded-md transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
+                className="px-6 py-2 bg-kibako-secondary hover:bg-kibako-secondary text-white rounded-md transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
               >
                 {loading ? (
                   <>

--- a/frontend/src/features/role/components/molecules/RoleSelector.tsx
+++ b/frontend/src/features/role/components/molecules/RoleSelector.tsx
@@ -44,7 +44,7 @@ const RoleSelector: React.FC<RoleSelectorProps> = ({
 
   return (
     <div>
-      <label className="block text-sm font-medium text-wood-dark mb-1">
+      <label className="block text-sm font-medium text-kibako-primary mb-1">
         権限選択
       </label>
       <div className="flex gap-3">
@@ -55,7 +55,7 @@ const RoleSelector: React.FC<RoleSelectorProps> = ({
               role.disabled
                 ? 'cursor-not-allowed opacity-50 border-gray-200 bg-gray-50'
                 : selectedRole === role.value
-                  ? 'border-wood-light bg-blue-50 shadow-sm cursor-pointer'
+                  ? 'border-kibako-secondary bg-blue-50 shadow-sm cursor-pointer'
                   : 'border-gray-200 hover:border-gray-300 hover:bg-gray-50 cursor-pointer'
             } ${loading ? 'opacity-60 cursor-not-allowed' : ''}`}
           >
@@ -73,16 +73,16 @@ const RoleSelector: React.FC<RoleSelectorProps> = ({
             {/* 上部：アイコンとロール名 */}
             <div className="flex items-center gap-2 justify-center">
               <div className={`${role.color} flex-shrink-0`}>{role.icon}</div>
-              <div className="text-base font-bold text-wood-dark">
+              <div className="text-base font-bold text-kibako-primary">
                 {role.name}
               </div>
             </div>
             {/* 下部：説明 */}
             <div className="text-center">
-              <div className="text-xs font-medium text-wood-dark mb-1">
+              <div className="text-xs font-medium text-kibako-primary mb-1">
                 {role.description}
               </div>
-              <div className="text-[10px] text-wood leading-tight">
+              <div className="text-[10px] text-kibako-secondary leading-tight">
                 {role.detailDescription}
               </div>
             </div>

--- a/frontend/src/features/role/components/molecules/UserRoleCard.tsx
+++ b/frontend/src/features/role/components/molecules/UserRoleCard.tsx
@@ -53,7 +53,7 @@ const UserRoleCard: React.FC<UserRoleCardProps> = ({
 
         <div className="flex-1">
           <div className="flex items-center gap-2">
-            <div className="font-medium text-wood-dark">
+            <div className="font-medium text-kibako-primary">
               {userRole.user.username}
             </div>
           </div>
@@ -102,7 +102,7 @@ const UserRoleCard: React.FC<UserRoleCardProps> = ({
             disabled={loading || !canRemove || editMode}
           >
             {loading ? (
-              <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-wood-light"></div>
+              <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-kibako-secondary"></div>
             ) : (
               <FaTrash className="h-4 w-4" />
             )}

--- a/frontend/src/features/role/components/molecules/UserRolesList.tsx
+++ b/frontend/src/features/role/components/molecules/UserRolesList.tsx
@@ -38,7 +38,7 @@ const UserRolesList: React.FC<UserRolesListProps> = ({
 }) => {
   if (userRoles.length === 0 && !loading) {
     return (
-      <div className="col-span-full flex flex-col items-center justify-center py-12 text-wood">
+      <div className="col-span-full flex flex-col items-center justify-center py-12 text-kibako-secondary">
         <FaUserShield className="h-12 w-12 text-gray-300 mb-4" />
         <p className="text-lg font-medium mb-2">
           ユーザー権限が設定されていません

--- a/frontend/src/features/role/components/molecules/UserSearchDropdown.tsx
+++ b/frontend/src/features/role/components/molecules/UserSearchDropdown.tsx
@@ -32,17 +32,17 @@ const UserSearchDropdown: React.FC<UserSearchDropdownProps> = ({
 }) => {
   return (
     <div>
-      <label className="block text-sm font-medium text-wood-dark mb-1">
+      <label className="block text-sm font-medium text-kibako-primary mb-1">
         ユーザー検索
       </label>
       <div className="relative">
         {/* 選択されたユーザー表示 */}
         {selectedUser ? (
-          <div className="w-full p-2 border border-gray-300 rounded-md bg-white focus:outline-none focus:ring-2 focus:ring-wood-light flex items-center justify-between">
+          <div className="w-full p-2 border border-gray-300 rounded-md bg-white focus:outline-none focus:ring-2 focus:ring-kibako-secondary flex items-center justify-between">
             <div className="flex items-center gap-2">
               <UserAvatar username={selectedUser.username} size="sm" />
               <div>
-                <div className="text-sm font-medium text-wood-dark">
+                <div className="text-sm font-medium text-kibako-primary">
                   {selectedUser.username}
                 </div>
               </div>
@@ -69,7 +69,7 @@ const UserSearchDropdown: React.FC<UserSearchDropdownProps> = ({
                 }}
                 onFocus={() => onToggleDropdown(true)}
                 placeholder="ユーザー名を入力..."
-                className="w-full p-2 pl-8 text-sm border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-wood-light focus:border-transparent"
+                className="w-full p-2 pl-8 text-sm border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-kibako-secondary focus:border-transparent"
                 disabled={loading}
               />
               <FaSearch className="absolute left-2 top-1/2 transform -translate-y-1/2 text-gray-400 h-3 w-3" />
@@ -99,14 +99,14 @@ const UserSearchDropdown: React.FC<UserSearchDropdownProps> = ({
                             size="sm"
                             className="group-hover:shadow-md transition-shadow"
                           />
-                          <div className="text-sm font-medium text-wood-dark">
+                          <div className="text-sm font-medium text-kibako-primary">
                             {user.username}
                           </div>
                         </button>
                       ))}
                     </div>
                   ) : (
-                    <div className="px-3 py-4 text-center text-wood">
+                    <div className="px-3 py-4 text-center text-kibako-secondary">
                       <FaUser className="h-6 w-6 text-gray-300 mx-auto mb-1" />
                       <div className="text-xs">
                         {searchTerm

--- a/frontend/src/features/role/components/organisms/RoleManagement.tsx
+++ b/frontend/src/features/role/components/organisms/RoleManagement.tsx
@@ -170,14 +170,14 @@ const RoleManagement: React.FC = () => {
             className="p-2 hover:bg-gray-100 rounded-full transition-colors absolute left-0"
             title="戻る"
           >
-            <IoArrowBack className="h-5 w-5 text-wood-dark hover:text-header transition-colors" />
+            <IoArrowBack className="h-5 w-5 text-kibako-primary hover:text-kibako-primary transition-colors" />
           </button>
           <h2 className="text-xl font-bold w-full text-center">権限設定</h2>
         </div>
 
         <div className="flex justify-center items-center py-12">
-          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-wood-light"></div>
-          <span className="ml-3 text-wood-dark">権限情報を読み込み中...</span>
+          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-kibako-secondary"></div>
+          <span className="ml-3 text-kibako-primary">権限情報を読み込み中...</span>
         </div>
       </div>
     );
@@ -191,13 +191,13 @@ const RoleManagement: React.FC = () => {
           className="p-2 hover:bg-gray-100 rounded-full transition-colors absolute left-0"
           title="戻る"
         >
-          <IoArrowBack className="h-5 w-5 text-wood-dark hover:text-header transition-colors" />
+          <IoArrowBack className="h-5 w-5 text-kibako-primary hover:text-kibako-primary transition-colors" />
         </button>
         <h2 className="text-xl font-bold w-full text-center">権限設定</h2>
       </div>
 
       <div className="mb-6">
-        <p className="text-center text-wood-dark">
+        <p className="text-center text-kibako-primary">
           プロジェクト
           {masterPrototypeName && `「${masterPrototypeName}」の`}
           ユーザー権限を管理します。

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -8,7 +8,6 @@ export default {
         kibako: {
           primary: '#5B3A29', // ダークブラウン（ヘッダー、ボタン）
           secondary: '#A98363', // 中間色（ボタン、テキスト）
-          accent: '#C9713C', // アクセント
           tertiary: '#EFE8DE', // ベース背景色（明るめ）
           white: '#F5F0E9', // テキスト
         },

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -12,26 +12,6 @@ export default {
           tertiary: '#EFE8DE', // ベース背景色（明るめ）
           white: '#F5F0E9', // テキスト
         },
-        background: 'var(--background)',
-        foreground: 'var(--foreground)',
-        // 木箱の色
-        wood: {
-          lightest: '#E6CCB2', // 最も明るい木目色
-          light: '#C8A887', // 明るい木目色
-          DEFAULT: '#B08968', // 標準的な木目色
-          dark: '#946B4D', // 濃い木目色
-          darkest: '#7D4B33', // 最も濃い木目色
-        },
-        // ヘッダーの色
-        header: {
-          DEFAULT: '#2C1810', // 深い茶色の背景
-          light: '#3D261C', // ホバー時などに使用する少し明るい色
-        },
-        // メインコンテンツの色
-        content: {
-          DEFAULT: '#FDF8F3', // 明るいベージュ（メイン背景）
-          secondary: '#F5E6D3', // やや暗いベージュ（セカンダリ背景）
-        },
       },
       // 木箱のグラデーション
       backgroundImage: {


### PR DESCRIPTION
## Summary
- drop wood/header/content color definitions from Tailwind config
- update components to use only core kibako colors

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1a453b3748326a4fe5bdb65f12c97

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - Updated app-wide theming to the Kibako color palette for improved visual consistency and contrast.
  - Refreshed styling across maintenance pages, profile edit and skeleton, prototype screens (help panel, sidebars, menus, project list/cards), role management views, tooltips, and buttons.
  - Adjusted gradients, borders, text colors, hover states, and focus rings; no behavioral changes.

- Chores
  - Cleaned up Tailwind configuration by removing deprecated color tokens, retaining core Kibako colors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->