### PR TITLE
refactor: make atom inputs controlled

### DIFF
--- a/frontend/src/components/atoms/NumberInput.tsx
+++ b/frontend/src/components/atoms/NumberInput.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useState } from 'react';
+import React, { ReactNode } from 'react';
 
 const NumberInput = ({
   value,
@@ -18,45 +18,24 @@ const NumberInput = ({
   // アイコン
   icon: ReactNode;
 }) => {
-  // 入力値
-  const [inputValue, setInputValue] = useState(value?.toString() || '');
-
-  /**
-   * 値が変更されたときの処理
-   */
-  const handleChange = () => {
-    const newValue = parseFloat(inputValue);
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    let newValue = e.target.valueAsNumber;
 
     if (isNaN(newValue)) {
-      setInputValue(value.toString());
+      onChange(newValue);
       return;
     }
 
-    const clampedValue = Math.min(
-      max ?? newValue,
-      Math.max(min ?? newValue, newValue)
-    );
-    onChange(clampedValue);
-  };
-
-  /**
-   * キー押下時の処理
-   */
-  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (e.key !== 'Enter') return;
-
-    handleChange();
-    (e.currentTarget as HTMLInputElement).blur();
+    newValue = Math.min(max ?? newValue, Math.max(min ?? newValue, newValue));
+    onChange(newValue);
   };
 
   return (
     <div className="relative h-fit w-full">
       <input
         type="number"
-        value={inputValue}
-        onChange={(e) => setInputValue(e.target.value)}
-        onBlur={handleChange}
-        onKeyDown={handleKeyDown}
+        value={value}
+        onChange={handleChange}
         min={min}
         max={max}
         className={`h-fit w-full rounded-lg border border-[#f5f5f5] bg-[#f5f5f5] px-2 py-1 pl-6 text-xs hover:border-[#e8e8e8]`}

--- a/frontend/src/components/atoms/TextInput.tsx
+++ b/frontend/src/components/atoms/TextInput.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useState } from 'react';
+import React, { ReactNode } from 'react';
 
 type TextInputProps = {
   // 入力値
@@ -20,61 +20,13 @@ const TextInput: React.FC<TextInputProps> = ({
   multiline = false,
   resizable = false,
 }) => {
-  // 入力値
-  const [inputValue, setInputValue] = useState(value);
-  // 日本語入力の変換中か
-  const [isComposing, setIsComposing] = useState(false);
-
-  /**
-   * キー押下時の処理
-   */
-  const handleKeyDown = (
-    e: React.KeyboardEvent<HTMLInputElement | HTMLTextAreaElement>
-  ) => {
-    // 複数行入力の場合、Enterキー以外の場合は何もしない
-    if (multiline || e.key !== 'Enter') return;
-
-    // 日本語変換中のEnterキーの場合は何もしない
-    if (isComposing) return;
-
-    onChange(inputValue);
-    // フォーカスを外す
-    (e.currentTarget as HTMLElement).blur();
-  };
-
-  /**
-   * フォーカスが外れたときの処理
-   */
-  const handleBlur = () => {
-    onChange(inputValue);
-  };
-
-  /**
-   * 日本語入力の変換開始時の処理
-   */
-  const handleCompositionStart = () => {
-    setIsComposing(true);
-  };
-
-  /**
-   * 日本語入力の変換終了時の処理
-   */
-  const handleCompositionEnd = () => {
-    setIsComposing(false);
-  };
-
-  // 入力コンポーネント
   const InputComponent = multiline ? 'textarea' : 'input';
 
   return (
     <div className="relative h-fit w-full">
       <InputComponent
-        value={inputValue}
-        onChange={(e) => setInputValue(e.target.value)}
-        onKeyDown={handleKeyDown}
-        onBlur={handleBlur}
-        onCompositionStart={handleCompositionStart}
-        onCompositionEnd={handleCompositionEnd}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
         rows={multiline ? 3 : undefined}
         className={`h-fit w-full rounded-lg border border-[#f5f5f5] bg-[#f5f5f5] px-2 py-1 pl-6 text-xs hover:border-[#e8e8e8] ${
           multiline && !resizable

--- a/frontend/src/components/atoms/__tests__/NumberInput.test.tsx
+++ b/frontend/src/components/atoms/__tests__/NumberInput.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+
+import NumberInput from '../NumberInput';
+
+describe('NumberInput', () => {
+  it('calls onChange with new value on input', () => {
+    const handleChange = vi.fn();
+    render(<NumberInput value={1} onChange={handleChange} icon={<span />} />);
+    const input = screen.getByRole('spinbutton');
+    fireEvent.change(input, { target: { value: '2' } });
+    expect(handleChange).toHaveBeenCalledWith(2);
+    // value is controlled by props
+    expect(input).toHaveValue(1);
+  });
+
+  it('clamps value within min and max', () => {
+    const handleChange = vi.fn();
+    render(
+      <NumberInput
+        value={5}
+        min={0}
+        max={10}
+        onChange={handleChange}
+        icon={<span />}
+      />
+    );
+    const input = screen.getByRole('spinbutton');
+    fireEvent.change(input, { target: { value: '20' } });
+    expect(handleChange).toHaveBeenCalledWith(10);
+  });
+});

--- a/frontend/src/components/atoms/__tests__/TextInput.test.tsx
+++ b/frontend/src/components/atoms/__tests__/TextInput.test.tsx
@@ -1,0 +1,15 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+
+import TextInput from '../TextInput';
+
+describe('TextInput', () => {
+  it('calls onChange with new value on input', () => {
+    const handleChange = vi.fn();
+    render(<TextInput value="hello" onChange={handleChange} icon={<span />} />);
+    const input = screen.getByRole('textbox');
+    fireEvent.change(input, { target: { value: 'world' } });
+    expect(handleChange).toHaveBeenCalledWith('world');
+    // value is controlled by props
+    expect(input).toHaveValue('hello');
+  });
+});


### PR DESCRIPTION
## Summary
- remove internal state from `NumberInput` and `TextInput`
- trigger `onChange` directly on input events
- add tests verifying controlled behavior

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6676253d08326b09fa67107fd359e