### PR TITLE
feat: add shortcut tooltips to part property menu

### DIFF
--- a/frontend/src/features/prototype/components/atoms/PartPropertyMenuButton.tsx
+++ b/frontend/src/features/prototype/components/atoms/PartPropertyMenuButton.tsx
@@ -9,6 +9,8 @@ type Props = {
   disabled?: boolean;
   // ボタンをクリックしたときの処理
   onClick?: () => void;
+  // ボタンのタイトル（ツールチップ）
+  title?: string;
 };
 
 const PartPropertyMenuButton = ({
@@ -16,12 +18,14 @@ const PartPropertyMenuButton = ({
   icon,
   disabled = false,
   onClick,
+  title,
 }: Props) => {
   return (
     <button
       className="flex items-center gap-2 rounded px-2 py-1 text-xs text-kibako-white bg-kibako-primary/30 hover:bg-kibako-primary"
       onClick={onClick}
       disabled={disabled}
+      title={title}
     >
       {icon}
       {text}

--- a/frontend/src/features/prototype/components/molecules/PartPropertyMenuSingle.tsx
+++ b/frontend/src/features/prototype/components/molecules/PartPropertyMenuSingle.tsx
@@ -73,7 +73,8 @@ export default function PartPropertyMenuSingle({
     );
     if (JSON.stringify(currentProperty) === JSON.stringify(updatedProperty)) return;
     // API は imageId のみ受け付けるため image は除外
-    const { image: _omit, ...updateProperty } = updatedProperty;
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { image: _image, ...updateProperty } = updatedProperty;
     dispatch({
       type: 'UPDATE_PART',
       payload: { partId: selectedPart.id, updateProperties: [updateProperty] },
@@ -142,13 +143,19 @@ export default function PartPropertyMenuSingle({
     <div className="flex flex-col gap-2" style={{ display: hidden ? 'none' : 'flex' }}>
       {!isPlayMode && (
         <div className="flex items-center justify-around px-2 pb-2">
-          <PartPropertyMenuButton text="複製" icon={<FaRegCopy className="h-3 w-3" />} onClick={onDuplicatePart} />
+          <PartPropertyMenuButton
+            text="複製"
+            icon={<FaRegCopy className="h-3 w-3" />}
+            onClick={onDuplicatePart}
+            title="Cmd/Ctrl + D"
+          />
           <PartPropertyMenuButton
             text="削除"
             icon={<FaRegTrashAlt className="h-3 w-3" />}
             onClick={() => {
               onDeletePart();
             }}
+            title="Delete / Backspace"
           />
         </div>
       )}


### PR DESCRIPTION
## Summary
- add optional title prop to `PartPropertyMenuButton`
- show shortcut hints for duplicate and delete actions in part property menu

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb76f308708326a0aa0dea4473815e