### PR TITLE
chore: remove unsupported eslint rule

### DIFF
--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -7,7 +7,10 @@
     "prettier"
   ],
   "plugins": ["import", "@typescript-eslint", "react"],
-  "ignorePatterns": ["src/api/types/**/*"],
+  "ignorePatterns": [
+    "src/api/types/**/*",
+    "next-env.d.ts"
+  ],
   "rules": {
     "react/react-in-jsx-scope": "off",
     "react/prop-types": "off",

--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -17,7 +17,6 @@
       "warn",
       { "argsIgnorePattern": "^_" }
     ],
-    "@typescript-eslint/no-empty-object-type": "warn",
     "@typescript-eslint/no-unused-expressions": ["error", {
       "allowShortCircuit": true,
       "allowTernary": true,

--- a/frontend/src/features/prototype/hooks/usePartContextMenu.ts
+++ b/frontend/src/features/prototype/hooks/usePartContextMenu.ts
@@ -55,7 +55,7 @@ export function usePartContextMenu({
         // evt が存在しないケースがあるため保護
         e.evt.preventDefault();
       } catch (err) {
-        // evt が無い、または preventDefault に失敗した場合は無視する
+        console.error('usePartContextMenu: preventDefault failed', err);
       }
 
       // ステージからマウス位置を取得してメニュー位置を設定

--- a/frontend/src/features/prototype/types/part.ts
+++ b/frontend/src/features/prototype/types/part.ts
@@ -27,8 +27,10 @@ export interface PartDefaultConfig {
 /**
  * パーツの共通プロパティ型
  */
-export interface CommonPartProperties
-  extends Pick<PartProperty, 'name' | 'description' | 'color' | 'textColor'> {}
+export type CommonPartProperties = Pick<
+  PartProperty,
+  'name' | 'description' | 'color' | 'textColor'
+>;
 
 /**
  * パーツを追加時のprops

--- a/frontend/src/features/role/components/organisms/RoleManagement.tsx
+++ b/frontend/src/features/role/components/organisms/RoleManagement.tsx
@@ -77,7 +77,7 @@ const RoleManagement: React.FC = () => {
       try {
         fetchAllUsers(searchTerm);
       } catch (e) {
-        // エラーは無視（フック側で処理される）
+        console.error('RoleManagement: fetchAllUsers failed', e);
       }
     }, 500);
 

--- a/frontend/src/utils/db.ts
+++ b/frontend/src/utils/db.ts
@@ -165,7 +165,6 @@ export const resetImageParamsInIndexedDb = async (
       await db.put(STORE_NAME, record);
     }
   } catch (error) {
-    // エラー時は何もしない
+    console.error('resetImageParamsInIndexedDb failed', error);
   }
 };
-


### PR DESCRIPTION
## Summary
- remove `@typescript-eslint/no-empty-object-type` from frontend ESLint config

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b64581ae1c832682de579a54a8e4ea

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Added clearer error logging for context menu actions, user search in role management, and image settings reset to improve visibility of failures in the browser console.

- Chores
  - Updated lint configuration, including adjustments to ignored files and rule cleanup. No user-facing impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->