### PR TITLE
feat: sync part selection across clients

### DIFF
--- a/backend/src/constants/socket.ts
+++ b/backend/src/constants/socket.ts
@@ -33,6 +33,8 @@ export const PROTOTYPE_SOCKET_EVENT = {
   DELETE_PARTS: 'DELETE_PARTS',
   // 接続中ユーザーリストの更新
   CONNECTED_USERS: 'CONNECTED_USERS',
+  // 他ユーザーのパーツ選択
+  SELECTED_PARTS: 'SELECTED_PARTS',
   // パーツ順序変更
   CHANGE_ORDER: 'CHANGE_ORDER',
   // デッキのシャッフル

--- a/backend/src/swagger-schemas.ts
+++ b/backend/src/swagger-schemas.ts
@@ -1,429 +1,480 @@
 // This file is auto-generated. DO NOT EDIT.
-
+/* eslint-disable */
 export const swaggerSchemas = {
   components: {
     schemas: {
       ...{
-        SuccessResponse: {
-          type: 'object',
-          properties: {
-            message: {
-              type: 'string',
-              description: '処理成功時のメッセージ',
+      "SuccessResponse": {
+            "type": "object",
+            "properties": {
+                  "message": {
+                        "type": "string",
+                        "description": "処理成功時のメッセージ"
+                  }
             },
-          },
-          required: ['message'],
-          example: {
-            message: '正常に処理が完了しました',
-          },
-        },
-        Error400Response: {
-          type: 'object',
-          properties: {
-            error: {
-              type: 'string',
-              description: 'エラーメッセージ',
-            },
-          },
-          required: ['error'],
-          example: {
-            error: 'リクエストが不正です',
-          },
-        },
-        Error401Response: {
-          type: 'object',
-          properties: {
-            error: {
-              type: 'string',
-              description: 'エラーメッセージ',
-            },
-          },
-          required: ['error'],
-          example: {
-            error: '認証が必要です',
-          },
-        },
-        Error404Response: {
-          type: 'object',
-          properties: {
-            error: {
-              type: 'string',
-              description: 'エラーメッセージ',
-            },
-          },
-          required: ['error'],
-          example: {
-            error: 'リソースが見つかりません',
-          },
-        },
-        Error500Response: {
-          type: 'object',
-          properties: {
-            error: {
-              type: 'string',
-              description: 'エラーメッセージ',
-            },
-          },
-          required: ['error'],
-          example: {
-            error: '予期せぬエラーが発生しました',
-          },
-        },
+            "required": [
+                  "message"
+            ],
+            "example": {
+                  "message": "正常に処理が完了しました"
+            }
       },
+      "Error400Response": {
+            "type": "object",
+            "properties": {
+                  "error": {
+                        "type": "string",
+                        "description": "エラーメッセージ"
+                  }
+            },
+            "required": [
+                  "error"
+            ],
+            "example": {
+                  "error": "リクエストが不正です"
+            }
+      },
+      "Error401Response": {
+            "type": "object",
+            "properties": {
+                  "error": {
+                        "type": "string",
+                        "description": "エラーメッセージ"
+                  }
+            },
+            "required": [
+                  "error"
+            ],
+            "example": {
+                  "error": "認証が必要です"
+            }
+      },
+      "Error404Response": {
+            "type": "object",
+            "properties": {
+                  "error": {
+                        "type": "string",
+                        "description": "エラーメッセージ"
+                  }
+            },
+            "required": [
+                  "error"
+            ],
+            "example": {
+                  "error": "リソースが見つかりません"
+            }
+      },
+      "Error500Response": {
+            "type": "object",
+            "properties": {
+                  "error": {
+                        "type": "string",
+                        "description": "エラーメッセージ"
+                  }
+            },
+            "required": [
+                  "error"
+            ],
+            "example": {
+                  "error": "予期せぬエラーが発生しました"
+            }
+      }
+},
       Image: {
-        type: 'object',
-        properties: {
-          id: {
-            type: 'string',
-            format: 'uuid',
-          },
-          displayName: {
-            type: 'string',
-          },
-          storagePath: {
-            type: 'string',
-          },
-          contentType: {
-            type: 'string',
-          },
-          fileSize: {
-            type: 'integer',
-          },
-          uploaderUserId: {
-            type: 'string',
-            format: 'uuid',
-          },
-          createdAt: {
-            type: 'string',
-          },
-          updatedAt: {
-            type: 'string',
-          },
-        },
-        required: [
-          'id',
-          'displayName',
-          'storagePath',
-          'contentType',
-          'fileSize',
-          'uploaderUserId',
-          'createdAt',
-          'updatedAt',
-        ],
+      "type": "object",
+      "properties": {
+            "id": {
+                  "type": "string",
+                  "format": "uuid"
+            },
+            "displayName": {
+                  "type": "string"
+            },
+            "storagePath": {
+                  "type": "string"
+            },
+            "contentType": {
+                  "type": "string"
+            },
+            "fileSize": {
+                  "type": "integer"
+            },
+            "uploaderUserId": {
+                  "type": "string",
+                  "format": "uuid"
+            },
+            "createdAt": {
+                  "type": "string"
+            },
+            "updatedAt": {
+                  "type": "string"
+            }
       },
+      "required": [
+            "id",
+            "displayName",
+            "storagePath",
+            "contentType",
+            "fileSize",
+            "uploaderUserId",
+            "createdAt",
+            "updatedAt"
+      ]
+},
       Part: {
-        type: 'object',
-        properties: {
-          id: {
-            type: 'integer',
-          },
-          type: {
-            type: 'string',
-            enum: ['token', 'card', 'hand', 'deck', 'area'],
-          },
-          prototypeId: {
-            type: 'string',
-            format: 'uuid',
-          },
-          position: {
-            type: 'object',
-            additionalProperties: true,
-          },
-          width: {
-            type: 'integer',
-          },
-          height: {
-            type: 'integer',
-          },
-          order: {
-            type: 'integer',
-          },
-          frontSide: {
-            oneOf: [
-              {
-                type: 'string',
-                enum: ['front', 'back'],
-              },
-              {
-                type: 'null',
-              },
-            ],
-          },
-          ownerId: {
-            oneOf: [
-              {
-                type: 'string',
-                format: 'uuid',
-              },
-              {
-                type: 'null',
-              },
-            ],
-          },
-          createdAt: {
-            type: 'string',
-          },
-          updatedAt: {
-            type: 'string',
-          },
-        },
-        required: [
-          'id',
-          'type',
-          'prototypeId',
-          'position',
-          'width',
-          'height',
-          'order',
-          'createdAt',
-          'updatedAt',
-        ],
+      "type": "object",
+      "properties": {
+            "id": {
+                  "type": "integer"
+            },
+            "type": {
+                  "type": "string",
+                  "enum": [
+                        "token",
+                        "card",
+                        "hand",
+                        "deck",
+                        "area"
+                  ]
+            },
+            "prototypeId": {
+                  "type": "string",
+                  "format": "uuid"
+            },
+            "position": {
+                  "type": "object",
+                  "additionalProperties": true
+            },
+            "width": {
+                  "type": "integer"
+            },
+            "height": {
+                  "type": "integer"
+            },
+            "order": {
+                  "type": "integer"
+            },
+            "frontSide": {
+                  "oneOf": [
+                        {
+                              "type": "string",
+                              "enum": [
+                                    "front",
+                                    "back"
+                              ]
+                        },
+                        {
+                              "type": "null"
+                        }
+                  ]
+            },
+            "ownerId": {
+                  "oneOf": [
+                        {
+                              "type": "string",
+                              "format": "uuid"
+                        },
+                        {
+                              "type": "null"
+                        }
+                  ]
+            },
+            "createdAt": {
+                  "type": "string"
+            },
+            "updatedAt": {
+                  "type": "string"
+            }
       },
+      "required": [
+            "id",
+            "type",
+            "prototypeId",
+            "position",
+            "width",
+            "height",
+            "order",
+            "createdAt",
+            "updatedAt"
+      ]
+},
       PartProperty: {
-        type: 'object',
-        properties: {
-          partId: {
-            type: 'integer',
-          },
-          side: {
-            type: 'string',
-            enum: ['front', 'back'],
-          },
-          name: {
-            type: 'string',
-          },
-          description: {
-            type: 'string',
-          },
-          color: {
-            type: 'string',
-          },
-          textColor: {
-            type: 'string',
-          },
-          imageId: {
-            oneOf: [
-              {
-                type: 'string',
-                format: 'uuid',
-              },
-              {
-                type: 'null',
-              },
-            ],
-          },
-          createdAt: {
-            type: 'string',
-          },
-          updatedAt: {
-            type: 'string',
-          },
-        },
-        required: [
-          'partId',
-          'side',
-          'name',
-          'description',
-          'color',
-          'textColor',
-          'createdAt',
-          'updatedAt',
-        ],
+      "type": "object",
+      "properties": {
+            "partId": {
+                  "type": "integer"
+            },
+            "side": {
+                  "type": "string",
+                  "enum": [
+                        "front",
+                        "back"
+                  ]
+            },
+            "name": {
+                  "type": "string"
+            },
+            "description": {
+                  "type": "string"
+            },
+            "color": {
+                  "type": "string"
+            },
+            "textColor": {
+                  "type": "string"
+            },
+            "imageId": {
+                  "oneOf": [
+                        {
+                              "type": "string",
+                              "format": "uuid"
+                        },
+                        {
+                              "type": "null"
+                        }
+                  ]
+            },
+            "createdAt": {
+                  "type": "string"
+            },
+            "updatedAt": {
+                  "type": "string"
+            }
       },
+      "required": [
+            "partId",
+            "side",
+            "name",
+            "description",
+            "color",
+            "textColor",
+            "createdAt",
+            "updatedAt"
+      ]
+},
       Permission: {
-        type: 'object',
-        properties: {
-          id: {
-            type: 'integer',
-          },
-          name: {
-            type: 'string',
-          },
-          resource: {
-            type: 'string',
-          },
-          action: {
-            type: 'string',
-          },
-          description: {
-            oneOf: [
-              {
-                type: 'string',
-              },
-              {
-                type: 'null',
-              },
-            ],
-          },
-          createdAt: {
-            type: 'string',
-          },
-          updatedAt: {
-            type: 'string',
-          },
-        },
-        required: [
-          'id',
-          'name',
-          'resource',
-          'action',
-          'createdAt',
-          'updatedAt',
-        ],
+      "type": "object",
+      "properties": {
+            "id": {
+                  "type": "integer"
+            },
+            "name": {
+                  "type": "string"
+            },
+            "resource": {
+                  "type": "string"
+            },
+            "action": {
+                  "type": "string"
+            },
+            "description": {
+                  "oneOf": [
+                        {
+                              "type": "string"
+                        },
+                        {
+                              "type": "null"
+                        }
+                  ]
+            },
+            "createdAt": {
+                  "type": "string"
+            },
+            "updatedAt": {
+                  "type": "string"
+            }
       },
+      "required": [
+            "id",
+            "name",
+            "resource",
+            "action",
+            "createdAt",
+            "updatedAt"
+      ]
+},
       Project: {
-        type: 'object',
-        properties: {
-          id: {
-            type: 'string',
-            format: 'uuid',
-          },
-          userId: {
-            type: 'string',
-            format: 'uuid',
-          },
-          createdAt: {
-            type: 'string',
-          },
-          updatedAt: {
-            type: 'string',
-          },
-        },
-        required: ['id', 'userId', 'createdAt', 'updatedAt'],
+      "type": "object",
+      "properties": {
+            "id": {
+                  "type": "string",
+                  "format": "uuid"
+            },
+            "userId": {
+                  "type": "string",
+                  "format": "uuid"
+            },
+            "createdAt": {
+                  "type": "string"
+            },
+            "updatedAt": {
+                  "type": "string"
+            }
       },
+      "required": [
+            "id",
+            "userId",
+            "createdAt",
+            "updatedAt"
+      ]
+},
       Prototype: {
-        type: 'object',
-        properties: {
-          id: {
-            type: 'string',
-            format: 'uuid',
-          },
-          projectId: {
-            type: 'string',
-            format: 'uuid',
-          },
-          name: {
-            type: 'string',
-          },
-          type: {
-            type: 'string',
-            enum: ['MASTER', 'VERSION', 'INSTANCE'],
-          },
-          sourceVersionPrototypeId: {
-            oneOf: [
-              {
-                type: 'string',
-                format: 'uuid',
-              },
-              {
-                type: 'null',
-              },
-            ],
-          },
-          createdAt: {
-            type: 'string',
-          },
-          updatedAt: {
-            type: 'string',
-          },
-        },
-        required: ['id', 'projectId', 'name', 'type', 'createdAt', 'updatedAt'],
+      "type": "object",
+      "properties": {
+            "id": {
+                  "type": "string",
+                  "format": "uuid"
+            },
+            "projectId": {
+                  "type": "string",
+                  "format": "uuid"
+            },
+            "name": {
+                  "type": "string"
+            },
+            "type": {
+                  "type": "string",
+                  "enum": [
+                        "MASTER",
+                        "VERSION",
+                        "INSTANCE"
+                  ]
+            },
+            "sourceVersionPrototypeId": {
+                  "oneOf": [
+                        {
+                              "type": "string",
+                              "format": "uuid"
+                        },
+                        {
+                              "type": "null"
+                        }
+                  ]
+            },
+            "createdAt": {
+                  "type": "string"
+            },
+            "updatedAt": {
+                  "type": "string"
+            }
       },
+      "required": [
+            "id",
+            "projectId",
+            "name",
+            "type",
+            "createdAt",
+            "updatedAt"
+      ]
+},
       Role: {
-        type: 'object',
-        properties: {
-          id: {
-            type: 'integer',
-          },
-          name: {
-            type: 'string',
-          },
-          description: {
-            oneOf: [
-              {
-                type: 'string',
-              },
-              {
-                type: 'null',
-              },
-            ],
-          },
-          createdAt: {
-            type: 'string',
-          },
-          updatedAt: {
-            type: 'string',
-          },
-        },
-        required: ['id', 'name', 'createdAt', 'updatedAt'],
+      "type": "object",
+      "properties": {
+            "id": {
+                  "type": "integer"
+            },
+            "name": {
+                  "type": "string"
+            },
+            "description": {
+                  "oneOf": [
+                        {
+                              "type": "string"
+                        },
+                        {
+                              "type": "null"
+                        }
+                  ]
+            },
+            "createdAt": {
+                  "type": "string"
+            },
+            "updatedAt": {
+                  "type": "string"
+            }
       },
+      "required": [
+            "id",
+            "name",
+            "createdAt",
+            "updatedAt"
+      ]
+},
       RolePermission: {
-        type: 'object',
-        properties: {
-          roleId: {
-            type: 'integer',
-          },
-          permissionId: {
-            type: 'integer',
-          },
-        },
-        required: ['roleId', 'permissionId'],
+      "type": "object",
+      "properties": {
+            "roleId": {
+                  "type": "integer"
+            },
+            "permissionId": {
+                  "type": "integer"
+            }
       },
+      "required": [
+            "roleId",
+            "permissionId"
+      ]
+},
       User: {
-        type: 'object',
-        properties: {
-          id: {
-            type: 'string',
-            format: 'uuid',
-          },
-          username: {
-            type: 'string',
-          },
-          createdAt: {
-            type: 'string',
-          },
-          updatedAt: {
-            type: 'string',
-          },
-        },
-        required: ['id', 'username', 'createdAt', 'updatedAt'],
+      "type": "object",
+      "properties": {
+            "id": {
+                  "type": "string",
+                  "format": "uuid"
+            },
+            "username": {
+                  "type": "string"
+            },
+            "createdAt": {
+                  "type": "string"
+            },
+            "updatedAt": {
+                  "type": "string"
+            }
       },
+      "required": [
+            "id",
+            "username",
+            "createdAt",
+            "updatedAt"
+      ]
+},
       UserRole: {
-        type: 'object',
-        properties: {
-          id: {
-            type: 'integer',
-          },
-          userId: {
-            type: 'string',
-            format: 'uuid',
-          },
-          roleId: {
-            type: 'integer',
-          },
-          resourceType: {
-            type: 'string',
-          },
-          resourceId: {
-            type: 'string',
-          },
-          createdAt: {
-            type: 'string',
-          },
-          updatedAt: {
-            type: 'string',
-          },
-        },
-        required: [
-          'id',
-          'userId',
-          'roleId',
-          'resourceType',
-          'resourceId',
-          'createdAt',
-          'updatedAt',
-        ],
+      "type": "object",
+      "properties": {
+            "id": {
+                  "type": "integer"
+            },
+            "userId": {
+                  "type": "string",
+                  "format": "uuid"
+            },
+            "roleId": {
+                  "type": "integer"
+            },
+            "resourceType": {
+                  "type": "string"
+            },
+            "resourceId": {
+                  "type": "string"
+            },
+            "createdAt": {
+                  "type": "string"
+            },
+            "updatedAt": {
+                  "type": "string"
+            }
       },
-    },
-  },
+      "required": [
+            "id",
+            "userId",
+            "roleId",
+            "resourceType",
+            "resourceId",
+            "createdAt",
+            "updatedAt"
+      ]
+},
+    }
+  }
 };

--- a/frontend/src/constants/gameBoardUi.ts
+++ b/frontend/src/constants/gameBoardUi.ts
@@ -1,0 +1,17 @@
+// 選択状態の描画用定数
+export const DEFAULT_STROKE_COLOR: string = 'grey';
+export const SELECTED_SHADOW_OPACITY: number = 0.9;
+
+// 選択装飾用定数
+export const SELECT_OUTLINE_STEP_PX: number = 3;
+export const SELECT_OUTLINE_STROKE_WIDTH: number = 2;
+
+// ラベル表示用定数
+export const LABEL_ITEM_HEIGHT: number = 32;
+export const LABEL_X_OFFSET: number = 6;
+export const LABEL_MARKER_SIZE: number = 16;
+export const LABEL_MARKER_RADIUS: number = 4;
+export const LABEL_MARKER_Y: number = 8;
+export const LABEL_TEXT_X: number = 22;
+export const LABEL_FONT_SIZE: number = 24;
+

--- a/frontend/src/features/prototype/components/molecules/PartOnGameBoard.tsx
+++ b/frontend/src/features/prototype/components/molecules/PartOnGameBoard.tsx
@@ -10,6 +10,19 @@ import { Group, Rect, Text, Image } from 'react-konva';
 import useImage from 'use-image';
 
 import { Part, PartProperty } from '@/api/types';
+import {
+  DEFAULT_STROKE_COLOR,
+  SELECTED_SHADOW_OPACITY,
+  SELECT_OUTLINE_STEP_PX,
+  SELECT_OUTLINE_STROKE_WIDTH,
+  LABEL_ITEM_HEIGHT,
+  LABEL_X_OFFSET,
+  LABEL_MARKER_SIZE,
+  LABEL_MARKER_RADIUS,
+  LABEL_MARKER_Y,
+  LABEL_TEXT_X,
+  LABEL_FONT_SIZE,
+} from '@/constants/gameBoardUi';
 import FlipIcon from '@/features/prototype/components/atoms/FlipIcon';
 import ShuffleIcon from '@/features/prototype/components/atoms/ShuffleIcon';
 import { FLIP_ANIMATION } from '@/features/prototype/constants/animation';
@@ -32,19 +45,6 @@ import {
   getShadowOffsetY,
 } from '@/features/prototype/utils/partUtils';
 import { getUserColor } from '@/features/prototype/utils/userColor';
-import {
-  DEFAULT_STROKE_COLOR,
-  SELECTED_SHADOW_OPACITY,
-  SELECT_OUTLINE_STEP_PX,
-  SELECT_OUTLINE_STROKE_WIDTH,
-  LABEL_ITEM_HEIGHT,
-  LABEL_X_OFFSET,
-  LABEL_MARKER_SIZE,
-  LABEL_MARKER_RADIUS,
-  LABEL_MARKER_Y,
-  LABEL_TEXT_X,
-  LABEL_FONT_SIZE,
-} from '@/constants/gameBoardUi';
 
 // 選択表示用の軽量ユーザー型
 type SelectedUser = { userId: string; username: string };
@@ -92,7 +92,7 @@ export default function PartOnGameBoard({
   selectedBy = [],
   selfUser,
   userRoles = [],
-}: PartOnGameBoardProps): JSX.Element {
+}: PartOnGameBoardProps): React.ReactElement {
   const groupRef = useRef<Konva.Group>(null);
   const { isReversing, setIsReversing, reverseCard } = useCard(part);
   const { dispatch } = usePartReducer();

--- a/frontend/src/features/prototype/components/molecules/PartOnGameBoard.tsx
+++ b/frontend/src/features/prototype/components/molecules/PartOnGameBoard.tsx
@@ -31,6 +31,7 @@ import {
   getShadowOffsetX,
   getShadowOffsetY,
 } from '@/features/prototype/utils/partUtils';
+import { getUserColor } from '@/features/prototype/utils/userColor';
 
 interface PartOnGameBoardProps {
   part: Part;
@@ -47,6 +48,7 @@ interface PartOnGameBoardProps {
     partId: number
   ) => void;
   isActive: boolean;
+  selectedBy?: Array<{ userId: string; username: string }>;
   // ユーザー情報
   userRoles?: Array<{
     userId: string;
@@ -67,6 +69,7 @@ export default function PartOnGameBoard({
   onClick,
   onContextMenu,
   isActive = false,
+  selectedBy = [],
   userRoles = [],
 }: PartOnGameBoardProps) {
   const groupRef = useRef<Konva.Group>(null);
@@ -487,6 +490,25 @@ export default function PartOnGameBoard({
         {isDeck && <ShuffleIcon size={20} color="#666" />}
         {isCard && <FlipIcon size={20} color="#666" />}
       </Group>
+
+      {selectedBy.map((user, index) => {
+        const color = getUserColor(user.userId, user.username);
+        const offset = (index + 1) * 3;
+        return (
+          <Rect
+            key={user.userId}
+            x={-offset}
+            y={-offset}
+            width={part.width + offset * 2}
+            height={part.height + offset * 2}
+            stroke={color}
+            strokeWidth={2}
+            cornerRadius={getCornerRadius(part.type)}
+            listening={false}
+            hitStrokeWidth={0}
+          />
+        );
+      })}
 
       {/* デバッグ情報: ID と順序（order） - showDebugInfoがtrueの場合のみ表示 */}
       {showDebugInfo && (

--- a/frontend/src/features/prototype/components/organisms/GameBoard.tsx
+++ b/frontend/src/features/prototype/components/organisms/GameBoard.tsx
@@ -60,6 +60,7 @@ interface GameBoardProps {
     userId: string;
     username: string;
   }>;
+  selectedUsersByPart: Record<number, { userId: string; username: string }[]>;
 }
 
 export default function GameBoard({
@@ -70,6 +71,7 @@ export default function GameBoard({
   propertiesMap,
   gameBoardMode,
   connectedUsers,
+  selectedUsersByPart,
 }: GameBoardProps) {
   const [prototypeName, setPrototypeName] = useState(initialPrototypeName);
   useEffect(() => {
@@ -561,6 +563,7 @@ export default function GameBoard({
               const partProperties = propertiesMap.get(part.id) || [];
               const filteredImages = filteredImagesMap[part.id] || [];
               const isActive = selectedPartIds.includes(part.id);
+              const selectedBy = selectedUsersByPart[part.id] || [];
 
               // カードの表示制御を判定
               const isOtherPlayerHandCard =
@@ -575,6 +578,7 @@ export default function GameBoard({
                   images={filteredImages}
                   gameBoardMode={gameBoardMode}
                   isActive={isActive}
+                  selectedBy={selectedBy}
                   isOtherPlayerHandCard={isOtherPlayerHandCard}
                   userRoles={userRoles}
                   onClick={(e) => handlePartClick(e, part.id)}

--- a/frontend/src/features/prototype/components/organisms/GameBoard.tsx
+++ b/frontend/src/features/prototype/components/organisms/GameBoard.tsx
@@ -61,6 +61,7 @@ interface GameBoardProps {
     username: string;
   }>;
   selectedUsersByPart: Record<number, { userId: string; username: string }[]>;
+  currentUserId: string;
 }
 
 export default function GameBoard({
@@ -72,6 +73,7 @@ export default function GameBoard({
   gameBoardMode,
   connectedUsers,
   selectedUsersByPart,
+  currentUserId,
 }: GameBoardProps) {
   const [prototypeName, setPrototypeName] = useState(initialPrototypeName);
   useEffect(() => {
@@ -94,6 +96,11 @@ export default function GameBoard({
   const { cardVisibilityMap } = useHandVisibility(parts, gameBoardMode);
   // ロール管理情報を取得
   const { userRoles } = useRoleManagement(projectId);
+
+  // 自分のユーザー情報（色付けに使用）
+  const selfUser = useMemo(() => {
+    return connectedUsers.find((u) => u.userId === currentUserId) || null;
+  }, [connectedUsers, currentUserId]);
 
   // 選択中のパーツ、および選択処理
   const {
@@ -579,6 +586,7 @@ export default function GameBoard({
                   gameBoardMode={gameBoardMode}
                   isActive={isActive}
                   selectedBy={selectedBy}
+                  selfUser={selfUser ?? undefined}
                   isOtherPlayerHandCard={isOtherPlayerHandCard}
                   userRoles={userRoles}
                   onClick={(e) => handlePartClick(e, part.id)}

--- a/frontend/src/features/prototype/components/organisms/SocketGameBoard.tsx
+++ b/frontend/src/features/prototype/components/organisms/SocketGameBoard.tsx
@@ -40,6 +40,7 @@ const SocketGameBoard: React.FC<SocketGameBoardProps> = ({
       projectId={projectId}
       gameBoardMode={gameBoardMode}
       connectedUsers={connectedUsers}
+      currentUserId={userId}
       selectedUsersByPart={selectedUsersByPart}
     />
   );

--- a/frontend/src/features/prototype/components/organisms/SocketGameBoard.tsx
+++ b/frontend/src/features/prototype/components/organisms/SocketGameBoard.tsx
@@ -25,10 +25,11 @@ const SocketGameBoard: React.FC<SocketGameBoardProps> = ({
   userId,
   gameBoardMode,
 }) => {
-  const { partsMap, propertiesMap, connectedUsers } = usePrototypeSocket({
-    prototypeId,
-    userId,
-  });
+  const { partsMap, propertiesMap, connectedUsers, selectedUsersByPart } =
+    usePrototypeSocket({
+      prototypeId,
+      userId,
+    });
 
   return (
     <GameBoard
@@ -39,6 +40,7 @@ const SocketGameBoard: React.FC<SocketGameBoardProps> = ({
       projectId={projectId}
       gameBoardMode={gameBoardMode}
       connectedUsers={connectedUsers}
+      selectedUsersByPart={selectedUsersByPart}
     />
   );
 };

--- a/frontend/src/features/prototype/constants/socket.ts
+++ b/frontend/src/features/prototype/constants/socket.ts
@@ -33,6 +33,8 @@ export const PROTOTYPE_SOCKET_EVENT = {
   DELETE_PARTS: 'DELETE_PARTS',
   // 接続中ユーザーリストの更新
   CONNECTED_USERS: 'CONNECTED_USERS',
+  // 他ユーザーのパーツ選択
+  SELECTED_PARTS: 'SELECTED_PARTS',
   // パーツ順序変更
   CHANGE_ORDER: 'CHANGE_ORDER',
   // デッキのシャッフル

--- a/frontend/src/features/prototype/hooks/usePrototypeSocket.ts
+++ b/frontend/src/features/prototype/hooks/usePrototypeSocket.ts
@@ -1,7 +1,7 @@
 /**
  * @page ソケット通信の設定を行うカスタムフック
  */
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { Part, PartProperty } from '@/api/types';
 import {
@@ -31,6 +31,8 @@ interface UsePrototypeSocketReturn {
   propertiesMap: PropertiesMap;
   /** 接続中ユーザーリスト */
   connectedUsers: ConnectedUser[];
+  /** 他ユーザーのパーツ選択 */
+  selectedUsersByPart: Record<number, ConnectedUser[]>;
 }
 
 /*
@@ -53,7 +55,7 @@ export const usePrototypeSocket = ({
   userId,
 }: UsePrototypeSocketProps): UsePrototypeSocketReturn => {
   const { socket } = useSocket();
-  const { selectMultipleParts } = useSelectedParts();
+  const { selectMultipleParts, selectedPartIds } = useSelectedParts();
 
   // パーツをMap管理（O(1)アクセス）
   const [partsMap, setPartsMap] = useState<PartsMap>(new Map());
@@ -61,6 +63,9 @@ export const usePrototypeSocket = ({
   const [propertiesMap, setPropertiesMap] = useState<PropertiesMap>(new Map());
   // 接続中ユーザーリスト
   const [connectedUsers, setConnectedUsers] = useState<ConnectedUser[]>([]);
+  const [otherSelections, setOtherSelections] = useState<
+    Record<string, { username: string; selectedPartIds: number[] }>
+  >({});
 
   // パーツとプロパティをMapに変換する関数
   const convertToMaps = useCallback(
@@ -192,6 +197,21 @@ export const usePrototypeSocket = ({
       }
     );
 
+    socket.on(
+      PROTOTYPE_SOCKET_EVENT.SELECTED_PARTS,
+      ({ userId, username, selectedPartIds }) => {
+        setOtherSelections((prev) => {
+          const next = { ...prev };
+          if (selectedPartIds.length === 0) {
+            delete next[userId];
+          } else {
+            next[userId] = { username, selectedPartIds };
+          }
+          return next;
+        });
+      }
+    );
+
     return () => {
       // イベントリスナーを削除
       // JOIN_PROTOTYPEはemitリスナーを登録しないため、削除不要
@@ -206,14 +226,32 @@ export const usePrototypeSocket = ({
         PROTOTYPE_SOCKET_EVENT.UPDATE_PARTS,
         PROTOTYPE_SOCKET_EVENT.DELETE_PARTS,
         PROTOTYPE_SOCKET_EVENT.CONNECTED_USERS,
+        PROTOTYPE_SOCKET_EVENT.SELECTED_PARTS,
       ];
       events.forEach((event) => socket.off(event));
     };
   }, [prototypeId, userId, convertToMaps, selectMultipleParts, socket]);
 
+  useEffect(() => {
+    if (!socket) return;
+    socket.emit(PROTOTYPE_SOCKET_EVENT.SELECTED_PARTS, { selectedPartIds });
+  }, [selectedPartIds, socket]);
+
+  const selectedUsersByPart = useMemo(() => {
+    const map: Record<number, ConnectedUser[]> = {};
+    Object.entries(otherSelections).forEach(([uid, { username, selectedPartIds }]) => {
+      selectedPartIds.forEach((id) => {
+        if (!map[id]) map[id] = [];
+        map[id].push({ userId: uid, username });
+      });
+    });
+    return map;
+  }, [otherSelections]);
+
   return {
     partsMap,
     propertiesMap,
     connectedUsers,
+    selectedUsersByPart,
   };
 };

--- a/frontend/src/features/prototype/types/socket.ts
+++ b/frontend/src/features/prototype/types/socket.ts
@@ -63,6 +63,16 @@ export type ShuffleDeckAction = {
   payload: ShuffleDeckPayload;
 };
 
+/** パーツ選択共有の送信ペイロード */
+export type SelectedPartsPayload = { selectedPartIds: number[] };
+
+/** パーツ選択共有の受信ペイロード */
+export type SelectedPartsResponse = {
+  userId: string;
+  username: string;
+  selectedPartIds: number[];
+};
+
 /** PartAction: usePartReducer で使われるアクションの型（ソケット送受信用） */
 export type PartAction =
   | AddPartAction

--- a/frontend/src/features/prototype/utils/userColor.ts
+++ b/frontend/src/features/prototype/utils/userColor.ts
@@ -1,0 +1,10 @@
+export function getUserColor(userId: string, username: string): string {
+  const str = `${userId}:${username}`;
+  let hash = 0;
+  for (let i = 0; i < str.length; i++) {
+    hash = str.charCodeAt(i) + ((hash << 5) - hash);
+    hash |= 0; // 32bit
+  }
+  const hue = Math.abs(hash) % 360;
+  return `hsl(${hue}, 70%, 60%)`;
+}


### PR DESCRIPTION
## Summary
- broadcast selected parts per user over sockets
- color remote selections using hashed user id and name
- rename select-parts event to selected-parts

## Testing
- `npm run lint` (backend) *(fails: Cannot find module 'file-type')*
- `npm test` (backend) *(fails: no test specified)*
- `npm run lint` (frontend)
- `npm test` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68b1653b2eb083269364ec8d953af3e5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Real-time display of other users’ selected parts on the game board with per-user colored outlines, right-side username labels, current-user highlighting, and selection resets on join/leave.
  - Deterministic per-user colors for consistent selection coloring across sessions.
  - Prototype real-time selection state exposed to UI (per-part mapping of selecting users).

- Tests
  - Expanded socket hook tests covering SELECTED_PARTS emit, receive, synchronization, and cleanup.

- Chores
  - Internal swagger schema formatting updated (no public API change).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->