### PR TITLE
fix: avoid innerHTML for part tooltip

### DIFF
--- a/frontend/src/features/prototype/hooks/usePartTooltip.ts
+++ b/frontend/src/features/prototype/hooks/usePartTooltip.ts
@@ -98,10 +98,18 @@ export const usePartTooltip = ({
       tooltip.style.left = `${tooltipPosition.x + 10}px`;
       tooltip.style.top = `${tooltipPosition.y - 10}px`;
 
-      tooltip.innerHTML = `
-        <div class="text-xs font-semibold text-wood-darkest mb-1">${partInfo.name}</div>
-        <div class="text-xs text-wood-dark leading-relaxed">${partInfo.description}</div>
-      `;
+      // パーツ名をテキストノードで設定
+      const nameEl = document.createElement('div');
+      nameEl.className = 'text-xs font-semibold text-wood-darkest mb-1';
+      nameEl.textContent = partInfo.name;
+
+      // パーツ説明をテキストノードで設定
+      const descEl = document.createElement('div');
+      descEl.className = 'text-xs text-wood-dark leading-relaxed';
+      descEl.textContent = partInfo.description;
+
+      tooltip.appendChild(nameEl);
+      tooltip.appendChild(descEl);
 
       tooltipContainer.appendChild(tooltip);
     } catch (error) {


### PR DESCRIPTION
## Summary
- prevent potential XSS in part tooltip by constructing DOM nodes instead of using innerHTML

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b40aee92408326b99be1a029981299