### PR TITLE
fix(frontend): remove gradient text from プロジェクト一覧 and プロフィール編集 headers

### DIFF
--- a/frontend/src/features/profile/components/ProfileEdit.tsx
+++ b/frontend/src/features/profile/components/ProfileEdit.tsx
@@ -104,7 +104,7 @@ const ProfileEdit: React.FC = () => {
           <IoArrowBack className="h-5 w-5 text-kibako-primary hover:text-kibako-primary transition-colors" />
         </button>
         <div className="flex-grow flex items-center justify-center">
-          <h1 className="text-4xl font-bold text-center bg-gradient-to-r from-kibako-primary via-kibako-secondary to-kibako-primary text-transparent bg-clip-text">
+          <h1 className="text-4xl font-bold text-center text-kibako-primary">
             プロフィール編集
           </h1>
         </div>

--- a/frontend/src/features/prototype/components/organisms/ProjectList.tsx
+++ b/frontend/src/features/prototype/components/organisms/ProjectList.tsx
@@ -278,7 +278,7 @@ const ProjectList: React.FC = () => {
       {/* タイトルと作成ボタンを同じ行に表示（小さい画面では縦並び） */}
       <div className="sticky top-20 z-30 bg-transparent backdrop-blur-sm flex flex-col md:flex-row md:items-center md:justify-between mb-8 gap-4 py-4 rounded-lg">
         <div className="flex items-center gap-3">
-          <h1 className="text-3xl text-kibako-primary font-bold mb-0 bg-gradient-to-r from-kibako-primary via-kibako-secondary to-kibako-primary text-transparent bg-clip-text">
+          <h1 className="text-3xl text-kibako-primary font-bold mb-0">
             プロジェクト一覧
           </h1>
 


### PR DESCRIPTION
This PR removes gradient text styling from two page headers to use a solid primary color, per design request.

Changes
- Project list header: `frontend/src/features/prototype/components/organisms/ProjectList.tsx`
  - Removed `bg-gradient-to-r ... text-transparent bg-clip-text` from `<h1>` and kept `text-kibako-primary`.
- Profile edit header: `frontend/src/features/profile/components/ProfileEdit.tsx`
  - Removed gradient classes and set `<h1>` to `text-kibako-primary`.

Rationale
- Align header styling with updated design that avoids gradient text for readability and consistency.

Notes
- No functional changes; purely presentational.
- Verified TS compiles locally for modified files; no impacts expected outside typography.

Please let me know if you want any additional headers normalized to solid color as well.