### PR TITLE
fix: redirect header link to top page

### DIFF
--- a/frontend/src/components/organisms/Header.tsx
+++ b/frontend/src/components/organisms/Header.tsx
@@ -10,19 +10,18 @@ const Header: React.FC = () => {
   const pathname = usePathname();
 
   /**
-   * プロジェクト一覧画面へ遷移する
-   * 現在すでにプロジェクト一覧画面またはログイン画面にいる場合は何もしない
+   * トップページへ遷移する
+   * 現在すでにトップページにいる場合は何もしない
    */
-  const goToProjects = () => {
-    // プロジェクト一覧画面、またはログイン画面の場合
-    if (pathname === '/projects' || pathname === '/') return;
+  const goToTop = () => {
+    if (pathname === '/') return;
 
-    router.push('/projects');
+    router.push('/');
   };
 
   return (
     <header className="sticky top-0 z-40 bg-kibako-primary/80 px-8 flex justify-between items-center h-20 backdrop-blur-sm">
-      <button onClick={goToProjects}>
+      <button onClick={goToTop}>
         <div className="flex gap-2">
           <GiWoodenCrate className="text-4xl drop-shadow-xl transform -rotate-6 text-kibako-white" />
           <span className="text-3xl tracking-wider font-medium text-kibako-white">


### PR DESCRIPTION
## Summary
- always navigate to top page when clicking header logo

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b4d411076883268205408221fd8a9d