### PR TITLE
fix: resolve frontend lint warning

### DIFF
--- a/frontend/src/features/prototype/components/molecules/PartOnGameBoard.tsx
+++ b/frontend/src/features/prototype/components/molecules/PartOnGameBoard.tsx
@@ -147,7 +147,7 @@ export default function PartOnGameBoard({
   const selfSelectedColor = useMemo<string | null>(() => {
     if (!selfUser) return null;
     return getUserColor(selfUser.userId, selfUser.username);
-  }, [selfUser?.userId, selfUser?.username]);
+  }, [selfUser]);
 
   // 選択装飾用の計算結果をメモ化
   const selectedByWithColors = useMemo(


### PR DESCRIPTION
## Summary
- fix selfSelectedColor memo dependency to include selfUser

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4e093183c832695590b857430b43f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of the self-selected player color on the game board so it updates consistently when your account details change.
  * Resolved rare cases where the displayed color could become stale or not refresh after profile updates, reducing mismatches between your chosen color and what appears during play.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->