### PR TITLE
Rename RoleMenu → RightTopMenu; rename HeaderRightMenu → UserMenu; embed UserMenu in RightTopMenu

### DIFF
--- a/frontend/src/components/molecules/UserMenu.tsx
+++ b/frontend/src/components/molecules/UserMenu.tsx
@@ -10,11 +10,11 @@ import { useUser } from '@/hooks/useUser';
 // フィードバックフォームのURL
 const FEEDBACK_FORM_URL = 'https://forms.gle/XjMV2WgFRCJg7cHj7';
 
-interface HeaderRightMenuProps {
+interface UserMenuProps {
   pathname: string;
 }
 
-const HeaderRightMenu: React.FC<HeaderRightMenuProps> = ({ pathname }) => {
+const UserMenu: React.FC<UserMenuProps> = ({ pathname }) => {
   const router = useRouter();
   const { user, setUser, isLoading } = useUser();
   const { logout } = useAuth();
@@ -131,4 +131,4 @@ const HeaderRightMenu: React.FC<HeaderRightMenuProps> = ({ pathname }) => {
   );
 };
 
-export default HeaderRightMenu;
+export default UserMenu;

--- a/frontend/src/components/organisms/Header.tsx
+++ b/frontend/src/components/organisms/Header.tsx
@@ -3,7 +3,7 @@ import { usePathname, useRouter } from 'next/navigation';
 import React from 'react';
 import { GiWoodenCrate } from 'react-icons/gi';
 
-import HeaderRightMenu from '@/components/molecules/HeaderRightMenu';
+import UserMenu from '@/components/molecules/UserMenu';
 
 const Header: React.FC = () => {
   const router = useRouter();
@@ -30,7 +30,7 @@ const Header: React.FC = () => {
         </div>
       </button>
 
-      <HeaderRightMenu pathname={pathname} />
+      <UserMenu pathname={pathname} />
     </header>
   );
 };

--- a/frontend/src/features/prototype/components/molecules/RightTopMenu.tsx
+++ b/frontend/src/features/prototype/components/molecules/RightTopMenu.tsx
@@ -13,7 +13,7 @@ import { MAX_DISPLAY_USERS } from '@/features/prototype/constants/presence';
 import { ConnectedUser } from '@/features/prototype/types';
 import { getUserColor } from '@/features/prototype/utils/userColor';
 
-interface RoleMenuProps {
+interface RightTopMenuProps {
   // プロジェクト識別子
   projectId: string;
   // 現在接続中のユーザー（左側のアイコン表示用）
@@ -31,13 +31,13 @@ interface RoleMenuProps {
  * - 接続中のユーザーは色バッジ付き
  * - 非接続ユーザーはテキストのみ
  */
-export default function RoleMenu({
+export default function RightTopMenu({
   projectId,
   connectedUsers,
   roleUsers,
   loading = false,
   showRoleManagementButton = true,
-}: RoleMenuProps): ReactElement | null {
+}: RightTopMenuProps): ReactElement | null {
   // ローディング中や空の場合は何も表示しない
   if (loading || !connectedUsers || connectedUsers.length === 0) {
     return null;

--- a/frontend/src/features/prototype/components/molecules/RightTopMenu.tsx
+++ b/frontend/src/features/prototype/components/molecules/RightTopMenu.tsx
@@ -5,9 +5,11 @@
 'use client';
 
 import Link from 'next/link';
+import { usePathname } from 'next/navigation';
 import type { ReactElement } from 'react';
 import { FaUsers } from 'react-icons/fa';
 
+import UserMenu from '@/components/molecules/UserMenu';
 import ConnectedUserIcon from '@/features/prototype/components/atoms/ConnectedUserIcon';
 import { MAX_DISPLAY_USERS } from '@/features/prototype/constants/presence';
 import { ConnectedUser } from '@/features/prototype/types';
@@ -38,10 +40,7 @@ export default function RightTopMenu({
   loading = false,
   showRoleManagementButton = true,
 }: RightTopMenuProps): ReactElement | null {
-  // ローディング中や空の場合は何も表示しない
-  if (loading || !connectedUsers || connectedUsers.length === 0) {
-    return null;
-  }
+  const pathname = usePathname();
 
   // ユーザー名リスト（最大3名まで表示、残りは+Nで省略）
   const displayUsers = connectedUsers.slice(0, MAX_DISPLAY_USERS);
@@ -49,70 +48,71 @@ export default function RightTopMenu({
   const activeUserIds = new Set(connectedUsers.map((u) => u.userId));
 
   return (
-    <div
-      className={`fixed top-4 right-4 z-overlay flex flex-row items-center justify-between ${showRoleManagementButton ? 'max-w-[150px]' : 'max-w-[100px]'} h-[56px] bg-kibako-white p-2 rounded-lg`}
-    >
+    <div className={`fixed top-4 right-4 z-overlay flex flex-row items-center gap-2 h-[56px] bg-kibako-white p-2 rounded-lg`}>
       {/* ユーザーアイコンリスト（左側・ホバーで全ユーザー名表示） */}
-      <div className="relative group">
-        <button
-          className="flex flex-row items-center focus:outline-none"
-          aria-label="ユーザーリストを表示"
-          tabIndex={0}
-        >
-          <div className="flex -space-x-3">
-            {displayUsers.map((user, idx) => (
-              <ConnectedUserIcon
-                key={user.userId || `user-${idx}`}
-                user={user}
-                users={roleUsers}
-                index={idx}
-              />
-            ))}
-          </div>
-          {moreCount > 0 && (
-            <span className="text-xs text-kibako-secondary ml-2">
-              +{moreCount}
-            </span>
-          )}
-        </button>
-        <div className="absolute right-0 mt-2 max-w-xs bg-kibako-white border border-kibako-secondary rounded shadow z-tooltip px-3 py-2 text-xs text-kibako-primary opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto transition-opacity duration-200">
-          <ul className="flex gap-1 flex-col">
-            {roleUsers.map((user) => {
-              const isActive = activeUserIds.has(user.userId);
-              const color: string | undefined = isActive
-                ? getUserColor(user.userId, roleUsers)
-                : undefined;
-              return (
-                <li
-                  key={user.userId}
-                  className="truncate max-w-[180px] px-0 py-0 leading-6"
-                  title={user.username}
-                >
-                  {isActive ? (
-                    <span
-                      className="inline-flex items-center gap-1 px-1 rounded border"
-                      style={{ borderColor: color }}
-                    >
+      {!loading && connectedUsers && connectedUsers.length > 0 && (
+        <div className="relative group">
+          <button
+            className="flex flex-row items-center focus:outline-none"
+            aria-label="ユーザーリストを表示"
+            tabIndex={0}
+          >
+            <div className="flex -space-x-3">
+              {displayUsers.map((user, idx) => (
+                <ConnectedUserIcon
+                  key={user.userId || `user-${idx}`}
+                  user={user}
+                  users={roleUsers}
+                  index={idx}
+                />
+              ))}
+            </div>
+            {moreCount > 0 && (
+              <span className="text-xs text-kibako-secondary ml-2">
+                +{moreCount}
+              </span>
+            )}
+          </button>
+          <div className="absolute right-0 mt-2 max-w-xs bg-kibako-white border border-kibako-secondary rounded shadow z-tooltip px-3 py-2 text-xs text-kibako-primary opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto transition-opacity duration-200">
+            <ul className="flex gap-1 flex-col">
+              {roleUsers.map((user) => {
+                const isActive = activeUserIds.has(user.userId);
+                const color: string | undefined = isActive
+                  ? getUserColor(user.userId, roleUsers)
+                  : undefined;
+                return (
+                  <li
+                    key={user.userId}
+                    className="truncate max-w-[180px] px-0 py-0 leading-6"
+                    title={user.username}
+                  >
+                    {isActive ? (
                       <span
-                        className="inline-block w-2 h-2"
-                        style={{ backgroundColor: color }}
-                      />
-                      {user.username}
-                    </span>
-                  ) : (
-                    user.username
-                  )}
-                </li>
-              );
-            })}
-          </ul>
+                        className="inline-flex items-center gap-1 px-1 rounded border"
+                        style={{ borderColor: color }}
+                      >
+                        <span
+                          className="inline-block w-2 h-2"
+                          style={{ backgroundColor: color }}
+                        />
+                        {user.username}
+                      </span>
+                    ) : (
+                      user.username
+                    )}
+                  </li>
+                );
+              })}
+            </ul>
+          </div>
         </div>
-      </div>
-      {/* 権限管理ページへのリンク（右側） - showRoleManagementButtonがtrueの時のみ表示 */}
+      )}
+
+      {/* 権限管理ページへのリンク（中央） - showRoleManagementButtonがtrueの時のみ表示 */}
       {showRoleManagementButton && (
         <Link
           href={`/projects/${projectId}/roles`}
-          className="group flex items-center justify-center w-10 h-10 relative hover:bg-kibako-tertiary rounded transition-colors ml-2"
+          className="group flex items-center justify-center w-10 h-10 relative hover:bg-kibako-tertiary rounded transition-colors"
           title="権限管理ページへ"
         >
           <FaUsers className="h-5 w-5 text-kibako-primary" />
@@ -121,6 +121,9 @@ export default function RightTopMenu({
           </span>
         </Link>
       )}
+
+      {/* ユーザーメニュー（右側） - 常時表示 */}
+      <UserMenu pathname={pathname} />
     </div>
   );
 }

--- a/frontend/src/features/prototype/components/organisms/GameBoard.tsx
+++ b/frontend/src/features/prototype/components/organisms/GameBoard.tsx
@@ -15,7 +15,7 @@ import LeftSidebar from '@/features/prototype/components/molecules/LeftSidebar';
 import PartCreateMenu from '@/features/prototype/components/molecules/PartCreateMenu';
 import PartPropertyMenu from '@/features/prototype/components/molecules/PartPropertyMenu';
 import PlaySidebar from '@/features/prototype/components/molecules/PlaySidebar';
-import RoleMenu from '@/features/prototype/components/molecules/RoleMenu';
+import RightTopMenu from '@/features/prototype/components/molecules/RightTopMenu';
 import ZoomToolbar from '@/features/prototype/components/molecules/ZoomToolbar';
 import { GAME_BOARD_SIZE } from '@/features/prototype/constants';
 import { DebugModeProvider } from '@/features/prototype/contexts/DebugModeContext';
@@ -544,7 +544,7 @@ export default function GameBoard({
       {/* ロールメニュー - CREATEモードとPLAYモードで表示 */}
       {(gameBoardMode === GameBoardMode.CREATE ||
         gameBoardMode === GameBoardMode.PLAY) && (
-        <RoleMenu
+        <RightTopMenu
           projectId={projectId}
           connectedUsers={connectedUsers}
           roleUsers={roleUsers}


### PR DESCRIPTION
This PR performs a small UI renaming and header menu integration:

Changes
- Rename RoleMenu component to RightTopMenu
  - File: frontend/src/features/prototype/components/molecules/RoleMenu.tsx → RightTopMenu.tsx
  - Update imports/usages in GameBoard
- Rename HeaderRightMenu component to UserMenu
  - File: frontend/src/components/molecules/HeaderRightMenu.tsx → UserMenu.tsx
  - Update import/usage in Header
- Embed UserMenu in RightTopMenu
  - Always displayed on the right of the Role Management button
  - Adjust RightTopMenu layout and pass pathname

Rationale
- Naming clarity: RightTopMenu better reflects position/role; UserMenu is more conventional
- Improves UX by surfacing the user menu consistently on the game board view

Notes
- No behavior changes to login/logout flows
- Role Management button still shown only in CREATE mode; UserMenu is always visible

Please review. If desired, I can follow up with any style tweaks or tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a floating top-right menu showing connected users with overlapping icons and a +N indicator.
  - Hover reveals a full list with active users highlighted and a quick link to role management.
  - Improved accessibility with labels and titles.

- Refactor
  - Renamed the header user menu component; behavior unchanged.
  - Replaced the old role menu with the new right-top menu across relevant screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->