### PR TITLE
chore: standardize package names

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "backend",
+  "name": "board-game-prototype-backend",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "backend",
+      "name": "board-game-prototype-backend",
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "backend",
+  "name": "board-game-prototype-backend",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "my-boardgame-app",
+  "name": "board-game-prototype-frontend",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "my-boardgame-app",
+      "name": "board-game-prototype-frontend",
       "version": "0.1.0",
       "dependencies": {
         "@radix-ui/react-context-menu": "^2.2.4",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "my-boardgame-app",
+  "name": "board-game-prototype-frontend",
   "version": "0.1.0",
   "private": true,
   "scripts": {


### PR DESCRIPTION
## Summary
- rename frontend package to `board-game-prototype-frontend`
- rename backend package to `board-game-prototype-backend`

## Testing
- `npm run lint` (backend)
- `npm test -- --run` (backend)
- `npm run lint` (frontend)
- `npm test` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68bc80a6531c8326ae52a6f7fee12591

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Chores
  * Updated package metadata to rename both backend and frontend packages to new public names.
  * No changes to code, dependencies, or scripts; runtime behavior remains unchanged.
  * Build artifacts, installation identifiers, and package registry display names will reflect the new names.
  * CI/CD logs and consumers may see updated identifiers; no action required unless workflows or tooling depend on exact package names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->