### PR TITLE
ci: reuse npm workflow for lint and tests

### DIFF
--- a/.github/workflows/backend-lint.yml
+++ b/.github/workflows/backend-lint.yml
@@ -18,27 +18,7 @@ on:
 
 jobs:
   backend-lint:
-    runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        node-version: [20.x]
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Set up Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ matrix.node-version }}
-          cache: 'npm'
-          cache-dependency-path: './backend/package-lock.json'
-
-      - name: Install backend dependencies
-        working-directory: ./backend
-        run: npm ci
-
-      - name: Run backend lint
-        working-directory: ./backend
-        run: npm run lint
+    uses: ./.github/workflows/npm-run.yml
+    with:
+      working-directory: ./backend
+      run: npm run lint

--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -18,41 +18,10 @@ on:
 
 jobs:
   backend-test:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      id-token: write
-
-    strategy:
-      matrix:
-        node-version: [20.x]
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Set up Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ matrix.node-version }}
-          cache: 'npm'
-          cache-dependency-path: './backend/package-lock.json'
-
-      - name: Install backend dependencies
-        working-directory: ./backend
-        run: npm ci
-
-      - name: Run backend tests with coverage
-        working-directory: ./backend
-        env:
-          CI: true
-        run: npm run test -- --coverage
-
-      - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v4
-        with:
-          files: ./backend/coverage/lcov.info
-          flags: backend
-          name: backend-coverage
-          fail_ci_if_error: false
-          use_oidc: true
+    uses: ./.github/workflows/npm-run.yml
+    with:
+      working-directory: ./backend
+      run: CI=true npm run test -- --coverage
+      coverage-file: ./backend/coverage/lcov.info
+      codecov-flags: backend
+      codecov-name: backend-coverage

--- a/.github/workflows/frontend-lint.yml
+++ b/.github/workflows/frontend-lint.yml
@@ -18,27 +18,7 @@ on:
 
 jobs:
   frontend-lint:
-    runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        node-version: [20.x]
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Set up Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ matrix.node-version }}
-          cache: 'npm'
-          cache-dependency-path: './frontend/package-lock.json'
-
-      - name: Install frontend dependencies
-        working-directory: ./frontend
-        run: npm ci
-
-      - name: Run frontend lint
-        working-directory: ./frontend
-        run: npm run lint
+    uses: ./.github/workflows/npm-run.yml
+    with:
+      working-directory: ./frontend
+      run: npm run lint

--- a/.github/workflows/frontend-test.yml
+++ b/.github/workflows/frontend-test.yml
@@ -18,39 +18,12 @@ on:
 
 jobs:
   frontend-test:
-    runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        node-version: [20.x]
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Set up Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ matrix.node-version }}
-          cache: 'npm'
-          cache-dependency-path: './frontend/package-lock.json'
-
-      - name: Install frontend dependencies
-        working-directory: ./frontend
-        run: npm ci
-
-      - name: Run frontend tests
-        working-directory: ./frontend
-        run: npm run test
-
-      - name: Run frontend test coverage
-        working-directory: ./frontend
-        run: npm run test:coverage
-
-      - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v4
-        with:
-          file: ./frontend/coverage/lcov.info
-          flags: frontend
-          name: frontend-coverage
-          fail_ci_if_error: false
+    uses: ./.github/workflows/npm-run.yml
+    with:
+      working-directory: ./frontend
+      run: |
+        npm run test
+        npm run test:coverage
+      coverage-file: ./frontend/coverage/lcov.info
+      codecov-flags: frontend
+      codecov-name: frontend-coverage

--- a/.github/workflows/npm-run.yml
+++ b/.github/workflows/npm-run.yml
@@ -1,0 +1,63 @@
+name: npm run
+
+on:
+  workflow_call:
+    inputs:
+      working-directory:
+        description: Directory where npm commands run
+        required: true
+        type: string
+      run:
+        description: Command to execute
+        required: true
+        type: string
+      coverage-file:
+        description: Optional coverage file path for Codecov upload
+        required: false
+        type: string
+      codecov-flags:
+        description: Flags for Codecov
+        required: false
+        type: string
+      codecov-name:
+        description: Name for Codecov upload
+        required: false
+        type: string
+
+jobs:
+  npm-run:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    strategy:
+      matrix:
+        node-version: [20.x]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'npm'
+          cache-dependency-path: "${{ inputs.working-directory }}/package-lock.json"
+
+      - name: Install dependencies
+        working-directory: ${{ inputs.working-directory }}
+        run: npm ci
+
+      - name: Run command
+        working-directory: ${{ inputs.working-directory }}
+        run: ${{ inputs.run }}
+
+      - name: Upload coverage reports to Codecov
+        if: inputs.coverage-file != ''
+        uses: codecov/codecov-action@v4
+        with:
+          files: ${{ inputs.coverage-file }}
+          flags: ${{ inputs.codecov-flags }}
+          name: ${{ inputs.codecov-name }}
+          fail_ci_if_error: false
+          use_oidc: true


### PR DESCRIPTION
## Summary
- add reusable `npm-run` workflow to run npm scripts with optional coverage upload
- simplify backend/frontend lint and test workflows to call reusable workflow

## Testing
- `npm test` (backend)
- `npm run lint` (backend)
- `npm run lint` (frontend)
- `npm test` (frontend)
- `npm run test:coverage` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68b43fe851688326ba327820e3075182