### PR TITLE
fix: resolve backend lint warnings

### DIFF
--- a/backend/src/scripts/cleanUpUnusedImages.ts
+++ b/backend/src/scripts/cleanUpUnusedImages.ts
@@ -25,7 +25,7 @@ async function cleanUpUnusedImages() {
       await deleteImageFromS3(image.storagePath);
       await ImageModel.destroy({ where: { id: image.id } });
     } catch (error) {
-      console.error(`Failed to delete image ${image.id}`);
+      console.error(`Failed to delete image ${image.id}`, error);
     }
   }
 

--- a/backend/src/services/imageDeleteService.ts
+++ b/backend/src/services/imageDeleteService.ts
@@ -27,7 +27,7 @@ export const deleteImageFromS3 = async (key: string): Promise<void> => {
     }
     // S3からの削除が成功した場合、何も返さない
     return;
-  } catch (error: any) {
+  } catch (error: unknown) {
     // AWS SDKのエラーをハンドリング
     handleAWSError(error);
   }

--- a/backend/src/services/imageFetchService.ts
+++ b/backend/src/services/imageFetchService.ts
@@ -27,9 +27,8 @@ export const fetchImageFromS3 = async (key: string): Promise<Readable> => {
     }
 
     return response.Body as Readable;
-  } catch (error: any) {
+  } catch (error: unknown) {
     // AWS SDKのエラーをハンドリング
-    handleAWSError(error);
-    throw error; // ここに到達することはないが、TypeScriptの型チェックを通すために必要
+    return handleAWSError(error);
   }
 };

--- a/backend/src/services/imageUploadService.ts
+++ b/backend/src/services/imageUploadService.ts
@@ -68,9 +68,8 @@ export const uploadImageToS3 = async (
       contentType: mime,
       fileSize: file.size,
     };
-  } catch (error: any) {
+  } catch (error: unknown) {
     // AWS SDKのエラーをハンドリング
-    handleAWSError(error);
-    throw error; // ここに到達することはないが、TypeScriptの型チェックを通すために必要
+    return handleAWSError(error);
   }
 };

--- a/backend/src/types/connect-pg-simple.d.ts
+++ b/backend/src/types/connect-pg-simple.d.ts
@@ -1,3 +1,9 @@
 declare module 'connect-pg-simple' {
-  export default function connectPgSimple(session: typeof session): any;
+  import { Store } from 'express-session';
+  class PGStore extends Store {
+    constructor(options?: Record<string, unknown>);
+  }
+  export default function connectPgSimple(
+    session: typeof import('express-session')
+  ): typeof PGStore;
 }

--- a/backend/src/types/sequelize-erd.d.ts
+++ b/backend/src/types/sequelize-erd.d.ts
@@ -1,6 +1,7 @@
 declare module 'sequelize-erd' {
-  export default function sequelizeErd(
-    source: any,
+  import { Sequelize } from 'sequelize';
+  interface ERDOptions {
+    source: Sequelize;
     format?:
       | 'svg'
       | 'dot'
@@ -10,17 +11,18 @@ declare module 'sequelize-erd' {
       | 'ps'
       | 'ps2'
       | 'json'
-      | 'json0',
-    engine?: 'circo' | 'dot' | 'fdp' | 'neato' | 'osage' | 'twopi',
+      | 'json0';
+    engine?: 'circo' | 'dot' | 'fdp' | 'neato' | 'osage' | 'twopi';
     arrowShapes?: {
       BelongsToMany: ['crow', 'crow'];
       BelongsTo: ['inv', 'crow'];
       HasMany: ['crow', 'inv'];
       HasOne: ['dot', 'dot'];
-    },
-    arrowSize?: number,
-    lineWidth?: number,
-    color?: string,
-    include?: string[]
-  ): Promise<string>;
+    };
+    arrowSize?: number;
+    lineWidth?: number;
+    color?: string;
+    include?: string[];
+  }
+  export default function sequelizeErd(options: ERDOptions): Promise<string>;
 }

--- a/backend/src/types/swagger-jsdoc.d.ts
+++ b/backend/src/types/swagger-jsdoc.d.ts
@@ -1,4 +1,9 @@
 declare module 'swagger-jsdoc' {
-  const swaggerJSDoc: (options: any) => any;
-  export default swaggerJSDoc;
+  interface SwaggerJSDocOptions {
+    definition: Record<string, unknown>;
+    apis: string[];
+  }
+  export default function swaggerJSDoc(
+    options: SwaggerJSDocOptions
+  ): Record<string, unknown>;
 }

--- a/backend/src/utils/awsErrorHandler.ts
+++ b/backend/src/utils/awsErrorHandler.ts
@@ -10,8 +10,12 @@ import {
  * AWS SDKのエラーをハンドリングして適切なCustomErrorをスローする
  * @param error - AWS SDKがスローしたエラー
  */
-export const handleAWSError = (error: any): never => {
-  switch (error.name) {
+export const handleAWSError = (error: unknown): never => {
+  const { name, message } = error as Partial<{
+    name: string;
+    message: string;
+  }>;
+  switch (name) {
     case 'NoSuchKey':
       throw new NotFoundError('指定されたリソースが存在しません');
     case 'AccessDenied':
@@ -24,7 +28,7 @@ export const handleAWSError = (error: any): never => {
       throw new ServiceUnavailableError('S3サービスが一時的に利用できません');
     default:
       throw new InternalServerError(
-        `AWS処理中にエラーが発生しました: ${error.message}`
+        `AWS処理中にエラーが発生しました: ${message}`
       );
   }
 };


### PR DESCRIPTION
## Summary
- replace `any` with safer typings in AWS services and utilities
- add explicit module typings for connect-pg-simple, sequelize-erd, and swagger-jsdoc
- improve swagger schema generation and image cleanup logging

## Testing
- `cd backend && npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b4d999871883268886ec09fb23589c