### PR TITLE
fix(backend): trust proxy for secure cookies behind proxy

### DIFF
--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -22,6 +22,8 @@ const PORT = 8080;
 console.log('Starting Board Game Prototype Server...');
 console.log(`Environment: ${env.NODE_ENV}`);
 
+app.set('trust proxy', 1);
+
 setupSwagger(app);
 setupSocket(server, app);
 connectDatabase();


### PR DESCRIPTION
Summary
- Add `app.set('trust proxy', 1)` before session initialization to ensure Express correctly detects HTTPS behind reverse proxies (e.g., CloudFront/Nginx/ALB).
- This allows `secure: true` session cookies to be set and fixes production-only 401 on Google login flow when session cookie wasn’t issued.

Context
- Recently `secure` and `sameSite` cookie flags were reintroduced in session config. Without `trust proxy`, `req.secure` can be false behind a proxy, preventing cookie issuance.
- Symptom: After Google OAuth callback, session wasn’t persisted, and `/auth/user` returned 401 only in production.

Changes
- backend/src/server.ts: add `app.set('trust proxy', 1)` before middleware setup.

Notes
- If further issues remain, review cookie domain (`FRONTEND_DOMAIN`) and consider `sameSite` adjustments per deployment.

Target branch: develop