### PR TITLE
feat: support bulk part updates via socket

### DIFF
--- a/frontend/src/features/prototype/hooks/__tests__/usePartReducer.test.ts
+++ b/frontend/src/features/prototype/hooks/__tests__/usePartReducer.test.ts
@@ -1,0 +1,51 @@
+import { renderHook, act } from '@testing-library/react';
+import { Socket } from 'socket.io-client';
+import { vi, type Mock } from 'vitest';
+
+import { usePartReducer } from '@/features/prototype/hooks/usePartReducer';
+
+// モック設定
+const mockSocket = {
+  emit: vi.fn(),
+} as unknown as Socket;
+
+// useSocketのモック
+vi.mock('@/features/prototype/contexts/SocketContext', () => ({
+  useSocket: () => ({ socket: mockSocket }),
+}));
+
+// usePerformanceTrackerのモック
+vi.mock('@/features/prototype/hooks/usePerformanceTracker', () => ({
+  usePerformanceTracker: () => ({
+    measureOperation: (_: string, fn: () => void) => fn(),
+  }),
+}));
+
+describe('usePartReducer', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (mockSocket.emit as Mock).mockClear();
+  });
+
+  it('UPDATE_PARTSアクションでソケットにイベントがemitされる', () => {
+    const { result } = renderHook(() => usePartReducer());
+
+    const updates = [
+      { partId: 1, updatePart: { position: { x: 10, y: 20 } } },
+      {
+        partId: 2,
+        updateProperties: [{ side: 'front' as const, name: 'name' }],
+      },
+    ];
+
+    act(() => {
+      result.current.dispatch({
+        type: 'UPDATE_PARTS',
+        payload: { updates },
+      });
+    });
+
+    expect(mockSocket.emit).toHaveBeenCalledWith('UPDATE_PARTS', { updates });
+  });
+});
+

--- a/frontend/src/features/prototype/hooks/usePartDragSystem.ts
+++ b/frontend/src/features/prototype/hooks/usePartDragSystem.ts
@@ -252,11 +252,9 @@ export const usePartDragSystem = ({
         });
 
         // 副作用：状態更新をまとめて実行
-        updatePartsData.forEach((updateData) => {
-          dispatch({
-            type: 'UPDATE_PART',
-            payload: updateData,
-          });
+        dispatch({
+          type: 'UPDATE_PARTS',
+          payload: { updates: updatePartsData },
         });
 
         // 元位置記録をクリア

--- a/frontend/src/features/prototype/hooks/usePartReducer.ts
+++ b/frontend/src/features/prototype/hooks/usePartReducer.ts
@@ -34,6 +34,12 @@ export const usePartReducer = (): PartReducer => {
               updateProperties: action.payload.updateProperties,
             });
             break;
+          // パーツ一括更新
+          case 'UPDATE_PARTS':
+            socket.emit('UPDATE_PARTS', {
+              updates: action.payload.updates,
+            });
+            break;
           // パーツの一括削除
           case 'DELETE_PARTS':
             socket.emit('DELETE_PARTS', {

--- a/frontend/src/features/prototype/types/socket.ts
+++ b/frontend/src/features/prototype/types/socket.ts
@@ -24,6 +24,11 @@ export type UpdatePartPayload = {
   updateProperties?: Partial<PartProperty>[];
 };
 
+/** パーツ一括更新のペイロード（ソケット送受信用） */
+export type UpdatePartsPayload = {
+  updates: UpdatePartPayload[];
+};
+
 /** パーツ削除のペイロード（ソケット送受信用） */
 export type DeletePartPayload = { partId: number };
 
@@ -43,6 +48,12 @@ export type AddPartAction = {
 export type UpdatePartAction = {
   type: 'UPDATE_PART';
   payload: UpdatePartPayload;
+};
+
+/** パーツ一括更新のアクション（ソケット送受信用） */
+export type UpdatePartsAction = {
+  type: 'UPDATE_PARTS';
+  payload: UpdatePartsPayload;
 };
 
 /** パーツ一括削除のアクション（ソケット送受信用） */
@@ -77,6 +88,7 @@ export type SelectedPartsResponse = {
 export type PartAction =
   | AddPartAction
   | UpdatePartAction
+  | UpdatePartsAction
   | DeletePartsAction
   | ChangeOrderAction
   | ShuffleDeckAction;


### PR DESCRIPTION
## Summary
- add server-side handler for bulk part updates and emit consolidated UPDATE_PARTS event
- update part reducer and drag system to batch socket updates
- expand socket type definitions and add tests for bulk update dispatch

## Testing
- `npm test` (frontend)
- `npm run lint` (frontend)
- `npm run lint` (backend)
- `npm test` (backend) *(fails: DB failure)*

------
https://chatgpt.com/codex/tasks/task_e_68b8c20efdac8326a3fe646b7194beb7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add batch updates for multiple parts and their properties in a single operation with real-time broadcasts to collaborators.

* **Performance**
  * Consolidate per-item drag-end updates into a single batched dispatch, reducing network chatter and improving responsiveness during edits.

* **Tests**
  * Add unit tests confirming batched part updates emit the correct real-time event and payload.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->