### PR TITLE
feat: lock parts during active selection

### DIFF
--- a/frontend/src/features/prototype/components/molecules/PartOnGameBoard.tsx
+++ b/frontend/src/features/prototype/components/molecules/PartOnGameBoard.tsx
@@ -364,12 +364,10 @@ export default function PartOnGameBoard({
     // ロック中や非ドラッグ対象はここで停止
     if (!isDraggable) {
       e.cancelBubble = true;
-      // 既にドラッグが開始された場合は停止
-      try {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (e.target as any).stopDrag?.();
-      } catch (_) {
-        // noop
+      // 既にドラッグが開始された場合は停止（Konva 型で安全に扱う）
+      const node = e.target as Konva.Node;
+      if (node.isDragging()) {
+        node.stopDrag();
       }
       return;
     }

--- a/frontend/src/features/prototype/components/organisms/GameBoard.tsx
+++ b/frontend/src/features/prototype/components/organisms/GameBoard.tsx
@@ -139,7 +139,12 @@ export default function GameBoard({
   } = useSelection({
     stageRef,
     parts,
-    onPartsSelected: selectMultipleParts,
+    onPartsSelected: (ids) => {
+      const selectable = ids.filter((id) => !selectedUsersByPart[id]);
+      if (selectable.length > 0) {
+        selectMultipleParts(selectable);
+      }
+    },
     onClearSelection: clearSelection,
   });
   // ドラッグ機能
@@ -178,6 +183,9 @@ export default function GameBoard({
     // 左クリックのみContextMenuを閉じる
     if ((e.evt as MouseEvent).button === 0) {
       handleCloseContextMenu();
+    }
+    if (selectedUsersByPart[partId] && !selectedPartIds.includes(partId)) {
+      return;
     }
     const isShift = (e.evt as MouseEvent).shiftKey;
     if (isShift) {

--- a/frontend/src/features/prototype/hooks/__tests__/usePrototypeSocket.test.ts
+++ b/frontend/src/features/prototype/hooks/__tests__/usePrototypeSocket.test.ts
@@ -399,5 +399,32 @@ describe('usePrototypeSocket', () => {
         { userId: 'other', username: 'Other User' },
       ]);
     });
+
+    it('一定時間更新が無い選択は自動的にクリアされる', () => {
+      jest.useFakeTimers();
+      const { result } = renderHook(() => usePrototypeSocket(defaultProps));
+
+      const selectedPartsCallback = getEventCallback(
+        mockSocket.on as jest.Mock,
+        PROTOTYPE_SOCKET_EVENT.SELECTED_PARTS
+      );
+
+      act(() => {
+        selectedPartsCallback!({
+          userId: 'other',
+          username: 'Other User',
+          selectedPartIds: [5],
+        });
+      });
+
+      expect(result.current.selectedUsersByPart[5]).toBeDefined();
+
+      act(() => {
+        jest.advanceTimersByTime(1600);
+      });
+
+      expect(result.current.selectedUsersByPart[5]).toBeUndefined();
+      jest.useRealTimers();
+    });
   });
 });


### PR DESCRIPTION
## Summary
- prevent selecting parts currently claimed by other users
- expire remote selections quickly to avoid stale locks
- add test for selection lock expiration

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b4068f923c83269d6437a7f82d593b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Collaborative locking: parts selected by others are treated as locked; dragging and selection are blocked.
  - Stale remote selections auto-clear after short inactivity, keeping the board current.
- Bug Fixes
  - Prevents drag initiation on non-draggable parts and for areas in PLAY mode.
  - Clicks on parts owned by other users are ignored to avoid unintended actions.
- Tests
  - Added a unit test verifying time-based auto-clearing of remote selections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->