### PR TITLE
feat: add project validation middleware

### DIFF
--- a/backend/src/middlewares/errorHandler.ts
+++ b/backend/src/middlewares/errorHandler.ts
@@ -1,5 +1,5 @@
 import { Request, Response, NextFunction } from 'express';
-import { CustomError } from '../errors/CustomError';
+import { CustomError, ValidationError } from '../errors/CustomError';
 
 export const errorHandler = (
   err: Error,
@@ -7,7 +7,9 @@ export const errorHandler = (
   res: Response,
   next: NextFunction // eslint-disable-line @typescript-eslint/no-unused-vars
 ): void => {
-  if (err instanceof CustomError) {
+  if (err instanceof ValidationError) {
+    res.status(400).json({ error: err.message });
+  } else if (err instanceof CustomError) {
     res.status(err.statusCode).json({ error: err.message });
   } else {
     console.error(err);

--- a/backend/src/middlewares/validators/project.ts
+++ b/backend/src/middlewares/validators/project.ts
@@ -1,0 +1,7 @@
+import { z } from 'zod';
+
+export const projectCreationSchema = z.object({
+  name: z
+    .string({ required_error: 'プロトタイプ名が必要です' })
+    .min(1, { message: 'プロトタイプ名が必要です' }),
+});

--- a/backend/src/middlewares/validators/validate.ts
+++ b/backend/src/middlewares/validators/validate.ts
@@ -1,0 +1,19 @@
+import { NextFunction, Request, Response } from 'express';
+import { ZodSchema, ZodError } from 'zod';
+import { ValidationError } from '../../errors/CustomError';
+
+export const validate =
+  (schema: ZodSchema, property: 'body' | 'params' = 'body') =>
+  (req: Request, _res: Response, next: NextFunction): void => {
+    try {
+      schema.parse(req[property]);
+      next();
+    } catch (error) {
+      if (error instanceof ZodError) {
+        const message = error.errors.map((e) => e.message).join(', ');
+        next(new ValidationError(message));
+      } else {
+        next(error);
+      }
+    }
+  };

--- a/backend/src/middlewares/validators/validate.ts
+++ b/backend/src/middlewares/validators/validate.ts
@@ -10,7 +10,7 @@ export const validate =
       next();
     } catch (error) {
       if (error instanceof ZodError) {
-        const message = error.errors.map((e) => e.message).join(', ');
+        const message = error.issues.map((e) => e.message).join(', ');
         next(new ValidationError(message));
       } else {
         next(error);


### PR DESCRIPTION
## Summary
- add Zod schemas and validation helper for project endpoints
- use validation middleware instead of manual checks
- handle ValidationError in global error handler

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b5b8abede08326b5596cd88ff8ca0d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added request validation for project creation endpoints.
  - Returns 400 with clear, aggregated validation messages.
  - Japanese error messages for missing/empty project name.

- Bug Fixes
  - Validation failures now consistently return 400 instead of generic server errors.
  - More predictable error handling across related endpoints.

- Refactor
  - Replaced inline request checks with a reusable validation middleware for cleaner, consistent route handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->