### PR TITLE
refactor: centralize part style config

### DIFF
--- a/frontend/src/features/prototype/utils/partTypeConfig.ts
+++ b/frontend/src/features/prototype/utils/partTypeConfig.ts
@@ -33,7 +33,7 @@ const DEFAULT_STYLE: PartStyle = {
   shadowOffset: 0,
 };
 
-export const partTypeConfig: Record<PartType, Partial<PartStyle>> = {
+export const partTypeConfig = {
   card: {
     cornerRadius: 10,
     imageCornerRadius: 10,
@@ -58,10 +58,9 @@ export const partTypeConfig: Record<PartType, Partial<PartStyle>> = {
     strokeWidth: 3,
     dashPattern: DASH_PATTERN_DASHED,
   },
-};
+} satisfies Partial<Record<PartType, Partial<PartStyle>>>;
 
 export const getPartStyle = (partType: PartType): PartStyle => ({
   ...DEFAULT_STYLE,
   ...(partTypeConfig[partType] ?? {}),
 });
-

--- a/frontend/src/features/prototype/utils/partTypeConfig.ts
+++ b/frontend/src/features/prototype/utils/partTypeConfig.ts
@@ -1,0 +1,67 @@
+import { Part } from '@/api/types';
+
+// パーツ種別（API の Part.type 相当）
+export type PartType = Part['type'];
+
+// 破線パターン
+const DASH_PATTERN_DASHED: number[] = [8, 8];
+
+// 影の設定値
+const SHADOW_COLOR_PHYSICAL = 'rgba(0, 0, 0, 0.15)';
+const SHADOW_BLUR_PHYSICAL = 4;
+const SHADOW_OFFSET_PHYSICAL = 2;
+
+// 各パーツ種別の見た目設定
+// 新しいパーツ種別を追加する場合はこのオブジェクトに設定を記述するだけで、
+// partUtils 内の各ヘルパー関数が自動的に参照します。
+export type PartStyle = {
+  cornerRadius: number;
+  imageCornerRadius: number;
+  strokeWidth: number;
+  dashPattern?: number[];
+  shadowColor: string;
+  shadowBlur: number;
+  shadowOffset: number;
+};
+
+const DEFAULT_STYLE: PartStyle = {
+  cornerRadius: 4,
+  imageCornerRadius: 4,
+  strokeWidth: 1,
+  shadowColor: 'transparent',
+  shadowBlur: 0,
+  shadowOffset: 0,
+};
+
+export const partTypeConfig: Record<PartType, Partial<PartStyle>> = {
+  card: {
+    cornerRadius: 10,
+    imageCornerRadius: 10,
+    shadowColor: SHADOW_COLOR_PHYSICAL,
+    shadowBlur: SHADOW_BLUR_PHYSICAL,
+    shadowOffset: SHADOW_OFFSET_PHYSICAL,
+  },
+  token: {
+    shadowColor: SHADOW_COLOR_PHYSICAL,
+    shadowBlur: SHADOW_BLUR_PHYSICAL,
+    shadowOffset: SHADOW_OFFSET_PHYSICAL,
+  },
+  hand: {
+    cornerRadius: 20,
+    dashPattern: DASH_PATTERN_DASHED,
+  },
+  deck: {
+    cornerRadius: 20,
+    dashPattern: DASH_PATTERN_DASHED,
+  },
+  area: {
+    strokeWidth: 3,
+    dashPattern: DASH_PATTERN_DASHED,
+  },
+};
+
+export const getPartStyle = (partType: PartType): PartStyle => ({
+  ...DEFAULT_STYLE,
+  ...(partTypeConfig[partType] ?? {}),
+});
+

--- a/frontend/src/features/prototype/utils/partTypeConfig.ts
+++ b/frontend/src/features/prototype/utils/partTypeConfig.ts
@@ -7,9 +7,9 @@ export type PartType = Part['type'];
 const DASH_PATTERN_DASHED: number[] = [8, 8];
 
 // 影の設定値
-const SHADOW_COLOR_PHYSICAL = 'rgba(0, 0, 0, 0.15)';
-const SHADOW_BLUR_PHYSICAL = 4;
-const SHADOW_OFFSET_PHYSICAL = 2;
+const SHADOW_COLOR_PHYSICAL: string = 'rgba(0, 0, 0, 0.15)';
+const SHADOW_BLUR_PHYSICAL: number = 4;
+const SHADOW_OFFSET_PHYSICAL: number = 2;
 
 // 各パーツ種別の見た目設定
 // 新しいパーツ種別を追加する場合はこのオブジェクトに設定を記述するだけで、
@@ -60,6 +60,12 @@ export const partTypeConfig = {
   },
 } satisfies Partial<Record<PartType, Partial<PartStyle>>>;
 
+/**
+ * 指定パーツ種別の見た目設定を返す。
+ * デフォルト設定にパーツ種別ごとの上書きをマージして完全な PartStyle を生成する。
+ * @param partType パーツ種別（API の Part.type）
+ * @returns 完全な見た目設定
+ */
 export const getPartStyle = (partType: PartType): PartStyle => ({
   ...DEFAULT_STYLE,
   ...(partTypeConfig[partType] ?? {}),

--- a/frontend/src/features/prototype/utils/partUtils.ts
+++ b/frontend/src/features/prototype/utils/partUtils.ts
@@ -1,36 +1,10 @@
-import { Part } from '@/api/types';
+import { getPartStyle, PartType } from './partTypeConfig';
 
-// パーツ種別（APIの Part.type 相当）
-export type PartType = Part['type'];
+export type { PartType } from './partTypeConfig';
 
-// 角丸の定数
-const CORNER_RADIUS_CONCEPT = 20;
-const CORNER_RADIUS_CARD = 10;
-const CORNER_RADIUS_DEFAULT = 4;
-
-// 画像角丸
-const IMAGE_CORNER_RADIUS_CARD = 10;
-const IMAGE_CORNER_RADIUS_DEFAULT = 4;
-
-// 枠線幅
-const STROKE_WIDTH_AREA = 3;
-const STROKE_WIDTH_DEFAULT = 1;
-
-// 破線パターン
-const DASH_PATTERN_DASHED: number[] = [8, 8];
-
-// 影の色
+// 影（アクティブ時）の色とサイズ
 const SHADOW_COLOR_ACTIVE = 'rgba(59, 130, 246, 1)';
-const SHADOW_COLOR_PHYSICAL = 'rgba(0, 0, 0, 0.15)';
-const SHADOW_COLOR_NONE = 'transparent';
-
-// 影のぼかし
 const SHADOW_BLUR_ACTIVE = 10;
-const SHADOW_BLUR_PHYSICAL = 4;
-const SHADOW_BLUR_NONE = 0;
-
-// 影のオフセット
-const SHADOW_OFFSET_PHYSICAL = 2;
 const SHADOW_OFFSET_ZERO = 0;
 
 /**
@@ -39,63 +13,44 @@ const SHADOW_OFFSET_ZERO = 0;
  * @param partType - 判定するパーツタイプ
  * @returns カードまたはトークンの場合true
  */
-export const isPhysicalPartType = (partType: PartType): boolean => {
-  // カードまたはトークンの場合
-  return partType === 'card' || partType === 'token';
-};
+const PHYSICAL_PART_TYPES: PartType[] = ['card', 'token'];
+
+export const isPhysicalPartType = (partType: PartType): boolean =>
+  PHYSICAL_PART_TYPES.includes(partType);
 
 /**
  * パーツタイプが概念的なパーツ（手札または山札）かどうかを判定する
  * @param partType - 判定するパーツタイプ
  * @returns 手札または山札の場合true
  */
-export const isConceptPartType = (partType: PartType): boolean => {
-  return partType === 'hand' || partType === 'deck';
-};
+const CONCEPT_PART_TYPES: PartType[] = ['hand', 'deck'];
+
+export const isConceptPartType = (partType: PartType): boolean =>
+  CONCEPT_PART_TYPES.includes(partType);
 
 /**
  * パーツの背景用の角丸半径を取得する
  * @param partType - パーツタイプ
  * @returns 角丸半径（ピクセル）
  */
-export const getCornerRadius = (partType: PartType): number => {
-  // 概念パーツ（手札・山札）の場合
-  if (isConceptPartType(partType)) {
-    return CORNER_RADIUS_CONCEPT;
-  }
-  // カードの場合
-  if (partType === 'card') {
-    return CORNER_RADIUS_CARD;
-  }
-  // 上記以外（トークン・エリア等）
-  return CORNER_RADIUS_DEFAULT;
-};
+export const getCornerRadius = (partType: PartType): number =>
+  getPartStyle(partType).cornerRadius;
 
 /**
  * パーツの画像用の角丸半径を取得する
  * @param partType - パーツタイプ
  * @returns 角丸半径（ピクセル）
  */
-export const getImageCornerRadius = (partType: PartType): number => {
-  // カードの場合
-  if (partType === 'card') {
-    return IMAGE_CORNER_RADIUS_CARD;
-  }
-  // 上記以外
-  return IMAGE_CORNER_RADIUS_DEFAULT;
-};
+export const getImageCornerRadius = (partType: PartType): number =>
+  getPartStyle(partType).imageCornerRadius;
 
 /**
  * パーツの枠線幅を取得する
  * @param partType - パーツタイプ
  * @returns 枠線幅（ピクセル）
  */
-export const getStrokeWidth = (partType: PartType): number => {
-  // エリアの場合
-  if (partType === 'area') return STROKE_WIDTH_AREA;
-  // 上記以外
-  return STROKE_WIDTH_DEFAULT;
-};
+export const getStrokeWidth = (partType: PartType): number =>
+  getPartStyle(partType).strokeWidth;
 
 /**
  * パーツの破線パターンを取得する
@@ -103,13 +58,8 @@ export const getStrokeWidth = (partType: PartType): number => {
  * @returns 破線パターン配列、または undefined（実線の場合）
  */
 export const getDashPattern = (partType: PartType): number[] | undefined => {
-  // 概念パーツまたはエリアの場合は点線
-  if (isConceptPartType(partType) || partType === 'area') {
-    // 破壊的変更の波及を避けるためコピーを返す
-    return [...DASH_PATTERN_DASHED];
-  }
-  // 実線
-  return undefined;
+  const pattern = getPartStyle(partType).dashPattern;
+  return pattern ? [...pattern] : undefined;
 };
 
 /**
@@ -121,18 +71,8 @@ export const getDashPattern = (partType: PartType): number[] | undefined => {
 export const getShadowColor = (
   partType: PartType,
   isActive: boolean
-): string => {
-  // アクティブの場合
-  if (isActive) {
-    return SHADOW_COLOR_ACTIVE;
-  }
-  // 物理パーツの場合
-  if (isPhysicalPartType(partType)) {
-    return SHADOW_COLOR_PHYSICAL;
-  }
-  // それ以外は影なし
-  return SHADOW_COLOR_NONE;
-};
+): string =>
+  isActive ? SHADOW_COLOR_ACTIVE : getPartStyle(partType).shadowColor;
 
 /**
  * パーツの影のぼかし値を取得する
@@ -143,14 +83,8 @@ export const getShadowColor = (
 export const getShadowBlur = (
   partType: PartType,
   isActive: boolean
-): number => {
-  // アクティブの場合
-  if (isActive) return SHADOW_BLUR_ACTIVE;
-  // 物理パーツの場合
-  if (isPhysicalPartType(partType)) return SHADOW_BLUR_PHYSICAL;
-  // それ以外
-  return SHADOW_BLUR_NONE;
-};
+): number =>
+  isActive ? SHADOW_BLUR_ACTIVE : getPartStyle(partType).shadowBlur;
 
 /**
  * パーツの影のX軸オフセットを取得する
@@ -161,14 +95,8 @@ export const getShadowBlur = (
 export const getShadowOffsetX = (
   partType: PartType,
   isActive: boolean
-): number => {
-  // アクティブの場合
-  if (isActive) return SHADOW_OFFSET_ZERO;
-  // 物理パーツの場合
-  if (isPhysicalPartType(partType)) return SHADOW_OFFSET_PHYSICAL;
-  // それ以外
-  return SHADOW_OFFSET_ZERO;
-};
+): number =>
+  isActive ? SHADOW_OFFSET_ZERO : getPartStyle(partType).shadowOffset;
 
 /**
  * パーツの影のY軸オフセットを取得する
@@ -179,14 +107,8 @@ export const getShadowOffsetX = (
 export const getShadowOffsetY = (
   partType: PartType,
   isActive: boolean
-): number => {
-  // アクティブの場合
-  if (isActive) return SHADOW_OFFSET_ZERO;
-  // 物理パーツの場合
-  if (isPhysicalPartType(partType)) return SHADOW_OFFSET_PHYSICAL;
-  // それ以外
-  return SHADOW_OFFSET_ZERO;
-};
+): number =>
+  isActive ? SHADOW_OFFSET_ZERO : getPartStyle(partType).shadowOffset;
 
 /**
  * 選択された色がカスタムカラーかどうかを判定する


### PR DESCRIPTION
## Summary
- add partTypeConfig to hold style settings by part type
- simplify part utility functions to use centralized config

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b453dcd8008326ab0f0c792b11a2d2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* Style
  * Harmonized visuals across part types: unified corner radii, image radii, stroke widths, dash patterns, and shadows.
  * Subtle, consistent visual updates applied to cards, tokens, hands, decks, and areas.

* Refactor
  * Centralized part-type styling in a single configuration used app-wide.
  * Simplified logic for determining part categories and visual properties, reducing inconsistencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->