### PR TITLE
refactor: abstract button styles with cva

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,6 +11,7 @@
         "@radix-ui/react-context-menu": "^2.2.4",
         "@tanstack/react-query": "^5.85.3",
         "axios": "^1.7.8",
+        "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "framer-motion": "^12.11.0",
         "idb": "^8.0.2",
@@ -4422,6 +4423,18 @@
       "integrity": "sha512-UX0OwmYRYQQetfrLEZeewIFFI+wSTofC+pMBLNuH3RUuu/xzG1oz84UCEDOSoQlN3fZ4+AzmV50ZYvGqkMh9yA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/class-variance-authority": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz",
+      "integrity": "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "clsx": "^2.1.1"
+      },
+      "funding": {
+        "url": "https://polar.sh/cva"
+      }
     },
     "node_modules/client-only": {
       "version": "0.0.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,6 +17,7 @@
     "@radix-ui/react-context-menu": "^2.2.4",
     "@tanstack/react-query": "^5.85.3",
     "axios": "^1.7.8",
+    "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "framer-motion": "^12.11.0",
     "idb": "^8.0.2",

--- a/frontend/src/components/atoms/Button.tsx
+++ b/frontend/src/components/atoms/Button.tsx
@@ -1,12 +1,36 @@
+import { cva, type VariantProps } from 'class-variance-authority';
 import Link from 'next/link';
 import { ButtonHTMLAttributes, ReactNode } from 'react';
 import { twMerge } from 'tailwind-merge';
 
-interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+const buttonStyles = cva(
+  'inline-block rounded-full font-semibold transition-colors',
+  {
+    variants: {
+      variant: {
+        primary:
+          'bg-kibako-primary text-kibako-white hover:bg-kibako-primary/80',
+        accent: 'bg-kibako-accent text-kibako-white hover:bg-kibako-accent/80',
+        outline:
+          'bg-transparent text-kibako-primary/70 hover:text-kibako-primary border border-kibako-primary/30 hover:border-kibako-primary/50',
+      },
+      size: {
+        sm: 'px-6 py-3 text-base',
+        md: 'px-8 py-4 text-lg',
+        lg: 'px-10 py-5 text-xl',
+      },
+    },
+    defaultVariants: {
+      variant: 'primary',
+      size: 'md',
+    },
+  },
+);
+
+interface ButtonProps
+  extends ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonStyles> {
   children: ReactNode;
-  variant?: 'primary' | 'accent' | 'outline';
-  size?: 'sm' | 'md' | 'lg';
-  type?: 'button' | 'submit' | 'reset';
   href?: string;
   className?: string;
   isLoading?: boolean;
@@ -14,32 +38,17 @@ interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
 
 export default function Button({
   children,
-  variant = 'primary',
-  size = 'md',
+  variant,
+  size,
   type = 'button',
   href,
   className = '',
   isLoading = false,
   ...props
 }: ButtonProps) {
-  const baseStyles =
-    'inline-block rounded-full font-semibold transition-colors';
-
-  const variants = {
-    primary: 'bg-kibako-primary text-kibako-white hover:bg-kibako-primary/80',
-    accent: 'bg-kibako-accent text-kibako-white hover:bg-kibako-accent/80',
-    outline:
-      'bg-transparent text-kibako-primary/70 hover:text-kibako-primary border border-kibako-primary/30 hover:border-kibako-primary/50',
-  };
-
-  const sizes = {
-    sm: 'px-6 py-3 text-base',
-    md: 'px-8 py-4 text-lg',
-    lg: 'px-10 py-5 text-xl',
-  };
-
   const buttonClasses = twMerge(
-    [baseStyles, variants[variant], sizes[size], className].join(' ')
+    buttonStyles({ variant, size }),
+    className,
   );
 
   return isLoading ? (


### PR DESCRIPTION
## Summary
- abstract Button styling with class-variance-authority
- default Button type to `button`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b440730dd88326976a2f45b33c75f2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None.

- Refactor
  - Unified Button styling using a variant-based system for more consistent appearance across primary, accent, and outline variants and sm/md/lg sizes. Existing behavior, including loading and link support, remains unchanged.

- Chores
  - Added a new styling utility dependency to support the variant-based Button implementation.

- Style
  - Improved consistency of Button styles by centralizing variant and size handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->