### PR TITLE
refactor: integrate react-query into API hooks

### DIFF
--- a/frontend/src/api/hooks/useAuth.ts
+++ b/frontend/src/api/hooks/useAuth.ts
@@ -1,22 +1,16 @@
-import { useCallback } from 'react';
+import { useMutation, useQuery } from '@tanstack/react-query';
 
 import { authService } from '@/api/endpoints/auth';
 
 export const useAuth = () => {
-  /**
-   * ログアウトする
-   */
-  const logout = useCallback(async () => {
-    await authService.logout();
-  }, []);
+  const logout = useMutation({
+    mutationFn: authService.logout,
+  });
 
-  /**
-   * ユーザーを取得する
-   */
-  const getUser = useCallback(async () => {
-    const user = await authService.getUser();
-    return user;
-  }, []);
+  const getUser = useQuery({
+    queryKey: ['auth', 'user'],
+    queryFn: authService.getUser,
+  });
 
   return { logout, getUser };
 };

--- a/frontend/src/api/hooks/useImages.ts
+++ b/frontend/src/api/hooks/useImages.ts
@@ -1,33 +1,22 @@
-import { useCallback } from 'react';
+import { useMutation } from '@tanstack/react-query';
 
 import { imagesService } from '@/api/endpoints/images';
 
 import { ImagesDeleteParams } from '../types';
 
 export const useImages = () => {
-  /**
-   * 画像取得
-   */
-  const fetchImage = useCallback(async (imageId: string) => {
-    return await imagesService.fetchImage(imageId);
-  }, []);
+  const fetchImage = useMutation({
+    mutationFn: (imageId: string) => imagesService.fetchImage(imageId),
+  });
 
-  /**
-   * 画像アップロード
-   */
-  const uploadImage = useCallback(async (data: FormData) => {
-    return await imagesService.uploadImage(data);
-  }, []);
+  const uploadImage = useMutation({
+    mutationFn: (data: FormData) => imagesService.uploadImage(data),
+  });
 
-  /**
-   * 画像削除
-   */
-  const deleteImage = useCallback(
-    async (imageId: string, params: Omit<ImagesDeleteParams, 'imageId'>) => {
-      return await imagesService.deleteImage(imageId, params);
-    },
-    []
-  );
+  const deleteImage = useMutation({
+    mutationFn: ({ imageId, ...params }: ImagesDeleteParams) =>
+      imagesService.deleteImage(imageId, params),
+  });
 
   return {
     fetchImage,

--- a/frontend/src/api/hooks/useUsers.ts
+++ b/frontend/src/api/hooks/useUsers.ts
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useMutation } from '@tanstack/react-query';
 
 import { usersService } from '@/api/endpoints/users';
 import {
@@ -8,32 +8,25 @@ import {
 } from '@/api/types';
 
 export const useUsers = () => {
-  /**
-   * ユーザーを検索する
-   */
-  const searchUsers = useCallback(async (query: UsersSearchListParams) => {
-    return await usersService.searchUsers(query);
-  }, []);
+  const searchUsers = useMutation({
+    mutationFn: (query: UsersSearchListParams) =>
+      usersService.searchUsers(query),
+  });
 
-  /**
-   * ユーザー情報を更新する
-   */
-  const updateUser = useCallback(
-    async (userId: string, data: UsersUpdatePayload) => {
-      return await usersService.updateUser(userId, data);
-    },
-    []
-  );
+  const updateUser = useMutation({
+    mutationFn: ({
+      userId,
+      data,
+    }: {
+      userId: string;
+      data: UsersUpdatePayload;
+    }) => usersService.updateUser(userId, data),
+  });
 
-  /**
-   * チュートリアル表示が必要かどうかを確認する
-   */
-  const checkNeedTutorial = useCallback(
-    async (userId: string): Promise<UsersNeedTutorialData> => {
-      return await usersService.checkNeedTutorial(userId);
-    },
-    []
-  );
+  const checkNeedTutorial = useMutation({
+    mutationFn: (userId: string): Promise<UsersNeedTutorialData> =>
+      usersService.checkNeedTutorial(userId),
+  });
 
   return {
     searchUsers,

--- a/frontend/src/components/molecules/HeaderRightMenu.tsx
+++ b/frontend/src/components/molecules/HeaderRightMenu.tsx
@@ -51,13 +51,14 @@ const HeaderRightMenu: React.FC<HeaderRightMenuProps> = ({ pathname }) => {
   /**
    * ログアウトする
    */
-  const handleLogout = () => {
-    logout()
-      .then(() => {
-        setUser(null);
-        router.replace('/');
-      })
-      .catch((error) => console.error('Logout error:', error));
+  const handleLogout = async () => {
+    try {
+      await logout.mutateAsync();
+      setUser(null);
+      router.replace('/');
+    } catch (error) {
+      console.error('Logout error:', error);
+    }
   };
 
   // ローディング時はnullを返す

--- a/frontend/src/components/molecules/Login.tsx
+++ b/frontend/src/components/molecules/Login.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useRouter } from 'next/navigation';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
 import { FaGoogle, FaDice, FaChessBoard } from 'react-icons/fa';
 import { GiWoodenCrate, GiCardAceSpades, GiPuzzle } from 'react-icons/gi';
 
@@ -13,28 +13,17 @@ import Loading from '@/components/organisms/Loading';
 function Login() {
   const router = useRouter();
   const { getUser } = useAuth();
-  const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
-    // ユーザーがログイン済みか確認
-    getUser()
-      .then((user) => {
-        // ユーザーデータが存在する場合
-        if (user && user.id) {
-          // /projects にリダイレクト
-          router.replace('/projects');
-        }
+    if (getUser.isSuccess && getUser.data?.id) {
+      router.replace('/projects');
+    }
+    if (getUser.isError) {
+      console.error('Login check error:', getUser.error);
+    }
+  }, [getUser.data, getUser.isError, getUser.isSuccess, getUser.error, router]);
 
-        setIsLoading(false);
-      })
-      .catch((error) => {
-        // エラーがあった場合はログイン画面を表示する
-        console.error('Login check error:', error);
-        setIsLoading(false);
-      });
-  }, [getUser, router]);
-
-  if (isLoading) {
+  if (getUser.isLoading) {
     return <Loading />;
   }
 

--- a/frontend/src/contexts/UserContext.tsx
+++ b/frontend/src/contexts/UserContext.tsx
@@ -28,31 +28,25 @@ export const UserProvider = ({ children }: { children: ReactNode }) => {
 
   // ユーザー情報
   const [user, setUser] = useState<UserListData | null>(null);
-  // ローディング状態
-  const [isLoading, setIsLoading] = useState<boolean>(true);
 
-  // ユーザー情報チェック、存在しない場合はユーザー情報取得
   useEffect(() => {
-    getUser()
-      .then((response) => {
-        const data = response;
-        // ユーザーが存在しない、またはidが存在しない場合
-        if (!data || !data.id) {
-          throw new Error('ユーザーが存在しません');
-        }
-
-        setUser(data);
-      })
-      .catch(() => {
+    if (getUser.isSuccess) {
+      const data = getUser.data;
+      if (!data || !data.id) {
         router.replace('/');
-      })
-      .finally(() => {
-        setIsLoading(false);
-      });
-  }, [getUser, router]);
+        return;
+      }
+      setUser(data);
+    }
+    if (getUser.isError) {
+      router.replace('/');
+    }
+  }, [getUser.data, getUser.isError, getUser.isSuccess, router]);
 
   return (
-    <UserContext.Provider value={{ user, setUser, isLoading }}>
+    <UserContext.Provider
+      value={{ user, setUser, isLoading: getUser.isLoading }}
+    >
       {children}
     </UserContext.Provider>
   );

--- a/frontend/src/features/profile/components/ProfileEdit.tsx
+++ b/frontend/src/features/profile/components/ProfileEdit.tsx
@@ -69,20 +69,19 @@ const ProfileEdit: React.FC = () => {
     }
 
     try {
-      const updatedUser = await updateUser(user.id, {
-        username: username.trim(),
+      const updatedUser = await updateUser.mutateAsync({
+        userId: user.id,
+        data: {
+          username: username.trim(),
+        },
       });
 
-      // ユーザーコンテキストを更新
       setUser(updatedUser);
-
-      // 更新成功メッセージを表示
       setSuccess('ユーザー名を更新しました');
       setError('');
     } catch (error) {
       console.error('Error updating username:', error);
       setError('ユーザー名の更新に失敗しました');
-      // エラー時は元のユーザー名に戻す
       if (user?.username) {
         setUsername(user.username);
       }

--- a/frontend/src/features/prototype/components/molecules/LeftSidebar.tsx
+++ b/frontend/src/features/prototype/components/molecules/LeftSidebar.tsx
@@ -116,7 +116,7 @@ export default function LeftSidebar({
     const fetchNeedTutorialStatus = async () => {
       if (!user?.id) return;
       try {
-        const result = await checkNeedTutorial(user.id);
+        const result = await checkNeedTutorial.mutateAsync(user.id);
         setNeedTutorial(result.needTutorial);
       } catch (error) {
         console.error(

--- a/frontend/src/features/prototype/components/molecules/PartPropertyMenu.tsx
+++ b/frontend/src/features/prototype/components/molecules/PartPropertyMenu.tsx
@@ -216,7 +216,7 @@ export default function PartPropertyMenu({
 
     setIsUploading(true); // ローディング開始
     try {
-      const response = await uploadImage(formData);
+      const response = await uploadImage.mutateAsync(formData);
       if (response.id) {
         // IndexedDBに画像を保存
         await saveImageToIndexedDb(response.id, image);

--- a/frontend/src/features/prototype/components/organisms/GameBoard.tsx
+++ b/frontend/src/features/prototype/components/organisms/GameBoard.tsx
@@ -304,7 +304,13 @@ export default function GameBoard({
       emitUpdate,
     }: DeleteImageProps) => {
       updateImageParamsInIndexedDb(imageId, true, new Date());
-      await deleteImage(imageId, { prototypeId, partId, side, emitUpdate });
+      await deleteImage.mutateAsync({
+        imageId,
+        prototypeId,
+        partId,
+        side,
+        emitUpdate,
+      });
     },
     [deleteImage]
   );
@@ -417,7 +423,7 @@ export default function GameBoard({
             return { imageId, url: cachedImageResult.objectURL };
           }
           try {
-            const s3ImageBlob = await fetchImage(imageId);
+            const s3ImageBlob = await fetchImage.mutateAsync(imageId);
             const imageResult = await saveImageToIndexedDb(imageId, s3ImageBlob);
             if (imageResult) {
               return { imageId, url: imageResult.objectURL };

--- a/frontend/src/features/role/hooks/useRoleManagement.ts
+++ b/frontend/src/features/role/hooks/useRoleManagement.ts
@@ -107,7 +107,7 @@ export const useRoleManagement = (projectId: string) => {
       // 作成者の情報を取得
       if (project.userId) {
         try {
-          const usersResponse = await searchUsers({ username: '' });
+          const usersResponse = await searchUsers.mutateAsync({ username: '' });
           const creatorUser = usersResponse.find(
             (user) => user.id === project.userId
           );
@@ -128,7 +128,7 @@ export const useRoleManagement = (projectId: string) => {
   const fetchUsers = useCallback(
     async (username: string = '') => {
       try {
-        const response = await searchUsers({ username });
+        const response = await searchUsers.mutateAsync({ username });
         setFetchedUsers(response);
       } catch (error) {
         console.error('Error fetching all users:', error);


### PR DESCRIPTION
## Summary
- refactor auth, image, and user hooks to expose React Query query/mutation objects
- update contexts and components to use mutation/query APIs
- improve consistency for cache and error handling

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b66771bb14832691f498b0013a09ef