### PR TITLE
fix(frontend): make prototype name heading keyboard accessible

### DIFF
--- a/frontend/src/features/prototype/components/atoms/PrototypeNameEditor.tsx
+++ b/frontend/src/features/prototype/components/atoms/PrototypeNameEditor.tsx
@@ -74,20 +74,17 @@ export default function PrototypeNameEditor({
           />
         </form>
       ) : (
-        <h2
-          className="text-xs font-medium truncate text-wood-darkest cursor-pointer px-1 -mx-1 rounded-md hover:bg-wood-lightest transition-colors"
-          title={name}
-          role="button"
-          tabIndex={0}
-          onClick={() => startEditing(prototypeId, name)}
-          onKeyDown={(e) => {
-            if (e.key === 'Enter' || e.key === ' ') {
-              e.preventDefault();
-              startEditing(prototypeId, name);
-            }
-          }}
-        >
-          {name}
+        <h2 className="text-xs font-medium text-wood-darkest">
+          {/* 表示モード（ボタンで編集開始） */}
+          <button
+            type="button"
+            className="w-full text-left truncate cursor-pointer px-1 -mx-1 rounded-md hover:bg-wood-lightest transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-header focus-visible:ring-offset-2 focus-visible:ring-offset-white"
+            title={name}
+            aria-label={`「${name}」を編集`}
+            onClick={() => startEditing(prototypeId, name)}
+          >
+            {name}
+          </button>
         </h2>
       )}
     </div>

--- a/frontend/src/features/prototype/components/atoms/PrototypeNameEditor.tsx
+++ b/frontend/src/features/prototype/components/atoms/PrototypeNameEditor.tsx
@@ -77,7 +77,15 @@ export default function PrototypeNameEditor({
         <h2
           className="text-xs font-medium truncate text-wood-darkest cursor-pointer px-1 -mx-1 rounded-md hover:bg-wood-lightest transition-colors"
           title={name}
+          role="button"
+          tabIndex={0}
           onClick={() => startEditing(prototypeId, name)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+              e.preventDefault();
+              startEditing(prototypeId, name);
+            }
+          }}
         >
           {name}
         </h2>


### PR DESCRIPTION
Summary
- Improve keyboard accessibility of the editable prototype name while preserving heading semantics.

Changes
- Replace `role="button"` + key handlers on the `h2` with a native `button` nested inside the `h2`.
- Keep the `h2` for document outline; the button provides default keyboard support (Enter/Space) without extra handlers.
- Add `focus-visible` ring styles to ensure visible focus per WCAG 2.4.7.

Why
- Using `role="button"` on a heading alters semantics and requires extra key handling. A native button retains expected keyboard behavior and keeps the heading in the document outline for assistive tech.

UX Notes
- Full-width, text-left button keeps the same look and hover behavior; adds a clear focus indicator when tabbed.
- `aria-label` clarifies the action (edit the given name).

Testing
- Tabbing reaches the control; Enter/Space starts editing.
- Mouse click still starts editing.

Risk
- Low. Changes are localized to the heading control.

Affected Files
- `frontend/src/features/prototype/components/atoms/PrototypeNameEditor.tsx`

Checklist
- [x] Conventional Commits used
- [x] Heading semantics preserved
- [x] Focus indicator added
- [ ] CI green on PR