### PR TITLE
chore: unify color palette across components

### DIFF
--- a/frontend/src/components/molecules/HeaderRightMenu.tsx
+++ b/frontend/src/components/molecules/HeaderRightMenu.tsx
@@ -76,7 +76,7 @@ const HeaderRightMenu: React.FC<HeaderRightMenuProps> = ({ pathname }) => {
     return (
       <Link
         href="/login"
-        className="px-4 py-2 bg-kibako-primary text-white rounded-lg hover:bg-kibako-primary/90 hover:scale-105 transition-all duration-200 shadow-md hover:shadow-lg active:scale-95"
+        className="px-4 py-2 bg-kibako-primary text-kibako-white rounded-lg hover:bg-kibako-primary/90 hover:scale-105 transition-all duration-200 shadow-md hover:shadow-lg active:scale-95"
       >
         ログイン
       </Link>

--- a/frontend/src/features/profile/components/ProfileEdit.tsx
+++ b/frontend/src/features/profile/components/ProfileEdit.tsx
@@ -129,7 +129,7 @@ const ProfileEdit: React.FC = () => {
               value={username}
               onChange={(e) => setUsername(e.target.value)}
               placeholder="ユーザー名を入力"
-              className="py-2 px-3 border border-kibako-secondary/30 rounded-lg bg-white w-full"
+              className="py-2 px-3 border border-kibako-secondary/30 rounded-lg bg-kibako-white w-full"
               maxLength={50}
               autoFocus
             />
@@ -138,20 +138,20 @@ const ProfileEdit: React.FC = () => {
           <div className="flex justify-end">
             <button
               type="submit"
-              className="flex items-center gap-1 px-4 py-2 rounded-md bg-kibako-secondary hover:bg-kibako-primary text-white hover:shadow-md transition-all font-medium"
+              className="flex items-center gap-1 px-4 py-2 rounded-md bg-kibako-secondary hover:bg-kibako-primary text-kibako-white hover:shadow-md transition-all font-medium"
             >
               <FaCheck className="w-4 h-4" />
               更新する
             </button>
           </div>
           {error && (
-            <div className="text-red-600 text-sm bg-red-50 p-2 rounded-md border border-red-100">
+            <div className="text-kibako-danger text-sm bg-kibako-danger/10 p-2 rounded-md border border-kibako-danger/10">
               {error}
             </div>
           )}
 
           {success && (
-            <div className="text-green-600 text-sm bg-green-50 p-2 rounded-md border border-green-100">
+            <div className="text-kibako-success text-sm bg-kibako-success/10 p-2 rounded-md border border-kibako-success/10">
               {success}
             </div>
           )}

--- a/frontend/src/features/prototype/components/atoms/DebugInfo.tsx
+++ b/frontend/src/features/prototype/components/atoms/DebugInfo.tsx
@@ -63,14 +63,14 @@ const DebugInfo: React.FC<DebugInfoProps> = ({
       case 'info':
         return (
           <div className="text-sm h-[50vh] overflow-y-auto">
-            <div className="border-b border-white border-opacity-20 mb-2 pb-1">
+            <div className="border-b border-kibako-white border-opacity-20 mb-2 pb-1">
               <strong>Current Status</strong>
             </div>
             <div className="mb-1.5">
               <span className="font-bold">Mode:</span> {mode}
             </div>
             <div
-              className={`font-bold mb-1.5 ${selectedPartIds.length ? 'text-yellow-400' : 'text-white'}`}
+              className={`font-bold mb-1.5 ${selectedPartIds.length ? 'text-yellow-400' : 'text-kibako-white'}`}
             >
               Selected Parts: {selectedPartIds.length}
             </div>
@@ -80,7 +80,7 @@ const DebugInfo: React.FC<DebugInfoProps> = ({
               </div>
             )}
 
-            <div className="border-b border-white border-opacity-20 mt-3 mb-2 pb-1">
+            <div className="border-b border-kibako-white border-opacity-20 mt-3 mb-2 pb-1">
               <strong>Camera</strong>
             </div>
             <div className="mb-1">
@@ -104,7 +104,7 @@ const DebugInfo: React.FC<DebugInfoProps> = ({
             </div>
             <div>Zoom: {camera.scale.toFixed(2)}x</div>
 
-            <div className="border-b border-white border-opacity-20 mt-3 mb-2 pb-1">
+            <div className="border-b border-kibako-white border-opacity-20 mt-3 mb-2 pb-1">
               <strong>Prototype</strong>
             </div>
             <div>Name: {prototypeName}</div>
@@ -115,7 +115,7 @@ const DebugInfo: React.FC<DebugInfoProps> = ({
       case 'perf':
         return (
           <div className="text-sm h-[50vh] overflow-y-auto">
-            <div className="border-b border-white border-opacity-20 mb-2 pb-1">
+            <div className="border-b border-kibako-white border-opacity-20 mb-2 pb-1">
               <strong>Performance</strong>
             </div>
 
@@ -179,7 +179,7 @@ const DebugInfo: React.FC<DebugInfoProps> = ({
                   {Object.entries(performanceMetrics).map(([op, metric]) => (
                     <div
                       key={op}
-                      className="mb-1 border border-white border-opacity-10 p-0.5 rounded-sm"
+                      className="mb-1 border border-kibako-white border-opacity-10 p-0.5 rounded-sm"
                     >
                       <div className="font-bold">{op}</div>
                       <div className="ml-2">
@@ -196,7 +196,7 @@ const DebugInfo: React.FC<DebugInfoProps> = ({
                 </div>
                 <button
                   onClick={resetMetrics}
-                  className="bg-white bg-opacity-20 border border-white border-opacity-30 text-white px-1.5 py-0.5 rounded text-[10px] cursor-pointer mt-1 hover:bg-opacity-30 transition-colors"
+                  className="bg-kibako-white bg-opacity-20 border border-kibako-white border-opacity-30 text-kibako-white px-1.5 py-0.5 rounded text-[10px] cursor-pointer mt-1 hover:bg-opacity-30 transition-colors"
                 >
                   Reset Metrics
                 </button>
@@ -208,7 +208,7 @@ const DebugInfo: React.FC<DebugInfoProps> = ({
       case 'data':
         return (
           <div className="text-sm h-[50vh] overflow-y-auto">
-            <div className="border-b border-white border-opacity-20 mb-2 pb-1">
+            <div className="border-b border-kibako-white border-opacity-20 mb-2 pb-1">
               <strong>Data Overview</strong>
             </div>
             <div className="mb-2">
@@ -270,7 +270,7 @@ const DebugInfo: React.FC<DebugInfoProps> = ({
                     return (
                       <div
                         key={`part-${index}`}
-                        className="mb-2 border border-white border-opacity-10 p-1 rounded-sm"
+                        className="mb-2 border border-kibako-white border-opacity-10 p-1 rounded-sm"
                       >
                         <div className="font-bold text-blue-300">
                           ID: {part.id} | Type: {part.type}
@@ -303,14 +303,14 @@ const DebugInfo: React.FC<DebugInfoProps> = ({
 
                         {/* このパーツのプロパティ */}
                         {partProperties.length > 0 && (
-                          <div className="mt-2 border-t border-white border-opacity-10 pt-1">
+                          <div className="mt-2 border-t border-kibako-white border-opacity-10 pt-1">
                             <div className="text-yellow-300 font-bold text-[10px]">
                               Properties ({partProperties.length}):
                             </div>
                             {partProperties.map((prop, propIndex) => (
                               <div
                                 key={`prop-${propIndex}`}
-                                className="ml-2 mt-1 text-[10px] border-l border-white border-opacity-10 pl-1"
+                                className="ml-2 mt-1 text-[10px] border-l border-kibako-white border-opacity-10 pl-1"
                               >
                                 <div className="text-green-300">
                                   Side: {prop.side}
@@ -347,9 +347,9 @@ const DebugInfo: React.FC<DebugInfoProps> = ({
   };
 
   return (
-    <div className="fixed bottom-4 left-4 bg-black bg-opacity-80 text-white p-2.5 rounded-md font-mono text-sm z-[1000] w-96 max-h-[80vh] flex flex-col">
+    <div className="fixed bottom-4 left-4 bg-kibako-black/80 text-kibako-white p-2.5 rounded-md font-mono text-sm z-[1000] w-96 max-h-[80vh] flex flex-col">
       {/* タブヘッダー */}
-      <div className="flex border-b border-white border-opacity-20 mb-2">
+      <div className="flex border-b border-kibako-white border-opacity-20 mb-2">
         {TABS.map((tab) => (
           <button
             key={tab.id}
@@ -357,7 +357,7 @@ const DebugInfo: React.FC<DebugInfoProps> = ({
             className={`flex-1 px-1 py-1 text-[11px] cursor-pointer transition-colors text-center ${
               activeTab === tab.id
                 ? 'text-blue-400 border-b-2 border-blue-400'
-                : 'text-white text-opacity-70 hover:text-opacity-100'
+                : 'text-kibako-white text-opacity-70 hover:text-opacity-100'
             }`}
           >
             {tab.label}
@@ -368,7 +368,7 @@ const DebugInfo: React.FC<DebugInfoProps> = ({
       {/* タブコンテンツ */}
       <div className="flex-1 overflow-y-auto">{renderTabContent()}</div>
 
-      <div className="text-[11px] mt-2 pt-2 border-t border-white border-opacity-20">
+      <div className="text-[11px] mt-2 pt-2 border-t border-kibako-white border-opacity-20">
         Press Cmd+i (Mac) or Ctrl+i (Windows) to toggle debug panel
       </div>
     </div>

--- a/frontend/src/features/prototype/components/atoms/ProjectContextMenu.tsx
+++ b/frontend/src/features/prototype/components/atoms/ProjectContextMenu.tsx
@@ -80,7 +80,7 @@ export const ProjectContextMenu: React.FC<ProjectContextMenuProps> = ({
   return (
     <div
       ref={menuRef}
-      className="absolute bg-white border border-gray-200 rounded-lg shadow-lg py-1"
+      className="absolute bg-kibako-white border border-kibako-secondary/20 rounded-lg shadow-lg py-1"
       style={{
         left: position.x + window.scrollX,
         top: position.y + window.scrollY,
@@ -93,11 +93,11 @@ export const ProjectContextMenu: React.FC<ProjectContextMenuProps> = ({
         <button
           key={item.id}
           className={`w-full px-4 text-left flex items-center gap-2 transition-colors ${
-            hoveredMenuItem === item.id ? 'bg-gray-100' : 'hover:bg-gray-100'
+            hoveredMenuItem === item.id ? 'bg-kibako-tertiary/20' : 'hover:bg-kibako-tertiary/20'
           } ${
             item.danger
-              ? 'text-red-600 hover:text-red-700'
-              : 'text-gray-700 hover:text-gray-900'
+              ? 'text-kibako-danger hover:text-kibako-danger/80'
+              : 'text-kibako-primary hover:text-kibako-primary/80'
           }`}
           style={{
             height: `${itemHeight}px`,

--- a/frontend/src/features/prototype/components/atoms/PrototypeNameEditor.tsx
+++ b/frontend/src/features/prototype/components/atoms/PrototypeNameEditor.tsx
@@ -69,7 +69,7 @@ export default function PrototypeNameEditor({
             onChange={(e) => setEditedValue(e.target.value)}
             onBlur={() => handleBlur(handleComplete, validate)}
             onKeyDown={(e) => handleKeyDown(e, handleComplete, validate)}
-            className="w-full text-kibako-primary font-medium bg-transparent border border-transparent rounded-md px-1 -mx-1 focus:outline-none focus:bg-white focus:border-kibako-primary focus:shadow-sm transition-all text-xs"
+            className="w-full text-kibako-primary font-medium bg-transparent border border-transparent rounded-md px-1 -mx-1 focus:outline-none focus:bg-kibako-white focus:border-kibako-primary focus:shadow-sm transition-all text-xs"
             autoFocus
           />
         </form>
@@ -78,7 +78,7 @@ export default function PrototypeNameEditor({
           {/* 表示モード（ボタンで編集開始） */}
           <button
             type="button"
-            className="w-full text-left truncate cursor-pointer px-1 -mx-1 rounded-md hover:bg-kibako-tertiary transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-kibako-primary focus-visible:ring-offset-2 focus-visible:ring-offset-white"
+            className="w-full text-left truncate cursor-pointer px-1 -mx-1 rounded-md hover:bg-kibako-tertiary transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-kibako-primary focus-visible:ring-offset-2 focus-visible:ring-offset-kibako-white"
             title={name}
             aria-label={`「${name}」を編集`}
             onClick={() => startEditing(prototypeId, name)}

--- a/frontend/src/features/prototype/components/molecules/GameBoardHelpPanel.tsx
+++ b/frontend/src/features/prototype/components/molecules/GameBoardHelpPanel.tsx
@@ -60,7 +60,7 @@ export default function GameBoardHelpPanel({
           aria-label={isExpanded ? 'ヘルプを閉じる' : 'ヘルプを開く'}
           title="操作ヘルプ (Shift+?)"
         >
-          <IoInformationCircleOutline className="h-4 w-4 text-white" />
+          <IoInformationCircleOutline className="h-4 w-4 text-kibako-white" />
         </button>
 
         {isExpanded && (

--- a/frontend/src/features/prototype/components/molecules/PartCreateMenu.tsx
+++ b/frontend/src/features/prototype/components/molecules/PartCreateMenu.tsx
@@ -243,15 +243,15 @@ export default function PartCreateMenu({
               title={`${partType.name}を作成`}
             >
               {creatingPartType === partType.type ? (
-                <div className="w-5 h-5 border-2 border-white border-t-transparent rounded-full animate-spin" />
+                <div className="w-5 h-5 border-2 border-kibako-white border-t-transparent rounded-full animate-spin" />
               ) : (
                 <PartTypeIcon
                   type={partType.type}
-                  className="h-5 w-5 text-white"
+                  className="h-5 w-5 text-kibako-white"
                   ariaHidden
                 />
               )}
-              <div className="absolute -top-10 left-1/2 transform -translate-x-1/2 bg-kibako-primary text-white text-xs px-2 py-1 rounded whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity duration-200 pointer-events-none">
+              <div className="absolute -top-10 left-1/2 transform -translate-x-1/2 bg-kibako-primary text-kibako-white text-xs px-2 py-1 rounded whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity duration-200 pointer-events-none">
                 {creatingPartType === partType.type
                   ? '作成中...'
                   : partType.name}

--- a/frontend/src/features/prototype/components/molecules/PlaySidebar.tsx
+++ b/frontend/src/features/prototype/components/molecules/PlaySidebar.tsx
@@ -122,8 +122,8 @@ export default function PlaySidebar({
                 key={hand.id}
                 className={`p-2 rounded border cursor-pointer transition-colors ${
                   selectedHandId === hand.id
-                    ? 'border-blue-500 bg-blue-50'
-                    : 'border-gray-200 hover:border-gray-300'
+                    ? 'border-kibako-info bg-kibako-info/10'
+                    : 'border-kibako-secondary/20 hover:border-kibako-secondary/30'
                 }`}
                 onClick={() => {
                   clearSelection();
@@ -137,8 +137,8 @@ export default function PlaySidebar({
                     <span
                       className={`text-xs ${
                         isOwnHand
-                          ? 'bg-green-100 text-green-800'
-                          : 'bg-blue-100 text-blue-800'
+                          ? 'bg-kibako-success/10 text-kibako-success/80'
+                          : 'bg-kibako-info/10 text-kibako-info/80'
                       } px-1 rounded`}
                     >
                       {hand.ownerName}の手札
@@ -152,10 +152,10 @@ export default function PlaySidebar({
 
         {/* 手札設定情報 */}
         {selectedHand && (
-          <div className="border-t border-gray-200 pt-4 mt-4">
+          <div className="border-t border-kibako-secondary/20 pt-4 mt-4">
             <span className="mb-2 text-xs font-bold">手札設定</span>
             <div className="space-y-3">
-              <div className="text-xs text-gray-600">
+              <div className="text-xs text-kibako-primary/70">
                 <div>所有者: {selectedHand.ownerName || '未設定'}</div>
                 <div>上のカード: {selectedHandCardCount}枚</div>
               </div>
@@ -173,7 +173,7 @@ export default function PlaySidebar({
                       },
                     });
                   }}
-                  className="px-3 py-1 text-xs bg-blue-500 text-white rounded hover:bg-blue-600"
+                  className="px-3 py-1 text-xs bg-kibako-info text-kibako-white rounded hover:bg-kibako-info/80"
                 >
                   自分を設定
                 </button>
@@ -187,7 +187,7 @@ export default function PlaySidebar({
                       },
                     });
                   }}
-                  className="px-3 py-1 text-xs bg-gray-500 text-white rounded hover:bg-gray-600"
+                  className="px-3 py-1 text-xs bg-kibako-secondary text-kibako-white rounded hover:bg-kibako-secondary/80"
                 >
                   クリア
                 </button>

--- a/frontend/src/features/prototype/components/molecules/ProjectCard.tsx
+++ b/frontend/src/features/prototype/components/molecules/ProjectCard.tsx
@@ -104,7 +104,7 @@ export const ProjectCard: React.FC<ProjectCardProps> = ({
                     alert(error.message || 'エラーが発生しました');
                   })
                 }
-                className="w-full text-kibako-primary font-semibold bg-transparent border border-transparent rounded-md p-1 -m-1 focus:outline-none focus:bg-white focus:border-kibako-primary focus:shadow-sm transition-all text-base"
+                className="w-full text-kibako-primary font-semibold bg-transparent border border-transparent rounded-md p-1 -m-1 focus:outline-none focus:bg-kibako-white focus:border-kibako-primary focus:shadow-sm transition-all text-base"
                 autoFocus
               />
             </form>

--- a/frontend/src/features/prototype/components/molecules/ZoomToolbar.tsx
+++ b/frontend/src/features/prototype/components/molecules/ZoomToolbar.tsx
@@ -25,11 +25,11 @@ export default function ZoomToolbar({
   const zoomPercentage = Math.floor(zoomValue * 100);
 
   return (
-    <div className="fixed bottom-4 right-4 z-20 flex items-center justify-center rounded-xl bg-white shadow-lg border border-gray-200 p-2">
+    <div className="fixed bottom-4 right-4 z-20 flex items-center justify-center rounded-xl bg-kibako-white shadow-lg border border-kibako-secondary/20 p-2">
       <div className="flex items-center justify-center gap-2">
         <div className="flex items-center justify-center">
           <ZoomOutButton onClick={zoomOut} disabled={!canZoomOut} />
-          <div className="mx-3 px-3 py-1 text-sm font-semibold text-gray-800 bg-gray-50 rounded-lg min-w-[50px] text-center border border-gray-200">
+          <div className="mx-3 px-3 py-1 text-sm font-semibold text-kibako-primary bg-kibako-tertiary/20 rounded-lg min-w-[50px] text-center border border-kibako-secondary/20">
             {`${zoomPercentage}`}%
           </div>
           <ZoomInButton onClick={zoomIn} disabled={!canZoomIn} />

--- a/frontend/src/features/prototype/components/organisms/DeletePrototypeConfirmation.tsx
+++ b/frontend/src/features/prototype/components/organisms/DeletePrototypeConfirmation.tsx
@@ -63,7 +63,7 @@ const DeletePrototypeConfirmation = () => {
 
   if (isLoading) {
     return (
-      <div className="max-w-3xl mx-auto mt-16 p-8 bg-white rounded-xl shadow-lg">
+      <div className="max-w-3xl mx-auto mt-16 p-8 bg-kibako-white rounded-xl shadow-lg">
         <div className="animate-pulse flex flex-col space-y-4">
           <div className="h-8 bg-slate-200 rounded w-1/2"></div>
           <div className="h-4 bg-slate-200 rounded w-3/4"></div>
@@ -76,11 +76,11 @@ const DeletePrototypeConfirmation = () => {
 
   if (error) {
     return (
-      <div className="max-w-3xl mx-auto mt-16 p-8 bg-white rounded-xl shadow-lg">
-        <div className="text-red-500 mb-4">{error}</div>
+      <div className="max-w-3xl mx-auto mt-16 p-8 bg-kibako-white rounded-xl shadow-lg">
+        <div className="text-kibako-danger mb-4">{error}</div>
         <button
           onClick={() => router.back()}
-          className="px-4 py-2 bg-gray-200 rounded-md hover:bg-gray-300 transition-colors"
+          className="px-4 py-2 bg-kibako-secondary/20 rounded-md hover:bg-kibako-secondary/30 transition-colors"
         >
           戻る
         </button>
@@ -90,14 +90,14 @@ const DeletePrototypeConfirmation = () => {
 
   if (!project) {
     return (
-      <div className="max-w-3xl mx-auto mt-16 p-8 bg-white rounded-xl shadow-lg">
-        <div className="text-center text-gray-600">
+      <div className="max-w-3xl mx-auto mt-16 p-8 bg-kibako-white rounded-xl shadow-lg">
+        <div className="text-center text-kibako-primary/70">
           プロジェクトが見つかりません
         </div>
         <div className="mt-4 text-center">
           <button
             onClick={() => router.push('/projects')}
-            className="px-4 py-2 bg-gray-200 rounded-md hover:bg-gray-300 transition-colors"
+            className="px-4 py-2 bg-kibako-secondary/20 rounded-md hover:bg-kibako-secondary/30 transition-colors"
           >
             プロジェクト一覧へ戻る
           </button>
@@ -107,11 +107,11 @@ const DeletePrototypeConfirmation = () => {
   }
 
   return (
-    <div className="max-w-3xl mx-auto mt-16 p-8 bg-white rounded-xl shadow-lg">
+    <div className="max-w-3xl mx-auto mt-16 p-8 bg-kibako-white rounded-xl shadow-lg">
       <div className="mb-6">
         <button
           onClick={() => router.back()}
-          className="p-2 hover:bg-gray-100 rounded-full transition-colors"
+          className="p-2 hover:bg-kibako-tertiary/20 rounded-full transition-colors"
           title="戻る"
         >
           <IoArrowBack className="h-5 w-5 text-kibako-primary hover:text-kibako-primary transition-colors" />
@@ -119,10 +119,10 @@ const DeletePrototypeConfirmation = () => {
       </div>
 
       <div className="text-center mb-6">
-        <h1 className="text-2xl font-bold text-red-600 mb-2">
+        <h1 className="text-2xl font-bold text-kibako-danger mb-2">
           プロジェクトを削除
         </h1>
-        <div className="bg-red-50 rounded-lg p-4 text-red-800 mb-6">
+        <div className="bg-kibako-danger/10 rounded-lg p-4 text-kibako-danger/80 mb-6">
           <p className="mb-2">
             <span className="font-bold">警告:</span> 削除操作は取り消せません。
           </p>
@@ -130,10 +130,10 @@ const DeletePrototypeConfirmation = () => {
         </div>
       </div>
 
-      <div className="bg-gray-50 p-6 rounded-lg mb-8 border border-gray-200">
+      <div className="bg-kibako-tertiary/20 p-6 rounded-lg mb-8 border border-kibako-secondary/20">
         <h2 className="text-xl font-semibold mb-4">削除するプロジェクト</h2>
         <div className="mb-4">
-          <div className="text-sm text-gray-500">プロジェクト名</div>
+          <div className="text-sm text-kibako-primary/60">プロジェクト名</div>
           <div className="text-lg font-medium">{masterPrototype?.name}</div>
         </div>
       </div>
@@ -141,19 +141,19 @@ const DeletePrototypeConfirmation = () => {
       <div className="flex justify-between gap-4">
         <button
           onClick={() => router.back()}
-          className="flex-1 py-3 px-6 bg-gray-200 rounded-lg hover:bg-gray-300 transition-colors font-medium"
+          className="flex-1 py-3 px-6 bg-kibako-secondary/20 rounded-lg hover:bg-kibako-secondary/30 transition-colors font-medium"
           disabled={isDeleting}
         >
           キャンセル
         </button>
         <button
           onClick={handleDelete}
-          className="flex-1 py-3 px-6 bg-red-600 text-white rounded-lg hover:bg-red-700 transition-colors font-medium flex items-center justify-center gap-2 disabled:opacity-70 disabled:cursor-not-allowed"
+          className="flex-1 py-3 px-6 bg-kibako-danger text-kibako-white rounded-lg hover:bg-kibako-danger/80 transition-colors font-medium flex items-center justify-center gap-2 disabled:opacity-70 disabled:cursor-not-allowed"
           disabled={isDeleting}
         >
           {isDeleting ? (
             <>
-              <div className="w-5 h-5 border-2 border-white/30 border-t-white rounded-full animate-spin"></div>
+              <div className="w-5 h-5 border-2 border-kibako-white/30 border-t-kibako-white rounded-full animate-spin"></div>
               削除中...
             </>
           ) : (

--- a/frontend/src/features/prototype/components/organisms/ProjectList.tsx
+++ b/frontend/src/features/prototype/components/organisms/ProjectList.tsx
@@ -292,7 +292,7 @@ const ProjectList: React.FC = () => {
             disabled={!!isFetching}
             aria-label="プロジェクト一覧を最新化"
             title="プロジェクト一覧を最新化"
-            className={`inline-flex items-center justify-center w-10 h-10 bg-white text-kibako-primary rounded-xl shadow-sm focus:outline-none focus:ring-2 focus:ring-kibako-primary transition-all duration-300 transform z-50
+            className={`inline-flex items-center justify-center w-10 h-10 bg-kibako-white text-kibako-primary rounded-xl shadow-sm focus:outline-none focus:ring-2 focus:ring-kibako-primary transition-all duration-300 transform z-50
               ${isFetching ? 'opacity-80 cursor-not-allowed' : 'hover:scale-105'}`}
           >
             <IoReload
@@ -320,7 +320,7 @@ const ProjectList: React.FC = () => {
           <button
             onClick={handleCreatePrototype}
             disabled={isCreating}
-            className={`inline-flex items-center gap-2 h-12 px-4 bg-white text-kibako-primary font-bold rounded-xl shadow-lg transition-all duration-300 transform z-50
+            className={`inline-flex items-center gap-2 h-12 px-4 bg-kibako-white text-kibako-primary font-bold rounded-xl shadow-lg transition-all duration-300 transform z-50
           ${isCreating ? 'opacity-80 cursor-not-allowed' : 'hover:shadow-xl hover:scale-105'}`}
             title={isCreating ? '作成中...' : '新しいプロジェクトを作成'}
           >

--- a/frontend/src/features/role/components/atoms/RoleBadge.tsx
+++ b/frontend/src/features/role/components/atoms/RoleBadge.tsx
@@ -17,29 +17,29 @@ const RoleBadge: React.FC<RoleBadgeProps> = ({
       case 'admin':
         return {
           icon: <FaUserShield className="h-3 w-3" />,
-          bgColor: 'bg-red-100',
-          textColor: 'text-red-700',
+          bgColor: 'bg-kibako-danger/10',
+          textColor: 'text-kibako-danger/80',
           label: 'Admin',
         };
       case 'editor':
         return {
           icon: <FaEdit className="h-3 w-3" />,
-          bgColor: 'bg-blue-100',
-          textColor: 'text-blue-700',
+          bgColor: 'bg-kibako-info/10',
+          textColor: 'text-kibako-info/80',
           label: 'Editor',
         };
       case 'viewer':
         return {
           icon: <FaEye className="h-3 w-3" />,
-          bgColor: 'bg-gray-100',
-          textColor: 'text-gray-700',
+          bgColor: 'bg-kibako-tertiary/20',
+          textColor: 'text-kibako-primary/80',
           label: 'Viewer',
         };
       default:
         return {
           icon: <FaEye className="h-3 w-3" />,
-          bgColor: 'bg-gray-100',
-          textColor: 'text-gray-700',
+          bgColor: 'bg-kibako-tertiary/20',
+          textColor: 'text-kibako-primary/80',
           label: role.charAt(0).toUpperCase() + role.slice(1),
         };
     }

--- a/frontend/src/features/role/components/atoms/UserAvatar.tsx
+++ b/frontend/src/features/role/components/atoms/UserAvatar.tsx
@@ -19,7 +19,7 @@ const UserAvatar: React.FC<UserAvatarProps> = ({
 
   return (
     <div
-      className={`bg-gradient-to-br from-kibako-primary to-kibako-secondary rounded-full flex items-center justify-center text-white font-medium ${sizeClasses[size]} ${className}`}
+      className={`bg-gradient-to-br from-kibako-primary to-kibako-secondary rounded-full flex items-center justify-center text-kibako-white font-medium ${sizeClasses[size]} ${className}`}
     >
       {username.charAt(0).toUpperCase()}
     </div>

--- a/frontend/src/features/role/components/molecules/ConfirmDialog.tsx
+++ b/frontend/src/features/role/components/molecules/ConfirmDialog.tsx
@@ -20,28 +20,28 @@ const ConfirmDialog: React.FC<ConfirmDialogProps> = ({
   onCancel,
   confirmText = '削除する',
   cancelText = 'キャンセル',
-  confirmButtonColor = 'bg-red-600 hover:bg-red-700',
+  confirmButtonColor = 'bg-kibako-danger hover:bg-kibako-danger/80',
 }) => {
   if (!show) return null;
 
   return (
-    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-      <div className="bg-white rounded-lg p-6 max-w-md w-full mx-4">
+    <div className="fixed inset-0 bg-kibako-black/50 flex items-center justify-center z-50">
+      <div className="bg-kibako-white rounded-lg p-6 max-w-md w-full mx-4">
         <div className="flex items-center mb-4">
-          <FaExclamationTriangle className="h-6 w-6 text-orange-500 mr-3" />
-          <h3 className="text-lg font-medium text-gray-900">{title}</h3>
+          <FaExclamationTriangle className="h-6 w-6 text-kibako-accent mr-3" />
+          <h3 className="text-lg font-medium text-kibako-primary">{title}</h3>
         </div>
-        <p className="text-gray-600 mb-6">{message}</p>
+        <p className="text-kibako-primary/70 mb-6">{message}</p>
         <div className="flex gap-3 justify-end">
           <button
             onClick={onCancel}
-            className="px-4 py-2 text-gray-600 border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors"
+            className="px-4 py-2 text-kibako-primary/70 border border-kibako-secondary/30 rounded-lg hover:bg-kibako-tertiary/20 transition-colors"
           >
             {cancelText}
           </button>
           <button
             onClick={onConfirm}
-            className={`px-4 py-2 text-white rounded-lg transition-colors ${confirmButtonColor}`}
+            className={`px-4 py-2 text-kibako-white rounded-lg transition-colors ${confirmButtonColor}`}
           >
             {confirmText}
           </button>

--- a/frontend/src/features/role/components/molecules/RoleManagementForm.tsx
+++ b/frontend/src/features/role/components/molecules/RoleManagementForm.tsx
@@ -58,7 +58,7 @@ const RoleManagementForm: React.FC<RoleManagementFormProps> = ({
 }) => {
   return (
     <div className="mb-4">
-      <div className="bg-gray-50 border border-gray-200 rounded-lg p-3">
+      <div className="bg-kibako-tertiary/20 border border-kibako-secondary/20 rounded-lg p-3">
         {/* ヘッダー */}
         <div className="mb-3">
           <div className="flex items-center gap-2">
@@ -69,7 +69,7 @@ const RoleManagementForm: React.FC<RoleManagementFormProps> = ({
                 </h3>
                 <button
                   onClick={onCancelEdit}
-                  className="ml-auto p-1 text-gray-400 hover:text-gray-600 hover:bg-gray-200 rounded transition-colors"
+                  className="ml-auto p-1 text-kibako-primary/60 hover:text-kibako-primary hover:bg-kibako-tertiary/20 rounded transition-colors"
                   title="編集をキャンセル"
                 >
                   <FaTimes className="h-4 w-4" />
@@ -113,18 +113,18 @@ const RoleManagementForm: React.FC<RoleManagementFormProps> = ({
                 <button
                   onClick={onCancelEdit}
                   disabled={loading}
-                  className="px-6 py-2 text-gray-600 border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
+                  className="px-6 py-2 text-kibako-primary/70 border border-kibako-secondary/30 rounded-lg hover:bg-kibako-tertiary/20 transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
                 >
                   <span className="text-sm">キャンセル</span>
                 </button>
                 <button
                   onClick={onUpdateRole}
                   disabled={loading}
-                  className="px-6 py-2 bg-kibako-secondary hover:bg-kibako-secondary text-white rounded-md transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
+                  className="px-6 py-2 bg-kibako-secondary hover:bg-kibako-secondary text-kibako-white rounded-md transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
                 >
                   {loading ? (
                     <>
-                      <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-white"></div>
+                      <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-kibako-white"></div>
                       <span className="text-sm">更新中...</span>
                     </>
                   ) : (
@@ -136,11 +136,11 @@ const RoleManagementForm: React.FC<RoleManagementFormProps> = ({
               <button
                 onClick={onAddRole}
                 disabled={!selectedUser || loading}
-                className="px-6 py-2 bg-kibako-secondary hover:bg-kibako-secondary text-white rounded-md transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
+                className="px-6 py-2 bg-kibako-secondary hover:bg-kibako-secondary text-kibako-white rounded-md transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
               >
                 {loading ? (
                   <>
-                    <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-white"></div>
+                    <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-kibako-white"></div>
                     <span className="text-sm">追加中...</span>
                   </>
                 ) : (

--- a/frontend/src/features/role/components/molecules/RoleSelector.tsx
+++ b/frontend/src/features/role/components/molecules/RoleSelector.tsx
@@ -17,7 +17,7 @@ const RoleSelector: React.FC<RoleSelectorProps> = ({
       value: 'viewer',
       name: 'Viewer',
       icon: <FaEye className="h-6 w-6" />,
-      color: 'text-gray-400',
+      color: 'text-kibako-primary/60',
       description: 'Coming Soon',
       detailDescription: '現在開発中です',
       disabled: true,
@@ -26,7 +26,7 @@ const RoleSelector: React.FC<RoleSelectorProps> = ({
       value: 'editor',
       name: 'Editor',
       icon: <FaEdit className="h-6 w-6" />,
-      color: 'text-gray-400',
+      color: 'text-kibako-primary/60',
       description: 'Coming Soon',
       detailDescription: '現在開発中です',
       disabled: true,
@@ -35,7 +35,7 @@ const RoleSelector: React.FC<RoleSelectorProps> = ({
       value: 'admin',
       name: 'Admin',
       icon: <FaUserShield className="h-6 w-6" />,
-      color: 'text-red-600',
+      color: 'text-kibako-danger',
       description: '全ての管理権限を持つ最高権限',
       detailDescription: 'プロトタイプ削除、ユーザー管理、権限変更、設定管理',
       disabled: false,
@@ -53,10 +53,10 @@ const RoleSelector: React.FC<RoleSelectorProps> = ({
             key={role.value}
             className={`flex-1 flex flex-col gap-2 p-3 border rounded-lg transition-all ${
               role.disabled
-                ? 'cursor-not-allowed opacity-50 border-gray-200 bg-gray-50'
+                ? 'cursor-not-allowed opacity-50 border-kibako-secondary/20 bg-kibako-tertiary/20'
                 : selectedRole === role.value
-                  ? 'border-kibako-secondary bg-blue-50 shadow-sm cursor-pointer'
-                  : 'border-gray-200 hover:border-gray-300 hover:bg-gray-50 cursor-pointer'
+                  ? 'border-kibako-secondary bg-kibako-info/10 shadow-sm cursor-pointer'
+                  : 'border-kibako-secondary/20 hover:border-kibako-secondary/30 hover:bg-kibako-tertiary/20 cursor-pointer'
             } ${loading ? 'opacity-60 cursor-not-allowed' : ''}`}
           >
             <input

--- a/frontend/src/features/role/components/molecules/UserRoleCard.tsx
+++ b/frontend/src/features/role/components/molecules/UserRoleCard.tsx
@@ -43,7 +43,7 @@ const UserRoleCard: React.FC<UserRoleCardProps> = ({
 
   return (
     <div
-      className={`bg-white border border-gray-200 rounded-lg p-4 transition-all ${
+      className={`bg-kibako-white border border-kibako-secondary/20 rounded-lg p-4 transition-all ${
         !editMode ? 'hover:shadow-md' : ''
       } ${loading ? 'opacity-60' : ''}`}
     >
@@ -71,7 +71,7 @@ const UserRoleCard: React.FC<UserRoleCardProps> = ({
             onClick={() => {
               // 現在は無効化されているため何もしない
             }}
-            className="p-2 rounded transition-colors text-gray-300 cursor-not-allowed"
+            className="p-2 rounded transition-colors text-kibako-secondary/50 cursor-not-allowed"
             title={
               isCreator
                 ? 'プロジェクト作成者の権限は変更できません'
@@ -87,8 +87,8 @@ const UserRoleCard: React.FC<UserRoleCardProps> = ({
             onClick={() => onRemove(userRole.userId)}
             className={`p-2 rounded transition-colors ${
               canRemove && !loading && !editMode
-                ? 'text-gray-400 hover:text-red-500 hover:bg-red-50'
-                : 'text-gray-300 cursor-not-allowed'
+                ? 'text-kibako-primary/60 hover:text-kibako-danger hover:bg-kibako-danger/10'
+                : 'text-kibako-secondary/50 cursor-not-allowed'
             }`}
             title={
               loading
@@ -112,8 +112,8 @@ const UserRoleCard: React.FC<UserRoleCardProps> = ({
 
       {/* 複数権限がある場合の表示 */}
       {userRole.roles.length > 1 && (
-        <div className="mt-3 pt-3 border-t border-gray-100">
-          <div className="text-xs text-gray-500">
+        <div className="mt-3 pt-3 border-t border-kibako-secondary/10">
+          <div className="text-xs text-kibako-primary/70">
             その他の権限:{' '}
             {userRole.roles
               .slice(1)
@@ -125,10 +125,10 @@ const UserRoleCard: React.FC<UserRoleCardProps> = ({
 
       {/* 制限の説明 */}
       {isCreator && (
-        <div className="mt-3 pt-3 border-t border-gray-100">
-          <div className="text-xs text-gray-500 flex items-center gap-1">
+        <div className="mt-3 pt-3 border-t border-kibako-secondary/10">
+          <div className="text-xs text-kibako-primary/70 flex items-center gap-1">
             <div>
-              <div className="text-yellow-600 font-medium">
+              <div className="text-kibako-accent font-medium">
                 プロジェクト作成者
               </div>
               <div className="flex items-center gap-1">

--- a/frontend/src/features/role/components/molecules/UserRolesList.tsx
+++ b/frontend/src/features/role/components/molecules/UserRolesList.tsx
@@ -39,11 +39,11 @@ const UserRolesList: React.FC<UserRolesListProps> = ({
   if (userRoles.length === 0 && !loading) {
     return (
       <div className="col-span-full flex flex-col items-center justify-center py-12 text-kibako-secondary">
-        <FaUserShield className="h-12 w-12 text-gray-300 mb-4" />
+        <FaUserShield className="h-12 w-12 text-kibako-secondary/50 mb-4" />
         <p className="text-lg font-medium mb-2">
           ユーザー権限が設定されていません
         </p>
-        <p className="text-sm text-gray-500">
+        <p className="text-sm text-kibako-primary/70">
           上のフォームからユーザーと権限を追加してください
         </p>
       </div>

--- a/frontend/src/features/role/components/molecules/UserSearchDropdown.tsx
+++ b/frontend/src/features/role/components/molecules/UserSearchDropdown.tsx
@@ -38,7 +38,7 @@ const UserSearchDropdown: React.FC<UserSearchDropdownProps> = ({
       <div className="relative">
         {/* 選択されたユーザー表示 */}
         {selectedUser ? (
-          <div className="w-full p-2 border border-gray-300 rounded-md bg-white focus:outline-none focus:ring-2 focus:ring-kibako-secondary flex items-center justify-between">
+          <div className="w-full p-2 border border-kibako-secondary/30 rounded-md bg-kibako-white focus:outline-none focus:ring-2 focus:ring-kibako-secondary flex items-center justify-between">
             <div className="flex items-center gap-2">
               <UserAvatar username={selectedUser.username} size="sm" />
               <div>
@@ -50,7 +50,7 @@ const UserSearchDropdown: React.FC<UserSearchDropdownProps> = ({
             <button
               onClick={onClearUser}
               disabled={loading}
-              className="p-1 text-gray-400 hover:text-red-500 hover:bg-red-50 rounded transition-colors"
+              className="p-1 text-kibako-primary/60 hover:text-kibako-danger hover:bg-kibako-danger/10 rounded transition-colors"
               title="選択を解除"
             >
               <FaTimes className="h-3 w-3" />
@@ -69,10 +69,10 @@ const UserSearchDropdown: React.FC<UserSearchDropdownProps> = ({
                 }}
                 onFocus={() => onToggleDropdown(true)}
                 placeholder="ユーザー名を入力..."
-                className="w-full p-2 pl-8 text-sm border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-kibako-secondary focus:border-transparent"
+                className="w-full p-2 pl-8 text-sm border border-kibako-secondary/30 rounded-md focus:outline-none focus:ring-2 focus:ring-kibako-secondary focus:border-transparent"
                 disabled={loading}
               />
-              <FaSearch className="absolute left-2 top-1/2 transform -translate-y-1/2 text-gray-400 h-3 w-3" />
+              <FaSearch className="absolute left-2 top-1/2 transform -translate-y-1/2 text-kibako-primary/60 h-3 w-3" />
             </div>
 
             {/* 検索結果ドロップダウン */}
@@ -85,14 +85,14 @@ const UserSearchDropdown: React.FC<UserSearchDropdownProps> = ({
                 />
 
                 {/* ドロップダウンメニュー */}
-                <div className="absolute top-full left-0 right-0 mt-1 bg-white border border-gray-200 rounded-md shadow-lg z-20 max-h-48 overflow-auto">
+                <div className="absolute top-full left-0 right-0 mt-1 bg-kibako-white border border-kibako-secondary/20 rounded-md shadow-lg z-20 max-h-48 overflow-auto">
                   {filteredUsers.length > 0 ? (
                     <div className="py-1">
                       {filteredUsers.map((user) => (
                         <button
                           key={user.id}
                           onClick={() => onUserSelect(user)}
-                          className="w-full px-3 py-2 text-left hover:bg-gray-50 transition-colors flex items-center gap-2 group"
+                          className="w-full px-3 py-2 text-left hover:bg-kibako-tertiary/20 transition-colors flex items-center gap-2 group"
                         >
                           <UserAvatar
                             username={user.username}
@@ -107,7 +107,7 @@ const UserSearchDropdown: React.FC<UserSearchDropdownProps> = ({
                     </div>
                   ) : (
                     <div className="px-3 py-4 text-center text-kibako-secondary">
-                      <FaUser className="h-6 w-6 text-gray-300 mx-auto mb-1" />
+                      <FaUser className="h-6 w-6 text-kibako-secondary/50 mx-auto mb-1" />
                       <div className="text-xs">
                         {searchTerm
                           ? `"${searchTerm}" に一致するユーザーが見つかりません`

--- a/frontend/src/features/role/components/organisms/RoleManagement.tsx
+++ b/frontend/src/features/role/components/organisms/RoleManagement.tsx
@@ -163,11 +163,11 @@ const RoleManagement: React.FC = () => {
   // ローディング中の表示
   if (loading && userRoles.length === 0) {
     return (
-      <div className="max-w-4xl mx-auto p-4 bg-white rounded-lg shadow mt-16">
+      <div className="max-w-4xl mx-auto p-4 bg-kibako-white rounded-lg shadow mt-16">
         <div className="flex items-center relative mb-6">
           <button
             onClick={() => router.back()}
-            className="p-2 hover:bg-gray-100 rounded-full transition-colors absolute left-0"
+            className="p-2 hover:bg-kibako-tertiary/20 rounded-full transition-colors absolute left-0"
             title="戻る"
           >
             <IoArrowBack className="h-5 w-5 text-kibako-primary hover:text-kibako-primary transition-colors" />
@@ -184,11 +184,11 @@ const RoleManagement: React.FC = () => {
   }
 
   return (
-    <div className="max-w-4xl mx-auto p-4 bg-white rounded-lg shadow mt-16">
+    <div className="max-w-4xl mx-auto p-4 bg-kibako-white rounded-lg shadow mt-16">
       <div className="flex items-center relative mb-6">
         <button
           onClick={() => router.back()}
-          className="p-2 hover:bg-gray-100 rounded-full transition-colors absolute left-0"
+          className="p-2 hover:bg-kibako-tertiary/20 rounded-full transition-colors absolute left-0"
           title="戻る"
         >
           <IoArrowBack className="h-5 w-5 text-kibako-primary hover:text-kibako-primary transition-colors" />

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -11,6 +11,10 @@ export default {
           accent: '#C9713C', // アクセント
           tertiary: '#EFE8DE', // ベース背景色（明るめ）
           white: '#F5F0E9', // テキスト
+          black: '#000000', // オーバーレイなど
+          danger: '#DC2626', // エラーメッセージ
+          success: '#16A34A', // 成功メッセージ
+          info: '#2563EB', // 情報メッセージ
         },
       },
       // 木箱のグラデーション


### PR DESCRIPTION
## Summary
- extend Tailwind kibako palette with black, danger, success, and info colors
- refactor various components to use kibako color utilities

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68b43fc0f2fc8326ad8331eccdd5148a