### PR TITLE
feat: colorize user list in role menu tooltip

### DIFF
--- a/frontend/src/features/prototype/components/molecules/RoleMenu.tsx
+++ b/frontend/src/features/prototype/components/molecules/RoleMenu.tsx
@@ -67,15 +67,27 @@ export default function RoleMenu({
         </button>
         <div className="absolute right-0 mt-2 max-w-xs bg-kibako-white border border-kibako-secondary rounded shadow z-tooltip px-3 py-2 text-xs text-kibako-primary opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto transition-opacity duration-200">
           <ul>
-            {connectedUsers.map((user) => (
-              <li
-                key={user.userId}
-                className="truncate max-w-[180px] px-0 py-0 leading-6"
-                title={user.username}
-              >
-                {user.username}
-              </li>
-            ))}
+            {connectedUsers.map((user) => {
+              const color = getUserColor(user.userId, user.username);
+              return (
+                <li
+                  key={user.userId}
+                  className="truncate max-w-[180px] px-0 py-0 leading-6"
+                  title={user.username}
+                >
+                  <span
+                    className="inline-flex items-center gap-1 px-1 rounded border"
+                    style={{ borderColor: color }}
+                  >
+                    <span
+                      className="inline-block w-2 h-2"
+                      style={{ backgroundColor: color }}
+                    />
+                    {user.username}
+                  </span>
+                </li>
+              );
+            })}
           </ul>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- display colored user badges in role menu tooltip like play sidebar hand banners

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b8d8aa935483269283ac7ec634a2e7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Connected users in the role menu tooltip now appear as color-coded badges with a small colored dot and matching border, replacing plain-text usernames.
  * Colors are consistently derived per user for quick visual identification, improving scanability in crowded lists.
  * Enhances readability and aesthetics without altering dropdown behavior or interactions.
  * No impact on functionality; purely a visual refinement for clearer differentiation of users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->