### PR TITLE
fix: configure frontend as ESM to remove Node warning

### DIFF
--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -15,4 +15,4 @@ const nextConfig = {
   },
 };
 
-module.exports = nextConfig;
+export default nextConfig;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,6 +2,7 @@
   "name": "my-boardgame-app",
   "version": "0.1.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "dev": "next dev --turbo",
     "build": "next build",

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -28,7 +28,7 @@
     "**/*.ts",
     "**/*.tsx",
     ".next/types/**/*.ts",
-    "next.config.js"
+    "next.config.mjs"
   ],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## Summary
- declare frontend package as an ES module to stop Node from reparsing `eslint.config.js`
- switch Next.js config to ESM and update TypeScript config

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc8055628c83269ffd59b5801e95dc