### PR TITLE
refactor: unify user icons between role menu and sidebar

### DIFF
--- a/frontend/src/features/prototype/components/atoms/ConnectedUserIcon.tsx
+++ b/frontend/src/features/prototype/components/atoms/ConnectedUserIcon.tsx
@@ -1,0 +1,20 @@
+import { ConnectedUser } from '@/features/prototype/types';
+import { getUserColor } from '@/features/prototype/utils/userColor';
+
+interface ConnectedUserIconProps {
+  user: ConnectedUser;
+  index?: number;
+}
+
+export default function ConnectedUserIcon({ user, index = 0 }: ConnectedUserIconProps) {
+  const color = getUserColor(user.userId, user.username);
+  return (
+    <span
+      className="flex items-center justify-center w-7 h-7 rounded-full bg-kibako-white text-kibako-primary font-bold text-sm select-none border-2 shadow-sm"
+      style={{ zIndex: 10 - index, borderColor: color }}
+      title={user.username}
+    >
+      {user.username.charAt(0).toUpperCase()}
+    </span>
+  );
+}

--- a/frontend/src/features/prototype/components/molecules/LeftSidebar.tsx
+++ b/frontend/src/features/prototype/components/molecules/LeftSidebar.tsx
@@ -9,6 +9,7 @@ import { MdMeetingRoom, MdDelete } from 'react-icons/md';
 import { useProject } from '@/api/hooks/useProject';
 import { useUsers } from '@/api/hooks/useUsers';
 import { Prototype, ProjectsDetailData } from '@/api/types';
+import ConnectedUserIcon from '@/features/prototype/components/atoms/ConnectedUserIcon';
 import PrototypeNameEditor from '@/features/prototype/components/atoms/PrototypeNameEditor';
 import GameBoardHelpPanel from '@/features/prototype/components/molecules/GameBoardHelpPanel';
 import { MAX_DISPLAY_USERS } from '@/features/prototype/constants';
@@ -247,21 +248,18 @@ export default function LeftSidebar({
                           {connectedUsers.length > 0 && (
                             <div className="flex items-center gap-1">
                               <span className="text-xs">接続中:</span>
-                              <div className="flex -space-x-1">
+                              <div className="flex -space-x-3">
                                 {connectedUsers
                                   .slice(0, MAX_DISPLAY_USERS)
                                   .map((user, idx) => (
-                                    <span
+                                    <ConnectedUserIcon
                                       key={user.userId}
-                                      className="flex items-center justify-center w-5 h-5 rounded-full bg-kibako-accent text-kibako-white font-bold text-xs border border-kibako-white"
-                                      style={{ zIndex: 10 - idx }}
-                                      title={user.username}
-                                    >
-                                      {user.username.charAt(0).toUpperCase()}
-                                    </span>
+                                      user={user}
+                                      index={idx}
+                                    />
                                   ))}
                                 {connectedUsers.length > MAX_DISPLAY_USERS && (
-                                  <span className="text-xs text-kibako-secondary ml-1">
+                                  <span className="text-xs text-kibako-secondary ml-2">
                                     +{connectedUsers.length - MAX_DISPLAY_USERS}
                                   </span>
                                 )}

--- a/frontend/src/features/prototype/components/molecules/RoleMenu.tsx
+++ b/frontend/src/features/prototype/components/molecules/RoleMenu.tsx
@@ -7,6 +7,7 @@
 import Link from 'next/link';
 import { FaUsers } from 'react-icons/fa';
 
+import ConnectedUserIcon from '@/features/prototype/components/atoms/ConnectedUserIcon';
 import { MAX_DISPLAY_USERS } from '@/features/prototype/constants/presence';
 import { ConnectedUser } from '@/features/prototype/types';
 import { getUserColor } from '@/features/prototype/utils/userColor';
@@ -45,19 +46,13 @@ export default function RoleMenu({
           tabIndex={0}
         >
           <div className="flex -space-x-3">
-            {displayUsers.map((user, idx) => {
-              const color = getUserColor(user.userId, user.username);
-              return (
-                <span
-                  key={user.userId || `user-${idx}`}
-                  className="flex items-center justify-center w-7 h-7 rounded-full bg-kibako-white text-kibako-primary font-bold text-sm select-none border-2 shadow-sm"
-                  style={{ zIndex: 10 - idx, borderColor: color }}
-                  title={user.username}
-                >
-                  {user.username.charAt(0).toUpperCase()}
-                </span>
-              );
-            })}
+            {displayUsers.map((user, idx) => (
+              <ConnectedUserIcon
+                key={user.userId || `user-${idx}`}
+                user={user}
+                index={idx}
+              />
+            ))}
           </div>
           {moreCount > 0 && (
             <span className="text-xs text-kibako-secondary ml-2">


### PR DESCRIPTION
## Summary
- extract `ConnectedUserIcon` component for shared styling
- use shared icon in RoleMenu and LeftSidebar so sidebar avatars match role menu

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b8dcf1580c8326aa28478f724bb4c0