### PR TITLE
feat: add image access middleware

### DIFF
--- a/backend/src/middlewares/checkImageAccess.test.ts
+++ b/backend/src/middlewares/checkImageAccess.test.ts
@@ -1,0 +1,75 @@
+import type { Request, Response } from 'express';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { checkImageAccess } from './checkImageAccess';
+import ImageModel from '../models/Image';
+import { UnauthorizedError, ForbiddenError } from '../errors/CustomError';
+
+vi.mock('../models/Image', () => ({
+  default: { findByPk: vi.fn() },
+}));
+
+const mockedFindByPk = ImageModel.findByPk as unknown as ReturnType<
+  typeof vi.fn
+>;
+
+beforeEach(() => {
+  mockedFindByPk.mockReset();
+});
+
+describe('checkImageAccess middleware', () => {
+  it('allows access when user uploaded image', async () => {
+    const req = {
+      params: { imageId: 'img1' },
+      user: { id: 'user1' },
+    } as unknown as Request;
+    const res = { locals: {} } as unknown as Response;
+    const next = vi.fn();
+
+    mockedFindByPk.mockResolvedValue({
+      id: 'img1',
+      uploaderUserId: 'user1',
+      storagePath: 'path',
+      contentType: 'image/png',
+    });
+
+    await checkImageAccess(req, res, next);
+
+    expect(next).toHaveBeenCalledWith();
+    expect(res.locals.image).toEqual(expect.objectContaining({ id: 'img1' }));
+  });
+
+  it('denies access for unauthenticated user', async () => {
+    const req = { params: { imageId: 'img1' } } as unknown as Request;
+    const res = { locals: {} } as unknown as Response;
+    const next = vi.fn();
+
+    await checkImageAccess(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+    const error = next.mock.calls[0][0] as UnauthorizedError;
+    expect(error.statusCode).toBe(401);
+    expect(mockedFindByPk).not.toHaveBeenCalled();
+  });
+
+  it('denies access when user not uploader', async () => {
+    const req = {
+      params: { imageId: 'img1' },
+      user: { id: 'user2' },
+    } as unknown as Request;
+    const res = { locals: {} } as unknown as Response;
+    const next = vi.fn();
+
+    mockedFindByPk.mockResolvedValue({
+      id: 'img1',
+      uploaderUserId: 'user1',
+      storagePath: 'path',
+      contentType: 'image/png',
+    });
+
+    await checkImageAccess(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+    const error = next.mock.calls[0][0] as ForbiddenError;
+    expect(error.statusCode).toBe(403);
+  });
+});

--- a/backend/src/middlewares/checkImageAccess.ts
+++ b/backend/src/middlewares/checkImageAccess.ts
@@ -1,0 +1,42 @@
+import { Request, Response, NextFunction } from 'express';
+import ImageModel from '../models/Image';
+import type UserModel from '../models/User';
+import {
+  UnauthorizedError,
+  ForbiddenError,
+  NotFoundError,
+  ValidationError,
+} from '../errors/CustomError';
+
+export const checkImageAccess = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> => {
+  try {
+    const user = req.user as UserModel | undefined;
+    const { imageId } = req.params;
+
+    if (!user) {
+      throw new UnauthorizedError('認証されていないユーザーです');
+    }
+
+    if (!imageId) {
+      throw new ValidationError('Image ID が指定されていません');
+    }
+
+    const image = await ImageModel.findByPk(imageId);
+    if (!image) {
+      throw new NotFoundError('指定された画像が存在しません');
+    }
+
+    if (image.uploaderUserId !== String(user.id)) {
+      throw new ForbiddenError('この画像にアクセスする権限がありません');
+    }
+
+    res.locals.image = image;
+    next();
+  } catch (error) {
+    next(error);
+  }
+};


### PR DESCRIPTION
## Summary
- add middleware to validate image access
- apply middleware to image routes
- test authorized and unauthorized access

## Testing
- `npm test -- --run`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68b62845ef88832680dd93f23a88cff1