### PR TITLE
fix: await database connection before starting server

### DIFF
--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -19,40 +19,53 @@ const app = express();
 const server = http.createServer(app);
 const PORT = 8080;
 
-console.log('Starting Board Game Prototype Server...');
-console.log(`Environment: ${env.NODE_ENV}`);
+async function start() {
+  console.log('Starting Board Game Prototype Server...');
+  console.log(`Environment: ${env.NODE_ENV}`);
 
-app.set('trust proxy', 1);
+  app.set('trust proxy', 1);
 
-setupSwagger(app);
-setupSocket(server, app);
-connectDatabase();
+  setupSwagger(app);
+  setupSocket(server, app);
 
-app.use(
-  cors({
-    origin: env.FRONTEND_URL,
-    credentials: true,
-  })
-);
-
-app.use(express.json());
-
-setupSession(app);
-
-app.use('/auth', authRoutes);
-app.use('/api/prototypes', prototypeRoutes);
-app.use('/api/projects', projectRoutes);
-app.use('/api/users', userRoutes);
-app.use('/api/images', imageRoutes);
-
-app.use(errorHandler);
-
-server.listen(PORT, () => {
-  console.log(`Server is running on port ${PORT}`);
-  console.log(`Socket.IO is ready for real-time connections`);
-  if (env.NODE_ENV === 'development') {
-    console.log(
-      `API Documentation available at: http://localhost:${PORT}/api-docs`
-    );
+  try {
+    await connectDatabase();
+  } catch (error) {
+    console.error('Failed to connect to database', error);
+    process.exit(1);
   }
+
+  app.use(
+    cors({
+      origin: env.FRONTEND_URL,
+      credentials: true,
+    })
+  );
+
+  app.use(express.json());
+
+  setupSession(app);
+
+  app.use('/auth', authRoutes);
+  app.use('/api/prototypes', prototypeRoutes);
+  app.use('/api/projects', projectRoutes);
+  app.use('/api/users', userRoutes);
+  app.use('/api/images', imageRoutes);
+
+  app.use(errorHandler);
+
+  server.listen(PORT, () => {
+    console.log(`Server is running on port ${PORT}`);
+    console.log(`Socket.IO is ready for real-time connections`);
+    if (env.NODE_ENV === 'development') {
+      console.log(
+        `API Documentation available at: http://localhost:${PORT}/api-docs`
+      );
+    }
+  });
+}
+
+start().catch((error) => {
+  console.error('Failed to start server', error);
+  process.exit(1);
 });


### PR DESCRIPTION
## Summary
- start backend server from async `start` to ensure database initialization
- handle database connection errors before starting the HTTP server

## Testing
- `npm test -- --run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b64c5a95b88326a3e8f7a78e8de616

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Streamlined server startup into a single async flow with clear sequencing.
  - Ensured middleware and routes are fully registered before the server begins listening.
  - Consolidated startup logging within the initialization process.

- Bug Fixes
  - Startup errors are now properly caught and reported, preventing partial or unstable launches.
  - Database connection is awaited with robust handling to avoid silent failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->