### PR TITLE
feat: split button component and add link variant

### DIFF
--- a/backend/swagger-output.json
+++ b/backend/swagger-output.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Board Game Prototype API",
     "version": "1.0.0",
-    "description": "\n## 概要\nこのAPIは、ボードゲームプロトタイプの作成と管理を行うためのものです。\n\n## 認証\n- 基本的にAPIエンドポイントは認証が必要です\n- アプリケーションを起動し、Google OAuth2.0を使用した認証を行なってください（Swagger UIでは認証ができません）\n- 認証後、Cookieにセッション情報が保存されます\n"
+    "description": "## 概要\nこのAPIは、ボードゲームプロトタイプの作成と管理を行うためのものです。\n\n## 認証\n- 基本的にAPIエンドポイントは認証が必要です\n- アプリケーションを起動し、Google OAuth2.0を使用した認証を行なってください（Swagger UIでは認証ができません）\n- 認証後、Cookieにセッション情報が保存されます\n"
   },
   "components": {
     "schemas": {

--- a/frontend/src/components/atoms/Button.tsx
+++ b/frontend/src/components/atoms/Button.tsx
@@ -1,9 +1,8 @@
 import { cva, type VariantProps } from 'class-variance-authority';
-import Link from 'next/link';
 import { ButtonHTMLAttributes, ReactNode } from 'react';
 import { twMerge } from 'tailwind-merge';
 
-const buttonStyles = cva(
+export const buttonStyles = cva(
   'inline-block rounded-full font-semibold transition-colors',
   {
     variants: {
@@ -31,7 +30,6 @@ interface ButtonProps
   extends ButtonHTMLAttributes<HTMLButtonElement>,
     VariantProps<typeof buttonStyles> {
   children: ReactNode;
-  href?: string;
   className?: string;
   isLoading?: boolean;
 }
@@ -41,7 +39,6 @@ export default function Button({
   variant,
   size,
   type = 'button',
-  href,
   className = '',
   isLoading = false,
   ...props
@@ -62,11 +59,6 @@ export default function Button({
         <span className="animate-pulse text-lg">・</span>
       </div>
     </button>
-  ) : href ? (
-    // リンク
-    <Link href={href} className={buttonClasses}>
-      {children}
-    </Link>
   ) : (
     // ボタン
     <button type={type} className={buttonClasses} {...props}>

--- a/frontend/src/components/atoms/LinkButton.tsx
+++ b/frontend/src/components/atoms/LinkButton.tsx
@@ -1,0 +1,32 @@
+import { type VariantProps } from 'class-variance-authority';
+import Link, { type LinkProps } from 'next/link';
+import { ReactNode } from 'react';
+import { twMerge } from 'tailwind-merge';
+
+import { buttonStyles } from './Button';
+
+interface LinkButtonProps
+  extends LinkProps,
+    VariantProps<typeof buttonStyles> {
+  children: ReactNode;
+  className?: string;
+}
+
+export default function LinkButton({
+  children,
+  variant,
+  size,
+  className = '',
+  ...props
+}: LinkButtonProps) {
+  const buttonClasses = twMerge(
+    buttonStyles({ variant, size }),
+    className,
+  );
+
+  return (
+    <Link className={buttonClasses} {...props}>
+      {children}
+    </Link>
+  );
+}

--- a/frontend/src/components/atoms/__tests__/Button.test.tsx
+++ b/frontend/src/components/atoms/__tests__/Button.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen } from '@testing-library/react';
+
+import Button from '../Button';
+
+describe('Button', () => {
+  it('renders a button element with default styles', () => {
+    render(<Button>Click me</Button>);
+    const button = screen.getByRole('button');
+    expect(button.tagName).toBe('BUTTON');
+    expect(button.className).toContain('rounded-full');
+    expect(button.className).toContain('bg-kibako-primary');
+  });
+
+  it('shows loading state', () => {
+    render(<Button isLoading>Loading</Button>);
+    // three dots are rendered when loading
+    const dots = screen.getAllByText('・');
+    expect(dots).toHaveLength(3);
+  });
+});

--- a/frontend/src/components/atoms/__tests__/LinkButton.test.tsx
+++ b/frontend/src/components/atoms/__tests__/LinkButton.test.tsx
@@ -1,0 +1,13 @@
+import { render, screen } from '@testing-library/react';
+
+import LinkButton from '../LinkButton';
+
+describe('LinkButton', () => {
+  it('renders a link element with button styles', () => {
+    render(<LinkButton href="/test">Go</LinkButton>);
+    const link = screen.getByRole('link');
+    expect(link.tagName).toBe('A');
+    expect(link.className).toContain('rounded-full');
+    expect(link.className).toContain('bg-kibako-primary');
+  });
+});

--- a/frontend/src/components/molecules/Login.tsx
+++ b/frontend/src/components/molecules/Login.tsx
@@ -7,7 +7,7 @@ import { GiWoodenCrate, GiCardAceSpades, GiPuzzle } from 'react-icons/gi';
 
 import { getApiUrl } from '@/api/client';
 import { useAuth } from '@/api/hooks/useAuth';
-import Button from '@/components/atoms/Button';
+import LinkButton from '@/components/atoms/LinkButton';
 import Loading from '@/components/organisms/Loading';
 
 function Login() {
@@ -57,18 +57,16 @@ function Login() {
 
         {/* 認証ボタン */}
         <div className="flex flex-col gap-4 items-center mt-12 sm:mt-16">
-          <Button
+          <LinkButton
             variant="accent"
             className="!px-6 !py-4 !text-lg"
-            onClick={() => {
-              router.push(getApiUrl('/auth/google'));
-            }}
+            href={getApiUrl('/auth/google')}
           >
             <div className="flex items-center gap-3">
               <FaGoogle className="text-2xl" />
               <span>Googleで続ける</span>
             </div>
-          </Button>
+          </LinkButton>
         </div>
 
         {/* サブタイトル */}

--- a/frontend/src/features/profile/components/ProfileEdit.tsx
+++ b/frontend/src/features/profile/components/ProfileEdit.tsx
@@ -6,10 +6,10 @@ import { FaCheck } from 'react-icons/fa6';
 import { IoArrowBack } from 'react-icons/io5';
 
 import { useUsers } from '@/api/hooks/useUsers';
+import Button from '@/components/atoms/Button';
 import { useUser } from '@/hooks/useUser';
 
 import ProfileEditSkeleton from './ProfileEditSkeleton';
-import Button from '@/components/atoms/Button';
 
 const ProfileEdit: React.FC = () => {
   const router = useRouter();

--- a/frontend/src/features/profile/components/ProfileEdit.tsx
+++ b/frontend/src/features/profile/components/ProfileEdit.tsx
@@ -9,6 +9,7 @@ import { useUsers } from '@/api/hooks/useUsers';
 import { useUser } from '@/hooks/useUser';
 
 import ProfileEditSkeleton from './ProfileEditSkeleton';
+import Button from '@/components/atoms/Button';
 
 const ProfileEdit: React.FC = () => {
   const router = useRouter();
@@ -136,13 +137,10 @@ const ProfileEdit: React.FC = () => {
           </div>
 
           <div className="flex justify-end">
-            <button
-              type="submit"
-              className="flex items-center gap-1 px-4 py-2 rounded-md bg-kibako-secondary hover:bg-kibako-primary text-kibako-white hover:shadow-md transition-all font-medium"
-            >
+            <Button type="submit" size="sm" className="flex items-center gap-1 !px-4 !py-2 !text-base">
               <FaCheck className="w-4 h-4" />
               更新する
-            </button>
+            </Button>
           </div>
           {error && (
             <div className="text-kibako-danger text-sm bg-kibako-danger/10 p-2 rounded-md border border-kibako-danger/10">


### PR DESCRIPTION
## Summary
- restrict `Button` to render only `<button>` with loading indicator
- add `LinkButton` for link rendering using shared button styles
- test both components for correct elements and classes

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b5b8ac4420832681a0be2525fe1ef4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added LinkButton: navigational links styled like buttons, matching existing button variants and sizes.
- Refactor
  - Button now always renders as a native button element (no href/link variant).
- UI Updates
  - Google sign-in now uses LinkButton; form submit uses the styled Button for consistent appearance.
- Tests
  - Added tests for Button (default and loading) and LinkButton (link role and styling).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->