### PR TITLE
fix: correct template string in image upload size message

### DIFF
--- a/backend/src/services/imageUploadService.ts
+++ b/backend/src/services/imageUploadService.ts
@@ -34,7 +34,7 @@ export const uploadImageToS3 = async (
   //最低限のチェック（ファイルサイズ、MIMEタイプ）
   if (file.size > IMAGE_MAX_SIZE) {
     throw new ValidationError(
-      `ファイルサイズが大きすぎます（最大$${IMAGE_MAX_SIZE_MB}MBまで）`
+      `ファイルサイズが大きすぎます（最大${IMAGE_MAX_SIZE_MB}MBまで）`
     );
   }
 


### PR DESCRIPTION
This pull request makes a minor correction to the error message formatting in the image upload validation logic. The change ensures that the maximum file size is displayed correctly in the error message.