### PR TITLE
feat(frontend): switch 整列 buttons to Lucide icons, center and enlarge

### DIFF
--- a/frontend/src/features/prototype/components/atoms/PartPropertyMenuButton.tsx
+++ b/frontend/src/features/prototype/components/atoms/PartPropertyMenuButton.tsx
@@ -24,7 +24,7 @@ const PartPropertyMenuButton = ({
 }: Props): React.ReactElement => {
   return (
     <button
-      className="flex items-center gap-2 rounded px-2 py-1 text-xs text-kibako-white bg-kibako-primary/30 hover:bg-kibako-primary"
+      className="flex items-center justify-center gap-2 rounded px-2 py-1 text-xs text-kibako-white bg-kibako-primary/30 hover:bg-kibako-primary"
       onClick={onClick}
       disabled={disabled}
       title={title}

--- a/frontend/src/features/prototype/components/atoms/PartPropertyMenuButton.tsx
+++ b/frontend/src/features/prototype/components/atoms/PartPropertyMenuButton.tsx
@@ -1,33 +1,37 @@
-import type React from 'react';
-import { ReactNode } from 'react';
+import type { ReactElement, ReactNode } from 'react';
 
 type Props = {
   // ボタンのテキスト
   text: string;
   // ボタンのアイコン
   icon: ReactNode;
+  // スクリーンリーダー用のラベル（text を表示しない場合に推奨）
+  ariaLabel?: string;
+  // ホバー時のツールチップ
+  title?: string;
   // ボタンが無効化されているか
   disabled?: boolean;
   // ボタンをクリックしたときの処理
   onClick?: () => void;
-  // ボタンのタイトル（ツールチップ）
-  title?: string;
 };
 
 /** コンポーネント: パーツのプロパティメニュー用ボタン。title でネイティブツールチップを表示する。 */
 const PartPropertyMenuButton = ({
   text,
   icon,
+  ariaLabel,
+  title,
   disabled = false,
   onClick,
-  title,
-}: Props): React.ReactElement => {
+}: Props): ReactElement => {
   return (
     <button
+      type="button"
+      aria-label={ariaLabel ?? undefined}
+      title={title ?? undefined}
       className="flex items-center justify-center gap-2 rounded px-2 py-1 text-xs text-kibako-white bg-kibako-primary/30 hover:bg-kibako-primary"
       onClick={onClick}
       disabled={disabled}
-      title={title}
     >
       {icon}
       {text}

--- a/frontend/src/features/prototype/components/molecules/PartPropertyMenuMulti.tsx
+++ b/frontend/src/features/prototype/components/molecules/PartPropertyMenuMulti.tsx
@@ -48,7 +48,7 @@ export default function PartPropertyMenuMulti({ selectedParts, hidden }: PartPro
           text=""
           ariaLabel="水平: 左揃え"
           title="左揃え（水平）"
-          icon={<LuAlignStartHorizontal className="h-5 w-5" />}
+          icon={<LuAlignStartVertical className="h-5 w-5" />}
           onClick={handleAlignLeft}
           disabled={alignInfo?.isLeft}
         />
@@ -56,7 +56,7 @@ export default function PartPropertyMenuMulti({ selectedParts, hidden }: PartPro
           text=""
           ariaLabel="水平: 中央揃え"
           title="中央揃え（水平）"
-          icon={<LuAlignCenterHorizontal className="h-5 w-5" />}
+          icon={<LuAlignCenterVertical className="h-5 w-5" />}
           onClick={handleAlignHCenter}
           disabled={alignInfo?.isHCenter}
         />
@@ -64,7 +64,7 @@ export default function PartPropertyMenuMulti({ selectedParts, hidden }: PartPro
           text=""
           ariaLabel="水平: 右揃え"
           title="右揃え（水平）"
-          icon={<LuAlignEndHorizontal className="h-5 w-5" />}
+          icon={<LuAlignEndVertical className="h-5 w-5" />}
           onClick={handleAlignRight}
           disabled={alignInfo?.isRight}
         />
@@ -72,7 +72,7 @@ export default function PartPropertyMenuMulti({ selectedParts, hidden }: PartPro
           text=""
           ariaLabel="垂直: 上揃え"
           title="上揃え（垂直）"
-          icon={<LuAlignStartVertical className="h-5 w-5" />}
+          icon={<LuAlignStartHorizontal className="h-5 w-5" />}
           onClick={handleAlignTop}
           disabled={alignInfo?.isTop}
         />
@@ -80,7 +80,7 @@ export default function PartPropertyMenuMulti({ selectedParts, hidden }: PartPro
           text=""
           ariaLabel="垂直: 中央揃え"
           title="中央揃え（垂直）"
-          icon={<LuAlignCenterVertical className="h-5 w-5" />}
+          icon={<LuAlignCenterHorizontal className="h-5 w-5" />}
           onClick={handleAlignVCenter}
           disabled={alignInfo?.isVCenter}
         />
@@ -88,7 +88,7 @@ export default function PartPropertyMenuMulti({ selectedParts, hidden }: PartPro
           text=""
           ariaLabel="垂直: 下揃え"
           title="下揃え（垂直）"
-          icon={<LuAlignEndVertical className="h-5 w-5" />}
+          icon={<LuAlignEndHorizontal className="h-5 w-5" />}
           onClick={handleAlignBottom}
           disabled={alignInfo?.isBottom}
         />

--- a/frontend/src/features/prototype/components/molecules/PartPropertyMenuMulti.tsx
+++ b/frontend/src/features/prototype/components/molecules/PartPropertyMenuMulti.tsx
@@ -46,36 +46,48 @@ export default function PartPropertyMenuMulti({ selectedParts, hidden }: PartPro
       <div className="grid grid-cols-3 gap-2">
         <PartPropertyMenuButton
           text=""
+          ariaLabel="水平: 左揃え"
+          title="左揃え（水平）"
           icon={<LuAlignStartHorizontal className="h-5 w-5" />}
           onClick={handleAlignLeft}
           disabled={alignInfo?.isLeft}
         />
         <PartPropertyMenuButton
           text=""
+          ariaLabel="水平: 中央揃え"
+          title="中央揃え（水平）"
           icon={<LuAlignCenterHorizontal className="h-5 w-5" />}
           onClick={handleAlignHCenter}
           disabled={alignInfo?.isHCenter}
         />
         <PartPropertyMenuButton
           text=""
+          ariaLabel="水平: 右揃え"
+          title="右揃え（水平）"
           icon={<LuAlignEndHorizontal className="h-5 w-5" />}
           onClick={handleAlignRight}
           disabled={alignInfo?.isRight}
         />
         <PartPropertyMenuButton
           text=""
+          ariaLabel="垂直: 上揃え"
+          title="上揃え（垂直）"
           icon={<LuAlignStartVertical className="h-5 w-5" />}
           onClick={handleAlignTop}
           disabled={alignInfo?.isTop}
         />
         <PartPropertyMenuButton
           text=""
+          ariaLabel="垂直: 中央揃え"
+          title="中央揃え（垂直）"
           icon={<LuAlignCenterVertical className="h-5 w-5" />}
           onClick={handleAlignVCenter}
           disabled={alignInfo?.isVCenter}
         />
         <PartPropertyMenuButton
           text=""
+          ariaLabel="垂直: 下揃え"
+          title="下揃え（垂直）"
           icon={<LuAlignEndVertical className="h-5 w-5" />}
           onClick={handleAlignBottom}
           disabled={alignInfo?.isBottom}

--- a/frontend/src/features/prototype/components/molecules/PartPropertyMenuMulti.tsx
+++ b/frontend/src/features/prototype/components/molecules/PartPropertyMenuMulti.tsx
@@ -1,5 +1,12 @@
 import React, { useCallback, useMemo } from 'react';
-import { MdFormatAlignLeft, MdFormatAlignCenter, MdFormatAlignRight, MdVerticalAlignTop, MdVerticalAlignCenter, MdVerticalAlignBottom } from 'react-icons/md';
+import {
+  LuAlignStartHorizontal,
+  LuAlignCenterHorizontal,
+  LuAlignEndHorizontal,
+  LuAlignStartVertical,
+  LuAlignCenterVertical,
+  LuAlignEndVertical,
+} from 'react-icons/lu';
 
 import { Part } from '@/api/types';
 import PartPropertyMenuButton from '@/features/prototype/components/atoms/PartPropertyMenuButton';
@@ -38,38 +45,38 @@ export default function PartPropertyMenuMulti({ selectedParts, hidden }: PartPro
       <p className="text-kibako-white">整列</p>
       <div className="grid grid-cols-3 gap-2">
         <PartPropertyMenuButton
-          text="左揃え"
-          icon={<MdFormatAlignLeft className="h-3 w-3" />}
+          text=""
+          icon={<LuAlignStartHorizontal className="h-5 w-5" />}
           onClick={handleAlignLeft}
           disabled={alignInfo?.isLeft}
         />
         <PartPropertyMenuButton
-          text="左右中央"
-          icon={<MdFormatAlignCenter className="h-3 w-3" />}
+          text=""
+          icon={<LuAlignCenterHorizontal className="h-5 w-5" />}
           onClick={handleAlignHCenter}
           disabled={alignInfo?.isHCenter}
         />
         <PartPropertyMenuButton
-          text="右揃え"
-          icon={<MdFormatAlignRight className="h-3 w-3" />}
+          text=""
+          icon={<LuAlignEndHorizontal className="h-5 w-5" />}
           onClick={handleAlignRight}
           disabled={alignInfo?.isRight}
         />
         <PartPropertyMenuButton
-          text="上揃え"
-          icon={<MdVerticalAlignTop className="h-3 w-3" />}
+          text=""
+          icon={<LuAlignStartVertical className="h-5 w-5" />}
           onClick={handleAlignTop}
           disabled={alignInfo?.isTop}
         />
         <PartPropertyMenuButton
-          text="上下中央"
-          icon={<MdVerticalAlignCenter className="h-3 w-3" />}
+          text=""
+          icon={<LuAlignCenterVertical className="h-5 w-5" />}
           onClick={handleAlignVCenter}
           disabled={alignInfo?.isVCenter}
         />
         <PartPropertyMenuButton
-          text="下揃え"
-          icon={<MdVerticalAlignBottom className="h-3 w-3" />}
+          text=""
+          icon={<LuAlignEndVertical className="h-5 w-5" />}
           onClick={handleAlignBottom}
           disabled={alignInfo?.isBottom}
         />
@@ -77,4 +84,3 @@ export default function PartPropertyMenuMulti({ selectedParts, hidden }: PartPro
     </div>
   );
 }
-

--- a/frontend/src/features/prototype/components/molecules/PartPropertyMenuSingle.tsx
+++ b/frontend/src/features/prototype/components/molecules/PartPropertyMenuSingle.tsx
@@ -73,9 +73,9 @@ export default function PartPropertyMenuSingle({
       { ...currentProperty, ...property } as PartPropertyWithImage
     );
     if (JSON.stringify(currentProperty) === JSON.stringify(updatedProperty)) return;
-    // API は imageId のみ受け付けるため image は除外
-    const updateProperty = { ...updatedProperty } as Record<string, unknown>;
-    delete updateProperty.image;
+    // API は imageId のみ受け付けるため image は除外（イミュータブルに除外）
+    const { image: _omit, ...updateProperty } =
+      updatedProperty as PartPropertyUpdate & { image?: unknown };
     dispatch({
       type: 'UPDATE_PART',
       payload: { partId: selectedPart.id, updateProperties: [updateProperty] },

--- a/frontend/src/features/prototype/components/molecules/PartPropertyMenuSingle.tsx
+++ b/frontend/src/features/prototype/components/molecules/PartPropertyMenuSingle.tsx
@@ -73,9 +73,9 @@ export default function PartPropertyMenuSingle({
       { ...currentProperty, ...property } as PartPropertyWithImage
     );
     if (JSON.stringify(currentProperty) === JSON.stringify(updatedProperty)) return;
-    // API は imageId のみ受け付けるため image を除外
-    const { image: _unusedImage, ...rest } = updatedProperty;
-    const updateProperty: PartPropertyUpdate = rest;
+    // API は imageId のみ受け付けるため image は除外
+    const updateProperty = { ...updatedProperty } as Record<string, unknown>;
+    delete updateProperty.image;
     dispatch({
       type: 'UPDATE_PART',
       payload: { partId: selectedPart.id, updateProperties: [updateProperty] },


### PR DESCRIPTION
Summary
- Replace alignment (整列) buttons icons with Lucide (`react-icons/lu`) set
- Make buttons icon-only and center content
- Increase icon size to `h-5 w-5`

Details
- Imports updated to use `LuAlign*` icons for horizontal/vertical start/center/end
- `PartPropertyMenuButton` updated with `justify-center` to center icon-only buttons

Files Changed
- `frontend/src/features/prototype/components/molecules/PartPropertyMenuMulti.tsx`
- `frontend/src/features/prototype/components/atoms/PartPropertyMenuButton.tsx`

Notes
- Target base: `develop` per repo guidelines
- If you prefer different sizes or spacing, I can adjust Tailwind classes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added aria-labels and title tooltips to alignment buttons for improved screen-reader and hover info.

* **Style**
  * Alignment controls are now icons-only with larger icons and horizontally centered button content for a cleaner, balanced appearance.
  * Switched to a consistent new icon set for horizontal and vertical alignment actions.
  * Existing actions, layout and disabled behavior remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->