### PR TITLE
fix: skip missing images during prototype load

### DIFF
--- a/frontend/src/features/prototype/components/organisms/GameBoard.tsx
+++ b/frontend/src/features/prototype/components/organisms/GameBoard.tsx
@@ -416,10 +416,14 @@ export default function GameBoard({
           if (cachedImageResult) {
             return { imageId, url: cachedImageResult.objectURL };
           }
-          const s3ImageBlob = await fetchImage(imageId);
-          const imageResult = await saveImageToIndexedDb(imageId, s3ImageBlob);
-          if (imageResult) {
-            return { imageId, url: imageResult.objectURL };
+          try {
+            const s3ImageBlob = await fetchImage(imageId);
+            const imageResult = await saveImageToIndexedDb(imageId, s3ImageBlob);
+            if (imageResult) {
+              return { imageId, url: imageResult.objectURL };
+            }
+          } catch (error) {
+            console.warn(`Image with ID ${imageId} could not be loaded.`, error);
           }
           return null;
         })


### PR DESCRIPTION
## Summary
- avoid crash when an imageId has no image by skipping failed fetches

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b63ca4c54c8326baec414686c0e0c4