### PR TITLE
feat: support multi-part alignment menu

### DIFF
--- a/frontend/src/features/prototype/components/molecules/PartPropertyMenu.tsx
+++ b/frontend/src/features/prototype/components/molecules/PartPropertyMenu.tsx
@@ -79,9 +79,10 @@ export default function PartPropertyMenu({
   onDuplicatePart,
 }: PartPropertyMenuProps) {
   const selectedPartId = selectedPartIds[0];
-  const selectedParts = useMemo(
+  /** 複数選択中のパーツ一覧 */
+  const selectedParts = useMemo<Part[]>(
     () => parts.filter((part) => selectedPartIds.includes(part.id)),
-    [parts, selectedPartIds]
+    [parts, selectedPartIds],
   );
   const multipleSelected = selectedPartIds.length > 1;
   const showMenu = selectedPartIds.length === 1;

--- a/frontend/src/features/prototype/components/molecules/PartPropertyMenu.tsx
+++ b/frontend/src/features/prototype/components/molecules/PartPropertyMenu.tsx
@@ -5,9 +5,23 @@
 'use client';
 
 import axios from 'axios';
-import React, { useState, useMemo, useEffect, useRef } from 'react';
+import React, {
+  useState,
+  useMemo,
+  useEffect,
+  useRef,
+  useCallback,
+} from 'react';
 import { FaRegCopy, FaRegTrashAlt, FaImage, FaSpinner } from 'react-icons/fa';
 import { IoMdMove } from 'react-icons/io';
+import {
+  MdFormatAlignLeft,
+  MdFormatAlignCenter,
+  MdFormatAlignRight,
+  MdVerticalAlignTop,
+  MdVerticalAlignCenter,
+  MdVerticalAlignBottom,
+} from 'react-icons/md';
 
 import { useImages } from '@/api/hooks/useImages';
 import { Part } from '@/api/types';
@@ -24,6 +38,11 @@ import {
   PartPropertyUpdate,
   PartPropertyWithImage,
 } from '@/features/prototype/types';
+import {
+  calculateAlignmentInfo,
+  getAlignmentUpdates,
+  AlignmentType,
+} from '@/features/prototype/utils/alignment';
 import { saveImageToIndexedDb } from '@/utils/db';
 
 // フロントエンドで許可する画像のMIMEタイプ
@@ -60,6 +79,11 @@ export default function PartPropertyMenu({
   onDuplicatePart,
 }: PartPropertyMenuProps) {
   const selectedPartId = selectedPartIds[0];
+  const selectedParts = useMemo(
+    () => parts.filter((part) => selectedPartIds.includes(part.id)),
+    [parts, selectedPartIds]
+  );
+  const multipleSelected = selectedPartIds.length > 1;
   const showMenu = selectedPartIds.length === 1;
 
   const [uploadedImage, setUploadedImage] = useState<{
@@ -105,6 +129,36 @@ export default function PartPropertyMenu({
       setUploadedImage(null);
     }
   }, [currentProperty]);
+
+  const alignInfo = useMemo(
+    () => calculateAlignmentInfo(selectedParts),
+    [selectedParts],
+  );
+
+  const alignParts = useCallback(
+    (type: AlignmentType) => {
+      if (!alignInfo) return;
+      const updates = getAlignmentUpdates(type, selectedParts, alignInfo);
+      dispatch({ type: 'UPDATE_PARTS', payload: { updates } });
+    },
+    [alignInfo, selectedParts, dispatch],
+  );
+
+  const handleAlignLeft = useCallback(() => alignParts('left'), [alignParts]);
+  const handleAlignRight = useCallback(() => alignParts('right'), [alignParts]);
+  const handleAlignHCenter = useCallback(
+    () => alignParts('hCenter'),
+    [alignParts]
+  );
+  const handleAlignTop = useCallback(() => alignParts('top'), [alignParts]);
+  const handleAlignBottom = useCallback(
+    () => alignParts('bottom'),
+    [alignParts]
+  );
+  const handleAlignVCenter = useCallback(
+    () => alignParts('vCenter'),
+    [alignParts]
+  );
 
   const {
     containerRef,
@@ -244,6 +298,79 @@ export default function PartPropertyMenu({
       setIsUploading(false); // ローディング終了
     }
   };
+
+  if (multipleSelected) {
+    return (
+      <>
+        <div
+          ref={containerRef}
+          className={`flex w-[240px] flex-col rounded-lg shadow-lg bg-kibako-secondary/70 max-h-[80vh] text-xs ${
+            isDragging ? 'opacity-95' : ''
+          }`}
+          style={{
+            position: 'fixed',
+            left: position ? `${position.x}px` : undefined,
+            top: position ? `${position.y}px` : undefined,
+            zIndex: 50,
+          }}
+        >
+          <div
+            className="relative rounded-t-lg bg-kibako-primary/70 text-kibako-white py-2 px-4 flex-shrink-0 cursor-move pr-8"
+            onMouseDown={handleDragStart}
+            onTouchStart={handleDragStart}
+          >
+            <div className="flex items-center select-none">
+              <span className="text-[12px] font-medium">整列</span>
+            </div>
+            <IoMdMove
+              className="h-4 w-4 absolute right-2 top-2 opacity-80"
+              aria-hidden="true"
+            />
+          </div>
+          <div className="flex flex-col gap-2 p-4">
+            <div className="grid grid-cols-3 gap-2">
+              <PartPropertyMenuButton
+                text="左揃え"
+                icon={<MdFormatAlignLeft className="h-3 w-3" />}
+                onClick={handleAlignLeft}
+                disabled={alignInfo?.isLeft}
+              />
+              <PartPropertyMenuButton
+                text="左右中央"
+                icon={<MdFormatAlignCenter className="h-3 w-3" />}
+                onClick={handleAlignHCenter}
+                disabled={alignInfo?.isHCenter}
+              />
+              <PartPropertyMenuButton
+                text="右揃え"
+                icon={<MdFormatAlignRight className="h-3 w-3" />}
+                onClick={handleAlignRight}
+                disabled={alignInfo?.isRight}
+              />
+              <PartPropertyMenuButton
+                text="上揃え"
+                icon={<MdVerticalAlignTop className="h-3 w-3" />}
+                onClick={handleAlignTop}
+                disabled={alignInfo?.isTop}
+              />
+              <PartPropertyMenuButton
+                text="上下中央"
+                icon={<MdVerticalAlignCenter className="h-3 w-3" />}
+                onClick={handleAlignVCenter}
+                disabled={alignInfo?.isVCenter}
+              />
+              <PartPropertyMenuButton
+                text="下揃え"
+                icon={<MdVerticalAlignBottom className="h-3 w-3" />}
+                onClick={handleAlignBottom}
+                disabled={alignInfo?.isBottom}
+              />
+            </div>
+          </div>
+        </div>
+      </>
+    );
+  }
 
   return (
     <>

--- a/frontend/src/features/prototype/components/molecules/PartPropertyMenu.tsx
+++ b/frontend/src/features/prototype/components/molecules/PartPropertyMenu.tsx
@@ -131,15 +131,21 @@ export default function PartPropertyMenu({
     }
   }, [currentProperty]);
 
-  const alignInfo = useMemo(
+  const alignInfo = useMemo<ReturnType<typeof calculateAlignmentInfo>>(
     () => calculateAlignmentInfo(selectedParts),
     [selectedParts],
   );
 
+  /**
+   * 整列を実行する
+   * @param type - 整列タイプ
+   */
   const alignParts = useCallback(
-    (type: AlignmentType) => {
+    (type: AlignmentType): void => {
+      // 整列情報がない場合：何もしない
       if (!alignInfo) return;
       const updates = getAlignmentUpdates(type, selectedParts, alignInfo);
+      if (updates.length === 0) return;
       dispatch({ type: 'UPDATE_PARTS', payload: { updates } });
     },
     [alignInfo, selectedParts, dispatch],

--- a/frontend/src/features/prototype/utils/alignment.ts
+++ b/frontend/src/features/prototype/utils/alignment.ts
@@ -1,0 +1,104 @@
+import { Part } from '@/api/types';
+
+export type AlignmentType =
+  | 'left'
+  | 'right'
+  | 'hCenter'
+  | 'top'
+  | 'bottom'
+  | 'vCenter';
+
+export type AlignmentInfo = {
+  minX: number;
+  maxX: number;
+  minY: number;
+  maxY: number;
+  centerX: number;
+  centerY: number;
+  isLeft: boolean;
+  isRight: boolean;
+  isHCenter: boolean;
+  isTop: boolean;
+  isBottom: boolean;
+  isVCenter: boolean;
+};
+
+/**
+ * 選択されたパーツの位置に基づく整列情報を計算する
+ * @param parts - 選択されたパーツ
+ * @returns 整列情報、パーツが2つ未満の場合は null
+ */
+export const calculateAlignmentInfo = (
+  parts: Part[],
+): AlignmentInfo | null => {
+  if (parts.length < 2) return null;
+
+  const minX = Math.min(...parts.map((p) => p.position.x));
+  const maxX = Math.max(...parts.map((p) => p.position.x + p.width));
+  const minY = Math.min(...parts.map((p) => p.position.y));
+  const maxY = Math.max(...parts.map((p) => p.position.y + p.height));
+  const centerX = Math.round((minX + maxX) / 2);
+  const centerY = Math.round((minY + maxY) / 2);
+
+  return {
+    minX,
+    maxX,
+    minY,
+    maxY,
+    centerX,
+    centerY,
+    isLeft: parts.every((p) => p.position.x === minX),
+    isRight: parts.every((p) => p.position.x + p.width === maxX),
+    isHCenter: parts.every(
+      (p) => Math.round(p.position.x + p.width / 2) === centerX,
+    ),
+    isTop: parts.every((p) => p.position.y === minY),
+    isBottom: parts.every((p) => p.position.y + p.height === maxY),
+    isVCenter: parts.every(
+      (p) => Math.round(p.position.y + p.height / 2) === centerY,
+    ),
+  };
+};
+
+/**
+ * 指定された整列タイプに基づいてパーツの更新を生成する
+ * @param type - 整列タイプ
+ * @param parts - 選択されたパーツ
+ * @param info - 整列情報
+ * @returns パーツ更新オブジェクトの配列
+ */
+export const getAlignmentUpdates = (
+  type: AlignmentType,
+  parts: Part[],
+  info: AlignmentInfo,
+) =>
+  parts.map((p) => {
+    let x = p.position.x;
+    let y = p.position.y;
+    switch (type) {
+      case 'left':
+        x = info.minX;
+        break;
+      case 'right':
+        x = info.maxX - p.width;
+        break;
+      case 'hCenter':
+        x = Math.round(info.centerX - p.width / 2);
+        break;
+      case 'top':
+        y = info.minY;
+        break;
+      case 'bottom':
+        y = info.maxY - p.height;
+        break;
+      case 'vCenter':
+        y = Math.round(info.centerY - p.height / 2);
+        break;
+    }
+    return {
+      partId: p.id,
+      updatePart: {
+        position: { ...p.position, x, y },
+      },
+    };
+  });


### PR DESCRIPTION
## Summary
- show PartPropertyMenu when multiple parts are selected
- add alignment actions and disable buttons if already aligned
- extract alignment calculations into reusable utilities

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b8dabe422883269a217ec22b1a7f5e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a multi-select alignment panel that appears when multiple parts are selected.
  * One-click alignment options: left, center, right, top, middle, and bottom, with clear iconography.
  * Buttons disable when items are already aligned to prevent redundant actions.
  * Draggable, fixed-position mini-panel for convenient placement while editing multiple parts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->