### PR TITLE
refactor: decouple deck shuffling

### DIFF
--- a/backend/src/helpers/prototypeHelper.test.ts
+++ b/backend/src/helpers/prototypeHelper.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, afterEach, beforeAll } from 'vitest';
+
+vi.mock('../models/Part', () => ({
+  default: { update: vi.fn() },
+}));
+vi.mock('../config/env', () => ({ default: {} }));
+vi.mock('../models/Project', () => ({ default: {} }));
+vi.mock('./roleHelper', () => ({ getAccessibleResourceIds: vi.fn() }));
+vi.mock('../const', () => ({ RESOURCE_TYPES: {}, PERMISSION_ACTIONS: {} }));
+
+let PartModel: any;
+let shuffleArray: any;
+let shuffleDeck: any;
+let persistDeckOrder: any;
+
+beforeAll(async () => {
+  process.env.DATABASE_URL = 'postgres://test';
+  process.env.FRONTEND_URL = 'http://localhost';
+  process.env.FRONTEND_DOMAIN = 'localhost';
+  process.env.SESSION_SECRET = 'secret';
+  process.env.GOOGLE_CLIENT_ID = 'id';
+  process.env.GOOGLE_CLIENT_SECRET = 'secret';
+  process.env.GOOGLE_CALLBACK_URL = 'http://localhost';
+  process.env.AWS_REGION = 'us-east-1';
+  process.env.AWS_ACCESS_KEY_ID = 'key';
+  process.env.AWS_SECRET_ACCESS_KEY = 'secret';
+  process.env.AWS_S3_BUCKET_NAME = 'bucket';
+
+  PartModel = (await import('../models/Part')).default;
+  ({ shuffleArray, shuffleDeck, persistDeckOrder } = await import(
+    './prototypeHelper'
+  ));
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('shuffleArray', () => {
+  it('shuffles array without mutating original', () => {
+    const randomSpy = vi
+      .spyOn(Math, 'random')
+      .mockReturnValueOnce(0.5)
+      .mockReturnValueOnce(0);
+
+    const original = [1, 2, 3];
+    const result = shuffleArray(original);
+
+    expect(original).toEqual([1, 2, 3]);
+    expect(result).toEqual([3, 1, 2]);
+
+    randomSpy.mockRestore();
+  });
+});
+
+describe('shuffleDeck and persistDeckOrder', () => {
+  it('shuffles deck and persists order', async () => {
+    vi.spyOn(Math, 'random').mockReturnValueOnce(0.5).mockReturnValueOnce(0);
+
+    const cards = [
+      { id: 1, order: 1 },
+      { id: 2, order: 2 },
+      { id: 3, order: 3 },
+    ];
+
+    const shuffled = shuffleDeck(cards);
+    expect(shuffled).toEqual([
+      { id: 3, order: 1 },
+      { id: 1, order: 2 },
+      { id: 2, order: 3 },
+    ]);
+
+    expect(cards.map((c) => c.order)).toEqual([1, 2, 3]);
+
+    const updateSpy = vi
+      .spyOn(PartModel, 'update')
+      .mockImplementation(async (values: any, options: any) => {
+        return [
+          1,
+          [{ dataValues: { id: options.where.id, order: values.order } }],
+        ] as any;
+      });
+
+    const updated = await persistDeckOrder(shuffled);
+    expect(updated).toEqual([
+      { id: 3, order: 1 },
+      { id: 1, order: 2 },
+      { id: 2, order: 3 },
+    ]);
+
+    expect(updateSpy).toHaveBeenCalledTimes(3);
+  });
+});

--- a/backend/src/socket/prototypeHandler.ts
+++ b/backend/src/socket/prototypeHandler.ts
@@ -5,7 +5,11 @@ import { UPDATABLE_PROTOTYPE_FIELDS } from '../const';
 import PrototypeModel from '../models/Prototype';
 import UserModel from '../models/User';
 import { Op } from 'sequelize';
-import { shuffleDeck, isOverlapping } from '../helpers/prototypeHelper';
+import {
+  shuffleDeck,
+  persistDeckOrder,
+  isOverlapping,
+} from '../helpers/prototypeHelper';
 import ImageModel from '../models/Image';
 import {
   ORDER_MAX_EXCLUSIVE,
@@ -607,7 +611,8 @@ function handleShuffleDeck(socket: Socket, io: Server): void {
             cardCenter.y <= deck.position.y + deck.height
           );
         });
-        const updatedCards = await shuffleDeck(cardsOnDeck);
+        const shuffledCards = shuffleDeck(cardsOnDeck);
+        const updatedCards = await persistDeckOrder(shuffledCards);
         io.to(prototypeId).emit(PROTOTYPE_SOCKET_EVENT.UPDATE_PARTS, {
           parts: updatedCards,
           properties: [],


### PR DESCRIPTION
## Summary
- extract pure `shuffleArray` utility
- add `persistDeckOrder` to save shuffled order
- update socket handler and add unit tests

## Testing
- `npx vitest run src/helpers/prototypeHelper.test.ts`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b628545878832683cba95bd8a9bb21