### PR TITLE
refactor: centralize image cache utilities

### DIFF
--- a/frontend/src/features/prototype/components/organisms/GameBoard.tsx
+++ b/frontend/src/features/prototype/components/organisms/GameBoard.tsx
@@ -39,10 +39,10 @@ import { useRoleManagement } from '@/features/role/hooks/useRoleManagement';
 import {
   getImageFromIndexedDb,
   resetImageParamsInIndexedDb,
-  revokeMultipleObjectURLsAndCleanCache,
   saveImageToIndexedDb,
   updateImageParamsInIndexedDb,
 } from '@/utils/db';
+import { revokeMultipleObjectURLsAndCleanCache } from '@/utils/imageCache';
 import { isInputFieldFocused } from '@/utils/inputFocus';
 
 import GameBoardCanvas from './GameBoardCanvas';

--- a/frontend/src/utils/imageCache.ts
+++ b/frontend/src/utils/imageCache.ts
@@ -1,0 +1,24 @@
+const objectUrlCache = new Map<string, string>();
+
+export const getCachedObjectURL = (id: string): string | undefined =>
+  objectUrlCache.get(id);
+
+export const setCachedObjectURL = (id: string, url: string): void => {
+  objectUrlCache.set(id, url);
+};
+
+export const hasCachedObjectURL = (id: string): boolean =>
+  objectUrlCache.has(id);
+
+export const revokeObjectURLAndCleanCache = (id: string): void => {
+  const objectURL = objectUrlCache.get(id);
+  if (objectURL) {
+    URL.revokeObjectURL(objectURL);
+    objectUrlCache.delete(id);
+  }
+};
+
+export const revokeMultipleObjectURLsAndCleanCache = (ids: string[]): void => {
+  ids.forEach((id) => revokeObjectURLAndCleanCache(id));
+};
+


### PR DESCRIPTION
## Summary
- add `imageCache` utility for object URL caching and revocation
- migrate DB utilities to use `imageCache`
- update GameBoard to import cache helpers from new module

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6282d42688326aeb80483e184ce23