### PR TITLE
feat: add user color to role menu icons

### DIFF
--- a/frontend/src/features/prototype/components/molecules/RoleMenu.tsx
+++ b/frontend/src/features/prototype/components/molecules/RoleMenu.tsx
@@ -9,6 +9,7 @@ import { FaUsers } from 'react-icons/fa';
 
 import { MAX_DISPLAY_USERS } from '@/features/prototype/constants/presence';
 import { ConnectedUser } from '@/features/prototype/types';
+import { getUserColor } from '@/features/prototype/utils/userColor';
 
 interface RoleMenuProps {
   projectId: string;
@@ -45,11 +46,12 @@ export default function RoleMenu({
         >
           <div className="flex -space-x-3">
             {displayUsers.map((user, idx) => {
+              const color = getUserColor(user.userId, user.username);
               return (
                 <span
                   key={user.userId || `user-${idx}`}
-                  className="flex items-center justify-center w-7 h-7 rounded-full bg-kibako-secondary text-kibako-primary font-bold text-sm select-none border-2 border-kibako-white shadow-sm"
-                  style={{ zIndex: 10 - idx }}
+                  className="flex items-center justify-center w-7 h-7 rounded-full bg-kibako-white text-kibako-primary font-bold text-sm select-none border-2 shadow-sm"
+                  style={{ zIndex: 10 - idx, borderColor: color }}
                   title={user.username}
                 >
                   {user.username.charAt(0).toUpperCase()}


### PR DESCRIPTION
## Summary
- show user-specific border colors on RoleMenu icons

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b835a7a3fc8326b4f2176237c5d6fa

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * User avatars in the role menu now have per-user colored borders for clearer visual differentiation.
  * Avatar background switched to white for improved contrast.
  * Border thickness and shadow are unchanged; avatar layout and stacking order remain the same to preserve the existing look and feel.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->