### PR TITLE
refactor: use react query for api hooks

### DIFF
--- a/frontend/src/api/hooks/useAuth.ts
+++ b/frontend/src/api/hooks/useAuth.ts
@@ -1,22 +1,34 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useCallback } from 'react';
 
 import { authService } from '@/api/endpoints/auth';
 
 export const useAuth = () => {
+  const queryClient = useQueryClient();
+
   /**
    * ログアウトする
    */
-  const logout = useCallback(async () => {
-    await authService.logout();
-  }, []);
+  const logoutMutation = useMutation({
+    mutationFn: () => authService.logout(),
+    onSuccess: () => queryClient.removeQueries({ queryKey: ['auth', 'user'] }),
+  });
+  const logout = useCallback(
+    () => logoutMutation.mutateAsync(),
+    [logoutMutation]
+  );
 
   /**
    * ユーザーを取得する
    */
-  const getUser = useCallback(async () => {
-    const user = await authService.getUser();
-    return user;
-  }, []);
+  const getUser = useCallback(
+    () =>
+      queryClient.fetchQuery({
+        queryKey: ['auth', 'user'],
+        queryFn: () => authService.getUser(),
+      }),
+    [queryClient]
+  );
 
   return { logout, getUser };
 };

--- a/frontend/src/api/hooks/useImages.ts
+++ b/frontend/src/api/hooks/useImages.ts
@@ -1,3 +1,4 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useCallback } from 'react';
 
 import { imagesService } from '@/api/endpoints/images';
@@ -5,28 +6,49 @@ import { imagesService } from '@/api/endpoints/images';
 import { ImagesDeleteParams } from '../types';
 
 export const useImages = () => {
+  const queryClient = useQueryClient();
+
   /**
    * 画像取得
    */
-  const fetchImage = useCallback(async (imageId: string) => {
-    return await imagesService.fetchImage(imageId);
-  }, []);
+  const fetchImage = useCallback(
+    (imageId: string) =>
+      queryClient.fetchQuery({
+        queryKey: ['images', imageId],
+        queryFn: () => imagesService.fetchImage(imageId),
+      }),
+    [queryClient]
+  );
 
   /**
    * 画像アップロード
    */
-  const uploadImage = useCallback(async (data: FormData) => {
-    return await imagesService.uploadImage(data);
-  }, []);
+  const uploadImageMutation = useMutation({
+    mutationFn: (data: FormData) => imagesService.uploadImage(data),
+  });
+  const uploadImage = useCallback(
+    (data: FormData) => uploadImageMutation.mutateAsync(data),
+    [uploadImageMutation]
+  );
 
   /**
    * 画像削除
    */
+  const deleteImageMutation = useMutation({
+    mutationFn: ({
+      imageId,
+      params,
+    }: {
+      imageId: string;
+      params: Omit<ImagesDeleteParams, 'imageId'>;
+    }) => imagesService.deleteImage(imageId, params),
+    onSuccess: (_, { imageId }) =>
+      queryClient.invalidateQueries({ queryKey: ['images', imageId] }),
+  });
   const deleteImage = useCallback(
-    async (imageId: string, params: Omit<ImagesDeleteParams, 'imageId'>) => {
-      return await imagesService.deleteImage(imageId, params);
-    },
-    []
+    (imageId: string, params: Omit<ImagesDeleteParams, 'imageId'>) =>
+      deleteImageMutation.mutateAsync({ imageId, params }),
+    [deleteImageMutation]
   );
 
   return {

--- a/frontend/src/api/hooks/useUsers.ts
+++ b/frontend/src/api/hooks/useUsers.ts
@@ -1,3 +1,4 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useCallback } from 'react';
 
 import { usersService } from '@/api/endpoints/users';
@@ -8,31 +9,52 @@ import {
 } from '@/api/types';
 
 export const useUsers = () => {
+  const queryClient = useQueryClient();
+
   /**
    * ユーザーを検索する
    */
-  const searchUsers = useCallback(async (query: UsersSearchListParams) => {
-    return await usersService.searchUsers(query);
-  }, []);
+  const searchUsersMutation = useMutation({
+    mutationFn: (query: UsersSearchListParams) => usersService.searchUsers(query),
+  });
+  const searchUsers = useCallback(
+    (query: UsersSearchListParams) => searchUsersMutation.mutateAsync(query),
+    [searchUsersMutation]
+  );
 
   /**
    * ユーザー情報を更新する
    */
-  const updateUser = useCallback(
-    async (userId: string, data: UsersUpdatePayload) => {
-      return await usersService.updateUser(userId, data);
+  const updateUserMutation = useMutation({
+    mutationFn: ({
+      userId,
+      data,
+    }: {
+      userId: string;
+      data: UsersUpdatePayload;
+    }) => usersService.updateUser(userId, data),
+    onSuccess: (updatedUser) => {
+      queryClient.invalidateQueries({
+        queryKey: ['users', updatedUser.id],
+      });
     },
-    []
+  });
+  const updateUser = useCallback(
+    (userId: string, data: UsersUpdatePayload) =>
+      updateUserMutation.mutateAsync({ userId, data }),
+    [updateUserMutation]
   );
 
   /**
    * チュートリアル表示が必要かどうかを確認する
    */
   const checkNeedTutorial = useCallback(
-    async (userId: string): Promise<UsersNeedTutorialData> => {
-      return await usersService.checkNeedTutorial(userId);
-    },
-    []
+    (userId: string) =>
+      queryClient.fetchQuery<UsersNeedTutorialData>({
+        queryKey: ['users', userId, 'needTutorial'],
+        queryFn: () => usersService.checkNeedTutorial(userId),
+      }),
+    [queryClient]
   );
 
   return {


### PR DESCRIPTION
## Summary
- use React Query for authentication API wrapper
- integrate React Query into user API hook for searching, updating and tutorial check
- add React Query to image API hook with caching and invalidation

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6748c66e48326b42c066df7ff046e