### PR TITLE
fix: show CI summary even on failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,9 +62,11 @@ jobs:
           echo "- Frontend test: ${{ steps.frontend_test.outcome }}" >> $GITHUB_STEP_SUMMARY
           echo "- Backend lint: ${{ steps.backend_lint.outcome }}" >> $GITHUB_STEP_SUMMARY
           echo "- Backend test: ${{ steps.backend_test.outcome }}" >> $GITHUB_STEP_SUMMARY
-          if [ "${{ steps.frontend_lint.outcome }}" != "success" ] || \
-             [ "${{ steps.frontend_test.outcome }}" != "success" ] || \
-             [ "${{ steps.backend_lint.outcome }}" != "success" ] || \
-             [ "${{ steps.backend_test.outcome }}" != "success" ]; then
-            exit 1
-          fi
+
+      - name: Fail if any step failed
+        if: >
+          steps.frontend_lint.outcome != 'success' ||
+          steps.frontend_test.outcome != 'success' ||
+          steps.backend_lint.outcome != 'success' ||
+          steps.backend_test.outcome != 'success'
+        run: exit 1


### PR DESCRIPTION
## Summary
- split CI summary and failure check steps so summary renders

## Testing
- `npm test` (frontend)
- `npm run lint` (frontend)
- `npm test -- --run` (backend)
- `npm run lint` (backend)


------
https://chatgpt.com/codex/tasks/task_e_68b63ff032a0832697d7b72111394286