### PR TITLE
feat(playroom): use role menu color for hand owner banner and square

### DIFF
--- a/frontend/src/features/prototype/components/molecules/PlaySidebar.tsx
+++ b/frontend/src/features/prototype/components/molecules/PlaySidebar.tsx
@@ -11,8 +11,8 @@ import Button from '@/components/atoms/Button';
 import PartTypeIcon from '@/features/prototype/components/atoms/PartTypeIcon';
 import { useSelectedParts } from '@/features/prototype/contexts/SelectedPartsContext';
 import { usePartReducer } from '@/features/prototype/hooks/usePartReducer';
-import { useUser } from '@/hooks/useUser';
 import { getUserColor } from '@/features/prototype/utils/userColor';
+import { useUser } from '@/hooks/useUser';
 
 interface PlaySidebarProps {
   parts: Part[];
@@ -53,7 +53,12 @@ export default function PlaySidebar({
   }, [userRoles]);
 
   // 手札
-  const hands = useMemo(() => {
+  type HandWithOwnerMeta = Part & {
+    ownerName: string | null;
+    ownerColor: string | null;
+  };
+
+  const hands: HandWithOwnerMeta[] = useMemo(() => {
     return parts
       .filter((part) => part.type === 'hand')
       .map((hand) => {
@@ -62,7 +67,7 @@ export default function PlaySidebar({
           ...hand,
           ownerName: meta?.username ?? null,
           ownerColor: meta?.color ?? null,
-        } as Part & { ownerName: string | null; ownerColor: string | null };
+        } as HandWithOwnerMeta;
       });
   }, [parts, userMetaMap]);
 
@@ -122,8 +127,6 @@ export default function PlaySidebar({
         {/* 手札一覧 */}
         <div className="space-y-2">
           {hands.map((hand, index) => {
-            const isOwnHand = hand.ownerId === user?.id;
-
             return (
               <div
                 key={hand.id}
@@ -169,14 +172,11 @@ export default function PlaySidebar({
                   {selectedHand.ownerName ? (
                     <span
                       className="inline-flex items-center gap-1 px-1 rounded border"
-                      style={{ borderColor: (selectedHand as any).ownerColor || undefined }}
+                      style={{ borderColor: selectedHand.ownerColor || undefined }}
                     >
                       <span
                         className="inline-block w-2 h-2"
-                        style={{
-                          backgroundColor:
-                            (selectedHand as any).ownerColor || undefined,
-                        }}
+                        style={{ backgroundColor: selectedHand.ownerColor || undefined }}
                       />
                       {selectedHand.ownerName}
                     </span>


### PR DESCRIPTION
Summary
- Use the same role menu color (getUserColor) for Play Room Settings hand owner UI.
- Apply color to the banner border and small square only; keep username text in default color.

Changes
- frontend/src/features/prototype/components/molecules/PlaySidebar.tsx
  - Build user meta map with username + color via getUserColor.
  - Map hands to include ownerName and ownerColor.
  - Update the hand list and selected hand owner display to use border + square colored with ownerColor, leaving text color unchanged.

Why
- Align visual language with RoleMenu while keeping readability by not tinting text.

Notes
- If desired, I can mirror the same border/square-only style for on-board owner labels as a follow-up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-user color support added for hands.
  * Hand headers now show an owner indicator with a color dot and owner name.
  * 手札設定 shows a color-coded owner badge; displays 未設定 when no owner is set.

* **Style**
  * Ownership visuals refreshed to a bordered inline element with a small color dot for quicker identification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->