### PR TITLE
feat: add loading dots and improve button accessibility

### DIFF
--- a/frontend/src/components/atoms/Button.tsx
+++ b/frontend/src/components/atoms/Button.tsx
@@ -2,6 +2,8 @@ import { cva, type VariantProps } from 'class-variance-authority';
 import { ButtonHTMLAttributes, ReactNode } from 'react';
 import { twMerge } from 'tailwind-merge';
 
+import LoadingDots from './LoadingDots';
+
 export const buttonStyles = cva(
   'inline-block rounded-full font-semibold transition-colors',
   {
@@ -48,21 +50,22 @@ export default function Button({
     className,
   );
 
-  return isLoading ? (
-    // ローディング中(3つのドットを点滅表示)
-    <button type={type} className={buttonClasses} {...props}>
-      {/* NOTE: ローディング中は子要素を非表示にする(ボタンの横幅を維持するためinvisibleを使用) */}
-      <div className="invisible h-0">{children}</div>
-      <div className="flex items-center justify-center gap-2">
-        <span className="animate-pulse text-lg">・</span>
-        <span className="animate-pulse text-lg">・</span>
-        <span className="animate-pulse text-lg">・</span>
-      </div>
-    </button>
-  ) : (
-    // ボタン
-    <button type={type} className={buttonClasses} {...props}>
-      {children}
+  return (
+    <button
+      type={type}
+      className={buttonClasses}
+      aria-busy={isLoading}
+      {...props}
+    >
+      {isLoading ? (
+        <>
+          {/* NOTE: ローディング中は子要素を非表示にする(ボタンの横幅を維持するためinvisibleを使用) */}
+          <div className="invisible h-0">{children}</div>
+          <LoadingDots />
+        </>
+      ) : (
+        children
+      )}
     </button>
   );
 }

--- a/frontend/src/components/atoms/LoadingDots.tsx
+++ b/frontend/src/components/atoms/LoadingDots.tsx
@@ -1,0 +1,17 @@
+import { FC } from 'react';
+
+interface LoadingDotsProps {
+  count?: number;
+}
+
+const LoadingDots: FC<LoadingDotsProps> = ({ count = 3 }) => (
+  <div className="flex items-center justify-center gap-2" role="status" aria-label="Loading">
+    {Array.from({ length: count }).map((_, index) => (
+      <span key={index} className="animate-pulse text-lg" aria-hidden="true">
+        ・
+      </span>
+    ))}
+  </div>
+);
+
+export default LoadingDots;

--- a/frontend/src/components/atoms/__tests__/Button.test.tsx
+++ b/frontend/src/components/atoms/__tests__/Button.test.tsx
@@ -13,8 +13,11 @@ describe('Button', () => {
 
   it('shows loading state', () => {
     render(<Button isLoading>Loading</Button>);
-    // three dots are rendered when loading
-    const dots = screen.getAllByText('・');
+    const button = screen.getByRole('button');
+    expect(button).toHaveAttribute('aria-busy', 'true');
+
+    const status = screen.getByRole('status');
+    const dots = status.querySelectorAll('span');
     expect(dots).toHaveLength(3);
   });
 });


### PR DESCRIPTION
## Summary
- create `LoadingDots` atom for animating dot indicators
- replace manual dots in `Button` with `LoadingDots` and add `aria-busy`
- cover loading state and accessibility in tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6678b33248326b1a44a81f1323b42