### PR TITLE
feat: add table view toggle for project list

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -46,3 +46,6 @@ dist
 .idea/
 *.sublime-workspace
 *.sublime-project
+
+# ESLint cache
+.eslintcache

--- a/backend/src/swagger-schemas.ts
+++ b/backend/src/swagger-schemas.ts
@@ -4,477 +4,426 @@ export const swaggerSchemas = {
   components: {
     schemas: {
       ...{
-      "SuccessResponse": {
-            "type": "object",
-            "properties": {
-                  "message": {
-                        "type": "string",
-                        "description": "処理成功時のメッセージ"
-                  }
+        SuccessResponse: {
+          type: 'object',
+          properties: {
+            message: {
+              type: 'string',
+              description: '処理成功時のメッセージ',
             },
-            "required": [
-                  "message"
-            ],
-            "example": {
-                  "message": "正常に処理が完了しました"
-            }
+          },
+          required: ['message'],
+          example: {
+            message: '正常に処理が完了しました',
+          },
+        },
+        Error400Response: {
+          type: 'object',
+          properties: {
+            error: {
+              type: 'string',
+              description: 'エラーメッセージ',
+            },
+          },
+          required: ['error'],
+          example: {
+            error: 'リクエストが不正です',
+          },
+        },
+        Error401Response: {
+          type: 'object',
+          properties: {
+            error: {
+              type: 'string',
+              description: 'エラーメッセージ',
+            },
+          },
+          required: ['error'],
+          example: {
+            error: '認証が必要です',
+          },
+        },
+        Error404Response: {
+          type: 'object',
+          properties: {
+            error: {
+              type: 'string',
+              description: 'エラーメッセージ',
+            },
+          },
+          required: ['error'],
+          example: {
+            error: 'リソースが見つかりません',
+          },
+        },
+        Error500Response: {
+          type: 'object',
+          properties: {
+            error: {
+              type: 'string',
+              description: 'エラーメッセージ',
+            },
+          },
+          required: ['error'],
+          example: {
+            error: '予期せぬエラーが発生しました',
+          },
+        },
       },
-      "Error400Response": {
-            "type": "object",
-            "properties": {
-                  "error": {
-                        "type": "string",
-                        "description": "エラーメッセージ"
-                  }
-            },
-            "required": [
-                  "error"
-            ],
-            "example": {
-                  "error": "リクエストが不正です"
-            }
-      },
-      "Error401Response": {
-            "type": "object",
-            "properties": {
-                  "error": {
-                        "type": "string",
-                        "description": "エラーメッセージ"
-                  }
-            },
-            "required": [
-                  "error"
-            ],
-            "example": {
-                  "error": "認証が必要です"
-            }
-      },
-      "Error404Response": {
-            "type": "object",
-            "properties": {
-                  "error": {
-                        "type": "string",
-                        "description": "エラーメッセージ"
-                  }
-            },
-            "required": [
-                  "error"
-            ],
-            "example": {
-                  "error": "リソースが見つかりません"
-            }
-      },
-      "Error500Response": {
-            "type": "object",
-            "properties": {
-                  "error": {
-                        "type": "string",
-                        "description": "エラーメッセージ"
-                  }
-            },
-            "required": [
-                  "error"
-            ],
-            "example": {
-                  "error": "予期せぬエラーが発生しました"
-            }
-      }
-},
       Image: {
-      "type": "object",
-      "properties": {
-            "id": {
-                  "type": "string",
-                  "format": "uuid"
-            },
-            "displayName": {
-                  "type": "string"
-            },
-            "storagePath": {
-                  "type": "string"
-            },
-            "contentType": {
-                  "type": "string"
-            },
-            "fileSize": {
-                  "type": "integer"
-            },
-            "uploaderUserId": {
-                  "type": "string",
-                  "format": "uuid"
-            },
-            "createdAt": {
-                  "type": "string"
-            },
-            "updatedAt": {
-                  "type": "string"
-            }
+        type: 'object',
+        properties: {
+          id: {
+            type: 'string',
+            format: 'uuid',
+          },
+          displayName: {
+            type: 'string',
+          },
+          storagePath: {
+            type: 'string',
+          },
+          contentType: {
+            type: 'string',
+          },
+          fileSize: {
+            type: 'integer',
+          },
+          uploaderUserId: {
+            type: 'string',
+            format: 'uuid',
+          },
+          createdAt: {
+            type: 'string',
+          },
+          updatedAt: {
+            type: 'string',
+          },
+        },
+        required: [
+          'id',
+          'displayName',
+          'storagePath',
+          'contentType',
+          'fileSize',
+          'uploaderUserId',
+          'createdAt',
+          'updatedAt',
+        ],
       },
-      "required": [
-            "id",
-            "displayName",
-            "storagePath",
-            "contentType",
-            "fileSize",
-            "uploaderUserId",
-            "createdAt",
-            "updatedAt"
-      ]
-},
       Part: {
-      "type": "object",
-      "properties": {
-            "id": {
-                  "type": "integer"
-            },
-            "type": {
-                  "type": "string",
-                  "enum": [
-                        "token",
-                        "card",
-                        "hand",
-                        "deck",
-                        "area"
-                  ]
-            },
-            "prototypeId": {
-                  "type": "string",
-                  "format": "uuid"
-            },
-            "position": {
-                  "type": "object",
-                  "additionalProperties": true
-            },
-            "width": {
-                  "type": "integer"
-            },
-            "height": {
-                  "type": "integer"
-            },
-            "order": {
-                  "type": "integer"
-            },
-            "frontSide": {
-                  "oneOf": [
-                        {
-                              "type": "string",
-                              "enum": [
-                                    "front",
-                                    "back"
-                              ]
-                        },
-                        {
-                              "type": "null"
-                        }
-                  ]
-            },
-            "ownerId": {
-                  "oneOf": [
-                        {
-                              "type": "string",
-                              "format": "uuid"
-                        },
-                        {
-                              "type": "null"
-                        }
-                  ]
-            },
-            "createdAt": {
-                  "type": "string"
-            },
-            "updatedAt": {
-                  "type": "string"
-            }
+        type: 'object',
+        properties: {
+          id: {
+            type: 'integer',
+          },
+          type: {
+            type: 'string',
+            enum: ['token', 'card', 'hand', 'deck', 'area'],
+          },
+          prototypeId: {
+            type: 'string',
+            format: 'uuid',
+          },
+          position: {
+            type: 'object',
+            additionalProperties: true,
+          },
+          width: {
+            type: 'integer',
+          },
+          height: {
+            type: 'integer',
+          },
+          order: {
+            type: 'integer',
+          },
+          frontSide: {
+            oneOf: [
+              {
+                type: 'string',
+                enum: ['front', 'back'],
+              },
+              {
+                type: 'null',
+              },
+            ],
+          },
+          ownerId: {
+            oneOf: [
+              {
+                type: 'string',
+                format: 'uuid',
+              },
+              {
+                type: 'null',
+              },
+            ],
+          },
+          createdAt: {
+            type: 'string',
+          },
+          updatedAt: {
+            type: 'string',
+          },
+        },
+        required: [
+          'id',
+          'type',
+          'prototypeId',
+          'position',
+          'width',
+          'height',
+          'order',
+          'createdAt',
+          'updatedAt',
+        ],
       },
-      "required": [
-            "id",
-            "type",
-            "prototypeId",
-            "position",
-            "width",
-            "height",
-            "order",
-            "createdAt",
-            "updatedAt"
-      ]
-},
       PartProperty: {
-      "type": "object",
-      "properties": {
-            "partId": {
-                  "type": "integer"
-            },
-            "side": {
-                  "type": "string",
-                  "enum": [
-                        "front",
-                        "back"
-                  ]
-            },
-            "name": {
-                  "type": "string"
-            },
-            "description": {
-                  "type": "string"
-            },
-            "color": {
-                  "type": "string"
-            },
-            "textColor": {
-                  "type": "string"
-            },
-            "imageId": {
-                  "oneOf": [
-                        {
-                              "type": "string",
-                              "format": "uuid"
-                        },
-                        {
-                              "type": "null"
-                        }
-                  ]
-            },
-            "createdAt": {
-                  "type": "string"
-            },
-            "updatedAt": {
-                  "type": "string"
-            }
+        type: 'object',
+        properties: {
+          partId: {
+            type: 'integer',
+          },
+          side: {
+            type: 'string',
+            enum: ['front', 'back'],
+          },
+          name: {
+            type: 'string',
+          },
+          description: {
+            type: 'string',
+          },
+          color: {
+            type: 'string',
+          },
+          textColor: {
+            type: 'string',
+          },
+          imageId: {
+            oneOf: [
+              {
+                type: 'string',
+                format: 'uuid',
+              },
+              {
+                type: 'null',
+              },
+            ],
+          },
+          createdAt: {
+            type: 'string',
+          },
+          updatedAt: {
+            type: 'string',
+          },
+        },
+        required: [
+          'partId',
+          'side',
+          'name',
+          'description',
+          'color',
+          'textColor',
+          'createdAt',
+          'updatedAt',
+        ],
       },
-      "required": [
-            "partId",
-            "side",
-            "name",
-            "description",
-            "color",
-            "textColor",
-            "createdAt",
-            "updatedAt"
-      ]
-},
       Permission: {
-      "type": "object",
-      "properties": {
-            "id": {
-                  "type": "integer"
-            },
-            "name": {
-                  "type": "string"
-            },
-            "resource": {
-                  "type": "string"
-            },
-            "action": {
-                  "type": "string"
-            },
-            "description": {
-                  "oneOf": [
-                        {
-                              "type": "string"
-                        },
-                        {
-                              "type": "null"
-                        }
-                  ]
-            },
-            "createdAt": {
-                  "type": "string"
-            },
-            "updatedAt": {
-                  "type": "string"
-            }
+        type: 'object',
+        properties: {
+          id: {
+            type: 'integer',
+          },
+          name: {
+            type: 'string',
+          },
+          resource: {
+            type: 'string',
+          },
+          action: {
+            type: 'string',
+          },
+          description: {
+            oneOf: [
+              {
+                type: 'string',
+              },
+              {
+                type: 'null',
+              },
+            ],
+          },
+          createdAt: {
+            type: 'string',
+          },
+          updatedAt: {
+            type: 'string',
+          },
+        },
+        required: [
+          'id',
+          'name',
+          'resource',
+          'action',
+          'createdAt',
+          'updatedAt',
+        ],
       },
-      "required": [
-            "id",
-            "name",
-            "resource",
-            "action",
-            "createdAt",
-            "updatedAt"
-      ]
-},
       Project: {
-      "type": "object",
-      "properties": {
-            "id": {
-                  "type": "string",
-                  "format": "uuid"
-            },
-            "userId": {
-                  "type": "string",
-                  "format": "uuid"
-            },
-            "createdAt": {
-                  "type": "string"
-            },
-            "updatedAt": {
-                  "type": "string"
-            }
+        type: 'object',
+        properties: {
+          id: {
+            type: 'string',
+            format: 'uuid',
+          },
+          userId: {
+            type: 'string',
+            format: 'uuid',
+          },
+          createdAt: {
+            type: 'string',
+          },
+          updatedAt: {
+            type: 'string',
+          },
+        },
+        required: ['id', 'userId', 'createdAt', 'updatedAt'],
       },
-      "required": [
-            "id",
-            "userId",
-            "createdAt",
-            "updatedAt"
-      ]
-},
       Prototype: {
-      "type": "object",
-      "properties": {
-            "id": {
-                  "type": "string",
-                  "format": "uuid"
-            },
-            "projectId": {
-                  "type": "string",
-                  "format": "uuid"
-            },
-            "name": {
-                  "type": "string"
-            },
-            "type": {
-                  "type": "string",
-                  "enum": [
-                        "MASTER",
-                        "VERSION",
-                        "INSTANCE"
-                  ]
-            },
-            "sourceVersionPrototypeId": {
-                  "oneOf": [
-                        {
-                              "type": "string",
-                              "format": "uuid"
-                        },
-                        {
-                              "type": "null"
-                        }
-                  ]
-            },
-            "createdAt": {
-                  "type": "string"
-            },
-            "updatedAt": {
-                  "type": "string"
-            }
+        type: 'object',
+        properties: {
+          id: {
+            type: 'string',
+            format: 'uuid',
+          },
+          projectId: {
+            type: 'string',
+            format: 'uuid',
+          },
+          name: {
+            type: 'string',
+          },
+          type: {
+            type: 'string',
+            enum: ['MASTER', 'VERSION', 'INSTANCE'],
+          },
+          sourceVersionPrototypeId: {
+            oneOf: [
+              {
+                type: 'string',
+                format: 'uuid',
+              },
+              {
+                type: 'null',
+              },
+            ],
+          },
+          createdAt: {
+            type: 'string',
+          },
+          updatedAt: {
+            type: 'string',
+          },
+        },
+        required: ['id', 'projectId', 'name', 'type', 'createdAt', 'updatedAt'],
       },
-      "required": [
-            "id",
-            "projectId",
-            "name",
-            "type",
-            "createdAt",
-            "updatedAt"
-      ]
-},
       Role: {
-      "type": "object",
-      "properties": {
-            "id": {
-                  "type": "integer"
-            },
-            "name": {
-                  "type": "string"
-            },
-            "description": {
-                  "oneOf": [
-                        {
-                              "type": "string"
-                        },
-                        {
-                              "type": "null"
-                        }
-                  ]
-            },
-            "createdAt": {
-                  "type": "string"
-            },
-            "updatedAt": {
-                  "type": "string"
-            }
+        type: 'object',
+        properties: {
+          id: {
+            type: 'integer',
+          },
+          name: {
+            type: 'string',
+          },
+          description: {
+            oneOf: [
+              {
+                type: 'string',
+              },
+              {
+                type: 'null',
+              },
+            ],
+          },
+          createdAt: {
+            type: 'string',
+          },
+          updatedAt: {
+            type: 'string',
+          },
+        },
+        required: ['id', 'name', 'createdAt', 'updatedAt'],
       },
-      "required": [
-            "id",
-            "name",
-            "createdAt",
-            "updatedAt"
-      ]
-},
       RolePermission: {
-      "type": "object",
-      "properties": {
-            "roleId": {
-                  "type": "integer"
-            },
-            "permissionId": {
-                  "type": "integer"
-            }
+        type: 'object',
+        properties: {
+          roleId: {
+            type: 'integer',
+          },
+          permissionId: {
+            type: 'integer',
+          },
+        },
+        required: ['roleId', 'permissionId'],
       },
-      "required": [
-            "roleId",
-            "permissionId"
-      ]
-},
       User: {
-      "type": "object",
-      "properties": {
-            "id": {
-                  "type": "string",
-                  "format": "uuid"
-            },
-            "username": {
-                  "type": "string"
-            },
-            "createdAt": {
-                  "type": "string"
-            },
-            "updatedAt": {
-                  "type": "string"
-            }
+        type: 'object',
+        properties: {
+          id: {
+            type: 'string',
+            format: 'uuid',
+          },
+          username: {
+            type: 'string',
+          },
+          createdAt: {
+            type: 'string',
+          },
+          updatedAt: {
+            type: 'string',
+          },
+        },
+        required: ['id', 'username', 'createdAt', 'updatedAt'],
       },
-      "required": [
-            "id",
-            "username",
-            "createdAt",
-            "updatedAt"
-      ]
-},
       UserRole: {
-      "type": "object",
-      "properties": {
-            "id": {
-                  "type": "integer"
-            },
-            "userId": {
-                  "type": "string",
-                  "format": "uuid"
-            },
-            "roleId": {
-                  "type": "integer"
-            },
-            "resourceType": {
-                  "type": "string"
-            },
-            "resourceId": {
-                  "type": "string"
-            },
-            "createdAt": {
-                  "type": "string"
-            },
-            "updatedAt": {
-                  "type": "string"
-            }
+        type: 'object',
+        properties: {
+          id: {
+            type: 'integer',
+          },
+          userId: {
+            type: 'string',
+            format: 'uuid',
+          },
+          roleId: {
+            type: 'integer',
+          },
+          resourceType: {
+            type: 'string',
+          },
+          resourceId: {
+            type: 'string',
+          },
+          createdAt: {
+            type: 'string',
+          },
+          updatedAt: {
+            type: 'string',
+          },
+        },
+        required: [
+          'id',
+          'userId',
+          'roleId',
+          'resourceType',
+          'resourceId',
+          'createdAt',
+          'updatedAt',
+        ],
       },
-      "required": [
-            "id",
-            "userId",
-            "roleId",
-            "resourceType",
-            "resourceId",
-            "createdAt",
-            "updatedAt"
-      ]
-},
-    }
-  }
+    },
+  },
 };

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -39,3 +39,6 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# ESLint cache
+.eslintcache

--- a/frontend/src/components/atoms/KibakoButton.tsx
+++ b/frontend/src/components/atoms/KibakoButton.tsx
@@ -24,7 +24,7 @@ export const buttonStyles = cva(
       variant: 'primary',
       size: 'md',
     },
-  },
+  }
 );
 
 interface KibakoButtonProps
@@ -44,10 +44,7 @@ export default function KibakoButton({
   isLoading = false,
   ...props
 }: KibakoButtonProps) {
-  const buttonClasses = twMerge(
-    buttonStyles({ variant, size }),
-    className,
-  );
+  const buttonClasses = twMerge(buttonStyles({ variant, size }), className);
 
   return isLoading ? (
     // ローディング中(3つのドットを点滅表示)

--- a/frontend/src/components/atoms/KibakoLink.tsx
+++ b/frontend/src/components/atoms/KibakoLink.tsx
@@ -5,9 +5,7 @@ import { twMerge } from 'tailwind-merge';
 
 import { buttonStyles } from './KibakoButton';
 
-interface KibakoLinkProps
-  extends LinkProps,
-    VariantProps<typeof buttonStyles> {
+interface KibakoLinkProps extends LinkProps, VariantProps<typeof buttonStyles> {
   children: ReactNode;
   className?: string;
 }
@@ -19,10 +17,7 @@ export default function KibakoLink({
   className = '',
   ...props
 }: KibakoLinkProps) {
-  const buttonClasses = twMerge(
-    buttonStyles({ variant, size }),
-    className,
-  );
+  const buttonClasses = twMerge(buttonStyles({ variant, size }), className);
 
   return (
     <Link className={buttonClasses} {...props}>

--- a/frontend/src/components/atoms/KibakoToggle.tsx
+++ b/frontend/src/components/atoms/KibakoToggle.tsx
@@ -1,0 +1,99 @@
+import React, { ReactNode } from 'react';
+import { twMerge } from 'tailwind-merge';
+
+type KibakoToggleProps = {
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+  labelLeft?: ReactNode;
+  labelRight?: ReactNode;
+  id?: string;
+  className?: string;
+  disabled?: boolean;
+  ariaLabel?: string;
+  shouldChangeBackgroud?: boolean; // optional: whether track bg changes with state (default: true)
+};
+
+/**
+ * KibakoToggle
+ * A simple, accessible toggle switch using the kibako color palette.
+ */
+export default function KibakoToggle({
+  checked,
+  onChange,
+  labelLeft,
+  labelRight,
+  id,
+  className = '',
+  disabled = false,
+  ariaLabel,
+  shouldChangeBackgroud = true,
+}: KibakoToggleProps) {
+  const baseWrapper = twMerge(
+    'inline-flex items-center gap-2 select-none',
+    className
+  );
+  const trackBg = shouldChangeBackgroud
+    ? checked
+      ? 'bg-kibako-primary'
+      : 'bg-kibako-tertiary'
+    : 'bg-kibako-tertiary';
+  const trackClasses = twMerge(
+    'relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border border-kibako-secondary/30 transition-colors duration-200 focus:outline-none',
+    trackBg,
+    disabled ? 'opacity-60 cursor-not-allowed' : ''
+  );
+  const knobClasses = twMerge(
+    'pointer-events-none absolute left-0.5 top-1/2 -translate-y-1/2 h-5 w-5 rounded-full bg-kibako-white ring-1 ring-kibako-primary/30 shadow-sm transition-transform duration-200',
+    checked ? 'translate-x-5' : 'translate-x-0'
+  );
+
+  return (
+    <div className={baseWrapper} aria-disabled={disabled}>
+      {labelLeft ? (
+        <button
+          type="button"
+          disabled={disabled}
+          onClick={() => !disabled && onChange(false)}
+          className={twMerge(
+            'inline-flex items-center gap-1 rounded px-1 py-0.5 text-xs font-medium focus:outline-none',
+            checked ? 'text-kibako-primary/70' : 'text-kibako-primary',
+            disabled
+              ? 'cursor-not-allowed opacity-60'
+              : 'cursor-pointer hover:opacity-80'
+          )}
+        >
+          <span>{labelLeft}</span>
+        </button>
+      ) : null}
+      <button
+        type="button"
+        id={id}
+        role="switch"
+        aria-checked={checked}
+        aria-label={ariaLabel}
+        disabled={disabled}
+        className={trackClasses}
+        onClick={() => !disabled && onChange(!checked)}
+      >
+        <span className="sr-only">Toggle</span>
+        <span aria-hidden="true" className={knobClasses} />
+      </button>
+      {labelRight ? (
+        <button
+          type="button"
+          disabled={disabled}
+          onClick={() => !disabled && onChange(true)}
+          className={twMerge(
+            'inline-flex items-center gap-1 rounded px-1 py-0.5 text-xs font-medium focus:outline-none',
+            checked ? 'text-kibako-primary' : 'text-kibako-primary/70',
+            disabled
+              ? 'cursor-not-allowed opacity-60'
+              : 'cursor-pointer hover:opacity-80'
+          )}
+        >
+          <span>{labelRight}</span>
+        </button>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/src/components/atoms/KibakoToggle.tsx
+++ b/frontend/src/components/atoms/KibakoToggle.tsx
@@ -10,7 +10,10 @@ type KibakoToggleProps = {
   className?: string;
   disabled?: boolean;
   ariaLabel?: string;
-  shouldChangeBackgroud?: boolean; // optional: whether track bg changes with state (default: true)
+  /** トラック背景を状態に応じて変えるか（デフォルト: true） */
+  shouldChangeBackground?: boolean;
+  /** @deprecated タイポ。shouldChangeBackground を使用してください */
+  shouldChangeBackgroud?: boolean;
 };
 
 /**
@@ -26,13 +29,19 @@ export default function KibakoToggle({
   className = '',
   disabled = false,
   ariaLabel,
-  shouldChangeBackgroud = true,
+  shouldChangeBackground = true,
+  shouldChangeBackgroud,
 }: KibakoToggleProps) {
+  // 旧プロップが指定されている場合はそれを優先
+  const effectiveShouldChangeBackground =
+    typeof shouldChangeBackgroud === 'boolean'
+      ? shouldChangeBackgroud
+      : shouldChangeBackground;
   const baseWrapper = twMerge(
     'inline-flex items-center gap-2 select-none',
     className
   );
-  const trackBg = shouldChangeBackgroud
+  const trackBg = effectiveShouldChangeBackground
     ? checked
       ? 'bg-kibako-primary'
       : 'bg-kibako-tertiary'

--- a/frontend/src/components/templates/Maintenance.tsx
+++ b/frontend/src/components/templates/Maintenance.tsx
@@ -27,7 +27,7 @@ const Maintenance: React.FC<MaintenanceProps> = ({
   const endTime = getMaintenanceEndTime();
 
   return (
-      <div className="min-h-[calc(100vh-80px)] bg-gradient-to-br from-kibako-tertiary to-kibako-white flex items-center justify-center p-4">
+    <div className="min-h-[calc(100vh-80px)] bg-gradient-to-br from-kibako-tertiary to-kibako-white flex items-center justify-center p-4">
       {/* メンテナンス情報カード */}
       <div className="max-w-md w-full bg-kibako-white rounded-lg shadow-xl p-8 text-center border border-kibako-secondary">
         {/* ヘッダー部分：ロゴとタイトル */}

--- a/frontend/src/constants/gameBoardUi.ts
+++ b/frontend/src/constants/gameBoardUi.ts
@@ -14,4 +14,3 @@ export const LABEL_MARKER_RADIUS: number = 4;
 export const LABEL_MARKER_Y: number = 8;
 export const LABEL_TEXT_X: number = 22;
 export const LABEL_FONT_SIZE: number = 24;
-

--- a/frontend/src/features/profile/components/ProfileEdit.tsx
+++ b/frontend/src/features/profile/components/ProfileEdit.tsx
@@ -76,7 +76,9 @@ const ProfileEdit: React.FC = () => {
 
     try {
       setIsSubmitting(true);
-      const updatedUser = await updateUser(user.id, { username: username.trim() });
+      const updatedUser = await updateUser(user.id, {
+        username: username.trim(),
+      });
 
       // ユーザーコンテキストを更新
       setUser(updatedUser);
@@ -151,12 +153,20 @@ const ProfileEdit: React.FC = () => {
               更新する
             </KibakoButton>
             {error && (
-              <p role="alert" aria-live="assertive" className="text-kibako-danger text-sm">
+              <p
+                role="alert"
+                aria-live="assertive"
+                className="text-kibako-danger text-sm"
+              >
                 {error}
               </p>
             )}
             {success && (
-              <p role="status" aria-live="polite" className="text-kibako-success text-sm">
+              <p
+                role="status"
+                aria-live="polite"
+                className="text-kibako-success text-sm"
+              >
                 {success}
               </p>
             )}

--- a/frontend/src/features/prototype/components/atoms/ProjectContextMenu.tsx
+++ b/frontend/src/features/prototype/components/atoms/ProjectContextMenu.tsx
@@ -93,7 +93,9 @@ export const ProjectContextMenu: React.FC<ProjectContextMenuProps> = ({
         <button
           key={item.id}
           className={`w-full px-4 text-left flex items-center gap-2 transition-colors ${
-            hoveredMenuItem === item.id ? 'bg-kibako-tertiary/20' : 'hover:bg-kibako-tertiary/20'
+            hoveredMenuItem === item.id
+              ? 'bg-kibako-tertiary/20'
+              : 'hover:bg-kibako-tertiary/20'
           } ${
             item.danger
               ? 'text-kibako-danger hover:text-kibako-danger/80'

--- a/frontend/src/features/prototype/components/molecules/LeftSidebar.tsx
+++ b/frontend/src/features/prototype/components/molecules/LeftSidebar.tsx
@@ -82,7 +82,7 @@ export default function LeftSidebar({
       router.push('/projects');
       return;
     }
-  // プレビューまたはプレイルームの場合はマスタープロトタイプに戻る
+    // プレビューまたはプレイルームの場合はマスタープロトタイプに戻る
     if (
       gameBoardMode === GameBoardMode.PLAY ||
       gameBoardMode === GameBoardMode.PREVIEW

--- a/frontend/src/features/prototype/components/molecules/PartPropertyMenu.tsx
+++ b/frontend/src/features/prototype/components/molecules/PartPropertyMenu.tsx
@@ -10,7 +10,10 @@ import { IoMdMove } from 'react-icons/io';
 import { Part } from '@/api/types';
 import PartTypeIcon from '@/features/prototype/components/atoms/PartTypeIcon';
 import useDraggablePartPropertyMenu from '@/features/prototype/hooks/useDraggablePartPropertyMenu';
-import { DeleteImageProps, PartPropertyWithImage } from '@/features/prototype/types';
+import {
+  DeleteImageProps,
+  PartPropertyWithImage,
+} from '@/features/prototype/types';
 import { GameBoardMode } from '@/features/prototype/types';
 
 import PartPropertyMenuMulti from './PartPropertyMenuMulti';
@@ -60,7 +63,7 @@ export default function PartPropertyMenu({
   /** 複数選択中のパーツ一覧 */
   const selectedParts = useMemo<Part[]>(
     () => parts.filter((part) => selectedPartIds.includes(part.id)),
-    [parts, selectedPartIds],
+    [parts, selectedPartIds]
   );
   const multipleSelected = selectedPartIds.length > 1;
   const isPlayMode = gameBoardMode === GameBoardMode.PLAY;
@@ -69,7 +72,8 @@ export default function PartPropertyMenu({
   // - PLAY mode with multiple selection (hide for single select in PLAY mode)
   const showMenu =
     selectedPartIds.length > 0 &&
-    (gameBoardMode === GameBoardMode.CREATE || (isPlayMode && multipleSelected));
+    (gameBoardMode === GameBoardMode.CREATE ||
+      (isPlayMode && multipleSelected));
 
   const {
     containerRef,
@@ -137,7 +141,10 @@ export default function PartPropertyMenu({
         />
       </div>
       <div className="flex flex-col gap-2 p-4 overflow-y-auto overflow-x-hidden [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden">
-        <PartPropertyMenuMulti selectedParts={selectedParts} hidden={!multipleSelected} />
+        <PartPropertyMenuMulti
+          selectedParts={selectedParts}
+          hidden={!multipleSelected}
+        />
         <PartPropertyMenuSingle
           selectedPart={selectedPart}
           properties={properties}

--- a/frontend/src/features/prototype/components/molecules/PartPropertyMenuMulti.tsx
+++ b/frontend/src/features/prototype/components/molecules/PartPropertyMenuMulti.tsx
@@ -14,20 +14,33 @@ import PartPropertyMenuButton from '@/features/prototype/components/atoms/PartPr
 import { usePartOverlayMessage } from '@/features/prototype/contexts/PartOverlayMessageContext';
 import { useSelectedParts } from '@/features/prototype/contexts/SelectedPartsContext';
 import { usePartReducer } from '@/features/prototype/hooks/usePartReducer';
-import { calculateAlignmentInfo, getAlignmentUpdates, AlignmentType } from '@/features/prototype/utils/alignment';
+import {
+  calculateAlignmentInfo,
+  getAlignmentUpdates,
+  AlignmentType,
+} from '@/features/prototype/utils/alignment';
 
 interface PartPropertyMenuMultiProps {
   selectedParts: Part[];
   hidden: boolean;
 }
 
-export default function PartPropertyMenuMulti({ selectedParts, hidden }: PartPropertyMenuMultiProps) {
+export default function PartPropertyMenuMulti({
+  selectedParts,
+  hidden,
+}: PartPropertyMenuMultiProps) {
   const { dispatch } = usePartReducer();
   const { selectMultipleParts } = useSelectedParts();
   const { runShuffleEffect } = usePartOverlayMessage();
 
-  const alignInfo = useMemo(() => calculateAlignmentInfo(selectedParts), [selectedParts]);
-  const cardParts = useMemo(() => selectedParts.filter((p) => p.type === 'card'), [selectedParts]);
+  const alignInfo = useMemo(
+    () => calculateAlignmentInfo(selectedParts),
+    [selectedParts]
+  );
+  const cardParts = useMemo(
+    () => selectedParts.filter((p) => p.type === 'card'),
+    [selectedParts]
+  );
   const showActionSection = cardParts.length >= 2;
 
   const alignParts = useCallback(
@@ -37,15 +50,24 @@ export default function PartPropertyMenuMulti({ selectedParts, hidden }: PartPro
       if (updates.length === 0) return;
       dispatch({ type: 'UPDATE_PARTS', payload: { updates } });
     },
-    [alignInfo, selectedParts, dispatch],
+    [alignInfo, selectedParts, dispatch]
   );
 
   const handleAlignLeft = useCallback(() => alignParts('left'), [alignParts]);
   const handleAlignRight = useCallback(() => alignParts('right'), [alignParts]);
-  const handleAlignHCenter = useCallback(() => alignParts('hCenter'), [alignParts]);
+  const handleAlignHCenter = useCallback(
+    () => alignParts('hCenter'),
+    [alignParts]
+  );
   const handleAlignTop = useCallback(() => alignParts('top'), [alignParts]);
-  const handleAlignBottom = useCallback(() => alignParts('bottom'), [alignParts]);
-  const handleAlignVCenter = useCallback(() => alignParts('vCenter'), [alignParts]);
+  const handleAlignBottom = useCallback(
+    () => alignParts('bottom'),
+    [alignParts]
+  );
+  const handleAlignVCenter = useCallback(
+    () => alignParts('vCenter'),
+    [alignParts]
+  );
 
   /**
    * カードのみを選択し、裏面へ反転・中央へ寄せ・順序を公平にシャッフルする
@@ -106,7 +128,10 @@ export default function PartPropertyMenuMulti({ selectedParts, hidden }: PartPro
   }, [cardParts, selectMultipleParts, dispatch, runShuffleEffect]);
 
   return (
-    <div className="flex flex-col gap-2" style={{ display: hidden ? 'none' : 'flex' }}>
+    <div
+      className="flex flex-col gap-2"
+      style={{ display: hidden ? 'none' : 'flex' }}
+    >
       {showActionSection && (
         <>
           <p className="text-kibako-white">アクション</p>

--- a/frontend/src/features/prototype/components/molecules/PartPropertyMenuSingle.tsx
+++ b/frontend/src/features/prototype/components/molecules/PartPropertyMenuSingle.tsx
@@ -11,7 +11,11 @@ import ColorPicker from '@/features/prototype/components/atoms/ColorPicker';
 import PartPropertyMenuButton from '@/features/prototype/components/atoms/PartPropertyMenuButton';
 import { COLORS } from '@/features/prototype/constants';
 import { usePartReducer } from '@/features/prototype/hooks/usePartReducer';
-import { DeleteImageProps, PartPropertyUpdate, PartPropertyWithImage } from '@/features/prototype/types';
+import {
+  DeleteImageProps,
+  PartPropertyUpdate,
+  PartPropertyWithImage,
+} from '@/features/prototype/types';
 import { saveImageToIndexedDb } from '@/utils/db';
 
 const IMAGE_ALLOWED_MIME_TYPES = ['image/jpeg', 'image/png'];
@@ -20,7 +24,13 @@ interface PartPropertyMenuSingleProps {
   selectedPart: Part | null;
   properties: PartPropertyWithImage[];
   onDeletePart: () => void;
-  onDeleteImage: ({ imageId, prototypeId, partId, side, emitUpdate }: DeleteImageProps) => void;
+  onDeleteImage: ({
+    imageId,
+    prototypeId,
+    partId,
+    side,
+    emitUpdate,
+  }: DeleteImageProps) => void;
   onDuplicatePart: () => void;
   isPlayMode: boolean;
   hidden: boolean;
@@ -39,8 +49,11 @@ export default function PartPropertyMenuSingle({
   const { uploadImage } = useImages();
 
   const selectedPartProperties = useMemo(
-    () => (selectedPart ? properties.filter((p) => p.partId === selectedPart.id) : []),
-    [properties, selectedPart],
+    () =>
+      selectedPart
+        ? properties.filter((p) => p.partId === selectedPart.id)
+        : [],
+    [properties, selectedPart]
   );
 
   const currentProperty = useMemo(() => {
@@ -67,15 +80,19 @@ export default function PartPropertyMenuSingle({
   }, [currentProperty]);
 
   /** プロパティを部分更新する（差分のみ送信） */
-  const handleUpdateProperty = (property: Partial<PartPropertyUpdate>): void => {
+  const handleUpdateProperty = (
+    property: Partial<PartPropertyUpdate>
+  ): void => {
     if (!selectedPart || !currentProperty) return;
-    const updatedProperty: PartPropertyWithImage = (
-      { ...currentProperty, ...property } as PartPropertyWithImage
-    );
-    if (JSON.stringify(currentProperty) === JSON.stringify(updatedProperty)) return;
+    const updatedProperty: PartPropertyWithImage = {
+      ...currentProperty,
+      ...property,
+    } as PartPropertyWithImage;
+    if (JSON.stringify(currentProperty) === JSON.stringify(updatedProperty))
+      return;
     // API は imageId のみ受け付けるため image は除外（イミュータブルに除外）
     const { image: imageToDrop, ...updateProperty } =
-      (updatedProperty as PartPropertyUpdate & { image?: unknown });
+      updatedProperty as PartPropertyUpdate & { image?: unknown };
     void imageToDrop;
     dispatch({
       type: 'UPDATE_PART',
@@ -90,7 +107,13 @@ export default function PartPropertyMenuSingle({
   };
 
   const handleFileClearClick = async () => {
-    if (!uploadedImage?.id || !currentProperty?.side || !selectedPart?.id || !currentProperty?.imageId) return;
+    if (
+      !uploadedImage?.id ||
+      !currentProperty?.side ||
+      !selectedPart?.id ||
+      !currentProperty?.imageId
+    )
+      return;
 
     onDeleteImage({
       imageId: uploadedImage.id,
@@ -101,7 +124,9 @@ export default function PartPropertyMenuSingle({
     });
   };
 
-  const handleImageUpload = async (event: React.ChangeEvent<HTMLInputElement>) => {
+  const handleImageUpload = async (
+    event: React.ChangeEvent<HTMLInputElement>
+  ) => {
     const image = event.target?.files ? event.target.files[0] : null;
     if (!image) return;
 
@@ -119,7 +144,10 @@ export default function PartPropertyMenuSingle({
       const response = await uploadImage(formData);
       if (response.id) {
         await saveImageToIndexedDb(response.id, image);
-        setUploadedImage({ id: response.id, displayName: response.displayName });
+        setUploadedImage({
+          id: response.id,
+          displayName: response.displayName,
+        });
         handleUpdateProperty({ imageId: response.id });
       }
     } catch (error) {
@@ -142,7 +170,10 @@ export default function PartPropertyMenuSingle({
   }
 
   return (
-    <div className="flex flex-col gap-2" style={{ display: hidden ? 'none' : 'flex' }}>
+    <div
+      className="flex flex-col gap-2"
+      style={{ display: hidden ? 'none' : 'flex' }}
+    >
       {!isPlayMode && (
         <div className="flex items-center justify-around px-2 pb-2">
           <PartPropertyMenuButton
@@ -165,7 +196,9 @@ export default function PartPropertyMenuSingle({
         <div className="flex items-center justify-center mb-2">
           <span
             className={`text-xs font-medium px-3 py-1 rounded-full ${
-              selectedPart.frontSide === 'front' ? 'text-green-800 bg-green-200' : 'text-red-800 bg-red-200'
+              selectedPart.frontSide === 'front'
+                ? 'text-green-800 bg-green-200'
+                : 'text-red-800 bg-red-200'
             }`}
           >
             {selectedPart.frontSide === 'front' ? '表面の設定' : '裏面の設定'}
@@ -183,7 +216,9 @@ export default function PartPropertyMenuSingle({
                 type: 'UPDATE_PART',
                 payload: {
                   partId: selectedPart.id,
-                  updatePart: { position: { x: number, y: selectedPart.position.y } },
+                  updatePart: {
+                    position: { x: number, y: selectedPart.position.y },
+                  },
                 },
               });
             }}
@@ -197,7 +232,9 @@ export default function PartPropertyMenuSingle({
                 type: 'UPDATE_PART',
                 payload: {
                   partId: selectedPart.id,
-                  updatePart: { position: { x: selectedPart.position.x, y: number } },
+                  updatePart: {
+                    position: { x: selectedPart.position.x, y: number },
+                  },
                 },
               });
             }}
@@ -214,7 +251,10 @@ export default function PartPropertyMenuSingle({
                 onChange={(number) => {
                   dispatch({
                     type: 'UPDATE_PART',
-                    payload: { partId: selectedPart.id, updatePart: { width: number } },
+                    payload: {
+                      partId: selectedPart.id,
+                      updatePart: { width: number },
+                    },
                   });
                 }}
                 icon={<>W</>}
@@ -225,7 +265,10 @@ export default function PartPropertyMenuSingle({
                 onChange={(number) => {
                   dispatch({
                     type: 'UPDATE_PART',
-                    payload: { partId: selectedPart.id, updatePart: { height: number } },
+                    payload: {
+                      partId: selectedPart.id,
+                      updatePart: { height: number },
+                    },
                   });
                 }}
                 icon={<>H</>}
@@ -245,7 +288,9 @@ export default function PartPropertyMenuSingle({
               <TextInput
                 key={`${selectedPart.id}-description-${currentProperty?.description}`}
                 value={currentProperty?.description ?? ''}
-                onChange={(description) => handleUpdateProperty({ description })}
+                onChange={(description) =>
+                  handleUpdateProperty({ description })
+                }
                 icon={<>T</>}
                 multiline
                 resizable
@@ -294,7 +339,10 @@ export default function PartPropertyMenuSingle({
               <div className="flex items-center w-full px-2 mb-2 gap-2">
                 {uploadedImage ? (
                   <>
-                    <span className="text-xs truncate w-1/2" title={uploadedImage.displayName}>
+                    <span
+                      className="text-xs truncate w-1/2"
+                      title={uploadedImage.displayName}
+                    >
                       {uploadedImage.displayName}
                     </span>
                     <button
@@ -308,7 +356,13 @@ export default function PartPropertyMenuSingle({
                 ) : (
                   <PartPropertyMenuButton
                     text="アップロード"
-                    icon={isUploading ? <FaSpinner className="h-3 w-3 animate-spin" /> : <FaImage className="h-3 w-3" />}
+                    icon={
+                      isUploading ? (
+                        <FaSpinner className="h-3 w-3 animate-spin" />
+                      ) : (
+                        <FaImage className="h-3 w-3" />
+                      )
+                    }
                     onClick={handleFileUploadClick}
                     disabled={isUploading}
                   />

--- a/frontend/src/features/prototype/components/molecules/PlaySidebar.tsx
+++ b/frontend/src/features/prototype/components/molecules/PlaySidebar.tsx
@@ -118,7 +118,11 @@ export default function PlaySidebar({
       {/* ヘッダー */}
       <div className="border-b border-kibako-tertiary/60 rounded-t-lg bg-gradient-to-r from-kibako-secondary/30 to-kibako-secondary/20 py-2 px-4">
         <div className="flex items-center">
-          <PartTypeIcon type="hand" className="h-4 w-4 text-kibako-primary mr-2" ariaHidden />
+          <PartTypeIcon
+            type="hand"
+            className="h-4 w-4 text-kibako-primary mr-2"
+            ariaHidden
+          />
           <span className="text-[12px] font-medium text-kibako-primary">
             プレイルーム設定
           </span>
@@ -155,7 +159,9 @@ export default function PlaySidebar({
                     >
                       <span
                         className="inline-block w-2 h-2"
-                        style={{ backgroundColor: hand.ownerColor || undefined }}
+                        style={{
+                          backgroundColor: hand.ownerColor || undefined,
+                        }}
                       />
                       {hand.ownerName}の手札
                     </span>
@@ -177,11 +183,15 @@ export default function PlaySidebar({
                   {selectedHand.ownerName ? (
                     <span
                       className="inline-flex items-center gap-1 px-1 rounded border"
-                      style={{ borderColor: selectedHand.ownerColor || undefined }}
+                      style={{
+                        borderColor: selectedHand.ownerColor || undefined,
+                      }}
                     >
                       <span
                         className="inline-block w-2 h-2"
-                        style={{ backgroundColor: selectedHand.ownerColor || undefined }}
+                        style={{
+                          backgroundColor: selectedHand.ownerColor || undefined,
+                        }}
                       />
                       {selectedHand.ownerName}
                     </span>

--- a/frontend/src/features/prototype/components/molecules/ProjectCard.tsx
+++ b/frontend/src/features/prototype/components/molecules/ProjectCard.tsx
@@ -115,7 +115,7 @@ export const ProjectCard: React.FC<ProjectCardProps> = ({
           )}
         </div>
         {/* 詳細情報 */}
-        <div className="flex justify-end">
+        <div className="flex justify-end mt-2">
           <div className="text-right text-xs text-kibako-secondary">
             <div>
               作成者:{' '}

--- a/frontend/src/features/prototype/components/molecules/ProjectCardList.tsx
+++ b/frontend/src/features/prototype/components/molecules/ProjectCardList.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+
+import { Prototype, Project } from '@/api/types';
+import { ProjectCard } from '@/features/prototype/components/molecules/ProjectCard';
+
+type ProjectCardListProps = {
+  prototypeList: { project: Project; masterPrototype: Prototype }[];
+  // 編集状態と値
+  isNameEditing: (prototypeId: string) => boolean;
+  editedName: string;
+  setEditedName: (value: string) => void;
+  // イベントハンドラー
+  onCardClick: (projectId: string, prototypeId: string) => void;
+  onContextMenu: (
+    e: React.MouseEvent,
+    project: Project,
+    masterPrototype: Prototype
+  ) => void;
+  onSubmit: (e: React.FormEvent<HTMLFormElement>) => void;
+  onBlur: () => Promise<void>;
+  onKeyDown: (e: React.KeyboardEvent<HTMLInputElement>) => Promise<void>;
+};
+
+export const ProjectCardList: React.FC<ProjectCardListProps> = ({
+  prototypeList,
+  isNameEditing,
+  editedName,
+  setEditedName,
+  onCardClick,
+  onContextMenu,
+  onSubmit,
+  onBlur,
+  onKeyDown,
+}) => {
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8 mb-8">
+      {prototypeList.map(({ masterPrototype, project }) => {
+        if (!masterPrototype) return null;
+        const { id } = masterPrototype;
+        const nameEditing = isNameEditing(id);
+
+        const handleCardClick = () => onCardClick(project.id, id);
+
+        return (
+          <ProjectCard
+            key={id}
+            project={project}
+            masterPrototype={masterPrototype}
+            isNameEditing={nameEditing}
+            editedName={editedName}
+            setEditedName={setEditedName}
+            onCardClick={handleCardClick}
+            onContextMenu={onContextMenu}
+            onSubmit={onSubmit}
+            onBlur={onBlur}
+            onKeyDown={onKeyDown}
+          />
+        );
+      })}
+    </div>
+  );
+};
+
+export default ProjectCardList;

--- a/frontend/src/features/prototype/components/molecules/ProjectTable.tsx
+++ b/frontend/src/features/prototype/components/molecules/ProjectTable.tsx
@@ -1,7 +1,17 @@
-import React from 'react';
-import { FaSort, FaSortDown, FaSortUp } from 'react-icons/fa';
+import Link from 'next/link';
+import React, { useContext, useState } from 'react';
+import {
+  FaFolderOpen,
+  FaSort,
+  FaSortDown,
+  FaSortUp,
+  FaTrash,
+  FaUsers,
+} from 'react-icons/fa';
 
 import { Prototype, Project } from '@/api/types';
+import { UserContext } from '@/contexts/UserContext';
+import PrototypeNameEditor from '@/features/prototype/components/atoms/PrototypeNameEditor';
 import formatDate from '@/utils/dateFormat';
 
 export type ProjectTableSortKey = 'name' | 'createdAt';
@@ -21,45 +31,129 @@ export const ProjectTable: React.FC<ProjectTableProps> = ({
   onSort,
   onRowClick,
 }) => {
+  // 即時反映用: 名前更新が完了した行の一時表示名
+  const [updatedNames, setUpdatedNames] = useState<Record<string, string>>({});
+  const userContext = useContext(UserContext);
+
   const renderSortIcon = (key: ProjectTableSortKey) => {
-    if (sortKey !== key) return <FaSort className="inline" />;
+    const base = 'inline align-middle text-sm';
+    if (sortKey !== key)
+      return <FaSort className={base + ' text-kibako-secondary'} />;
     return sortOrder === 'asc' ? (
-      <FaSortUp className="inline" />
+      <FaSortUp className={base + ' text-kibako-accent'} />
     ) : (
-      <FaSortDown className="inline" />
+      <FaSortDown className={base + ' text-kibako-accent'} />
     );
   };
 
   return (
-    <table className="w-full table-auto border-collapse mb-8">
-      <thead>
-        <tr className="bg-kibako-tertiary/10 text-left">
-          <th className="p-2 cursor-pointer" onClick={() => onSort('name')}>
-            プロジェクト名 {renderSortIcon('name')}
-          </th>
-          <th
-            className="p-2 cursor-pointer"
-            onClick={() => onSort('createdAt')}
-          >
-            作成日時 {renderSortIcon('createdAt')}
-          </th>
-        </tr>
-      </thead>
-      <tbody>
-        {prototypeList.map(({ project, masterPrototype }) => (
-          <tr
-            key={project.id}
-            className="border-b hover:bg-kibako-tertiary/5 cursor-pointer"
-            onClick={() => onRowClick(project.id, masterPrototype.id)}
-          >
-            <td className="p-2">{masterPrototype.name}</td>
-            <td className="p-2">
-              {formatDate(masterPrototype.createdAt, true)}
-            </td>
-          </tr>
-        ))}
-      </tbody>
-    </table>
+    <div className="mb-8 overflow-hidden rounded-xl border border-kibako-secondary/30 bg-kibako-white shadow-sm">
+      <div className="overflow-x-auto">
+        <table className="min-w-full table-auto border-collapse text-left text-sm">
+          <thead className="sticky top-0 z-sticky bg-kibako-primary text-kibako-white">
+            <tr>
+              <th className="px-4 py-3 w-[50%]">
+                <button
+                  type="button"
+                  onClick={() => onSort('name')}
+                  className="group inline-flex select-none items-center gap-2 font-semibold text-kibako-white hover:text-kibako-tertiary focus:outline-none focus:ring-2 focus:ring-kibako-accent/60 focus:ring-offset-2 focus:ring-offset-kibako-primary"
+                >
+                  <span className="inline-flex items-center gap-2">
+                    <FaFolderOpen className="text-base opacity-90" />
+                    <span>プロジェクト名</span>
+                  </span>
+                  {renderSortIcon('name')}
+                </button>
+              </th>
+              <th className="px-4 py-3 w-[120px]">作成者</th>
+              <th className="px-4 py-3 w-[200px]">
+                <button
+                  type="button"
+                  onClick={() => onSort('createdAt')}
+                  className="group inline-flex select-none items-center gap-2 font-semibold text-kibako-white hover:text-kibako-tertiary focus:outline-none focus:ring-2 focus:ring-kibako-accent/60 focus:ring-offset-2 focus:ring-offset-kibako-primary"
+                >
+                  <span>作成日時</span>
+                  {renderSortIcon('createdAt')}
+                </button>
+              </th>
+              <th className="px-4 py-3 text-right w-[120px]">操作</th>
+            </tr>
+          </thead>
+          <tbody>
+            {prototypeList.map(({ project, masterPrototype }) => (
+              <tr
+                key={project.id}
+                className="odd:bg-kibako-white even:bg-kibako-tertiary/40 border-b border-kibako-secondary/20 text-kibako-primary transition-colors hover:bg-kibako-accent/5"
+              >
+                <td className="px-4 py-3 align-middle">
+                  <div className="flex min-w-0 items-center gap-3">
+                    <div className="h-2 w-2 shrink-0 rounded-full bg-kibako-accent/70 ring-2 ring-kibako-accent/30" />
+                    <div className="min-w-0 flex-1">
+                      <div className="font-medium min-w-0">
+                        <PrototypeNameEditor
+                          prototypeId={masterPrototype.id}
+                          name={
+                            updatedNames[masterPrototype.id] ??
+                            masterPrototype.name
+                          }
+                          onUpdated={(newName) =>
+                            setUpdatedNames((prev) => ({
+                              ...prev,
+                              [masterPrototype.id]: newName,
+                            }))
+                          }
+                        />
+                      </div>
+                    </div>
+                  </div>
+                </td>
+                <td className="px-4 py-3 align-middle">
+                  <span className="text-xs text-kibako-primary">
+                    {userContext?.user?.id === project.userId
+                      ? '自分'
+                      : '他のユーザー'}
+                  </span>
+                </td>
+                <td className="px-4 py-3 align-middle">
+                  <span className="rounded-md bg-kibako-tertiary/60 px-2 py-1 text-xs text-kibako-primary ring-1 ring-inset ring-kibako-secondary/30 whitespace-nowrap">
+                    {formatDate(masterPrototype.createdAt, true)}
+                  </span>
+                </td>
+                <td className="px-4 py-3 align-middle">
+                  <div className="flex items-center justify-end gap-2">
+                    <button
+                      type="button"
+                      aria-label="開く"
+                      title="開く"
+                      onClick={() => onRowClick(project.id, masterPrototype.id)}
+                      className="inline-flex items-center justify-center rounded-md border border-kibako-secondary/30 bg-white px-2 py-1 text-kibako-primary shadow-sm hover:bg-kibako-tertiary/60 hover:text-kibako-primary focus:outline-none"
+                    >
+                      <FaFolderOpen className="h-4 w-4" />
+                    </button>
+                    <Link
+                      href={`/projects/${project.id}/roles`}
+                      aria-label="権限設定"
+                      title="権限設定"
+                      className="inline-flex items-center justify-center rounded-md border border-kibako-secondary/30 bg-white px-2 py-1 text-kibako-primary shadow-sm hover:bg-kibako-tertiary/60 hover:text-kibako-primary focus:outline-none"
+                    >
+                      <FaUsers className="h-4 w-4" />
+                    </Link>
+                    <Link
+                      href={`/projects/${project.id}/delete`}
+                      aria-label="削除"
+                      title="削除"
+                      className="inline-flex items-center justify-center rounded-md border border-kibako-secondary/30 bg-white px-2 py-1 text-kibako-primary shadow-sm hover:bg-red-50 hover:text-red-600 focus:outline-none"
+                    >
+                      <FaTrash className="h-4 w-4" />
+                    </Link>
+                  </div>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
   );
 };
 

--- a/frontend/src/features/prototype/components/molecules/ProjectTable.tsx
+++ b/frontend/src/features/prototype/components/molecules/ProjectTable.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { FaSort, FaSortDown, FaSortUp } from 'react-icons/fa';
+
+import { Prototype, Project } from '@/api/types';
+import formatDate from '@/utils/dateFormat';
+
+export type ProjectTableSortKey = 'name' | 'createdAt';
+
+type ProjectTableProps = {
+  prototypeList: { project: Project; masterPrototype: Prototype }[];
+  sortKey: ProjectTableSortKey;
+  sortOrder: 'asc' | 'desc';
+  onSort: (key: ProjectTableSortKey) => void;
+  onRowClick: (projectId: string, prototypeId: string) => void;
+};
+
+export const ProjectTable: React.FC<ProjectTableProps> = ({
+  prototypeList,
+  sortKey,
+  sortOrder,
+  onSort,
+  onRowClick,
+}) => {
+  const renderSortIcon = (key: ProjectTableSortKey) => {
+    if (sortKey !== key) return <FaSort className="inline" />;
+    return sortOrder === 'asc' ? (
+      <FaSortUp className="inline" />
+    ) : (
+      <FaSortDown className="inline" />
+    );
+  };
+
+  return (
+    <table className="w-full table-auto border-collapse mb-8">
+      <thead>
+        <tr className="bg-kibako-tertiary/10 text-left">
+          <th className="p-2 cursor-pointer" onClick={() => onSort('name')}>
+            プロジェクト名 {renderSortIcon('name')}
+          </th>
+          <th
+            className="p-2 cursor-pointer"
+            onClick={() => onSort('createdAt')}
+          >
+            作成日時 {renderSortIcon('createdAt')}
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        {prototypeList.map(({ project, masterPrototype }) => (
+          <tr
+            key={project.id}
+            className="border-b hover:bg-kibako-tertiary/5 cursor-pointer"
+            onClick={() => onRowClick(project.id, masterPrototype.id)}
+          >
+            <td className="p-2">{masterPrototype.name}</td>
+            <td className="p-2">
+              {formatDate(masterPrototype.createdAt, true)}
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+};
+
+export default ProjectTable;

--- a/frontend/src/features/prototype/components/molecules/RightTopMenu.tsx
+++ b/frontend/src/features/prototype/components/molecules/RightTopMenu.tsx
@@ -48,7 +48,9 @@ export default function RightTopMenu({
   const activeUserIds = new Set(connectedUsers.map((u) => u.userId));
 
   return (
-    <div className={`fixed top-4 right-4 z-overlay flex flex-row items-center gap-2 h-[56px] bg-kibako-white p-2 rounded-lg`}>
+    <div
+      className={`fixed top-4 right-4 z-overlay flex flex-row items-center gap-2 h-[56px] bg-kibako-white p-2 rounded-lg`}
+    >
       {/* ユーザーアイコンリスト（左側・ホバーで全ユーザー名表示） */}
       {!loading && connectedUsers && connectedUsers.length > 0 && (
         <div className="relative group">

--- a/frontend/src/features/prototype/components/organisms/GameBoard.tsx
+++ b/frontend/src/features/prototype/components/organisms/GameBoard.tsx
@@ -436,12 +436,18 @@ export default function GameBoard({
           }
           try {
             const s3ImageBlob = await fetchImage(imageId);
-            const imageResult = await saveImageToIndexedDb(imageId, s3ImageBlob);
+            const imageResult = await saveImageToIndexedDb(
+              imageId,
+              s3ImageBlob
+            );
             if (imageResult) {
               return { imageId, url: imageResult.objectURL };
             }
           } catch (error) {
-            console.warn(`Image with ID ${imageId} could not be loaded.`, error);
+            console.warn(
+              `Image with ID ${imageId} could not be loaded.`,
+              error
+            );
           }
           return null;
         })
@@ -497,121 +503,120 @@ export default function GameBoard({
 
   return (
     <DebugModeProvider>
-      
       {/* Provide overlay messages for parts (e.g., shuffle text like deck) */}
       <PartOverlayMessageProvider>
-      <ModeToggleButton
-        isSelectionMode={isSelectionMode}
-        onToggle={toggleMode}
-      />
-      <GameBoardCanvas
-        stageRef={stageRef}
-        viewportSize={viewportSize}
-        canvasSize={canvasSize}
-        camera={camera}
-        gameBoardMode={gameBoardMode}
-        isSelectionMode={isSelectionMode}
-        cursorStyle={cursorStyle}
-        grabbingHandlers={grabbingHandlers}
-        handleWheel={handleWheel}
-        handleStageClick={handleStageClick}
-        handleCloseContextMenu={handleCloseContextMenu}
-        handleSelectionMove={handleSelectionMove}
-        handleSelectionEnd={handleSelectionEnd}
-        handleDragMove={handleDragMove}
-        handleSelectionStart={handleSelectionStart}
-        handleBackgroundClick={handleBackgroundClick}
-        parts={parts}
-        propertiesMap={propertiesMap}
-        images={images}
-        selectedPartIds={selectedPartIds}
-        selectedUsersByPart={selectedUsersByPart}
-        cardVisibilityMap={cardVisibilityMap}
-        selfUser={selfUser}
-        userRoles={userRoles}
-        handlePartClick={handlePartClick}
-        handlePartDragStart={handlePartDragStart}
-        handlePartDragMove={handlePartDragMove}
-        handlePartDragEnd={handlePartDragEnd}
-        handlePartContextMenu={handlePartContextMenu}
-        rectForSelection={rectForSelection}
-      />
-
-      <LeftSidebar
-        prototypeName={prototypeName}
-        prototypeId={prototypeId}
-        gameBoardMode={gameBoardMode}
-        projectId={projectId}
-        onPrototypeNameChange={setPrototypeName}
-      />
-
-      {/* ロールメニュー - CREATEモードとPLAYモードで表示 */}
-      {(gameBoardMode === GameBoardMode.CREATE ||
-        gameBoardMode === GameBoardMode.PLAY) && (
-        <RightTopMenu
-          projectId={projectId}
-          connectedUsers={connectedUsers}
-          roleUsers={roleUsers}
-          loading={false}
-          showRoleManagementButton={gameBoardMode === GameBoardMode.CREATE}
+        <ModeToggleButton
+          isSelectionMode={isSelectionMode}
+          onToggle={toggleMode}
         />
-      )}
-
-      {gameBoardMode === GameBoardMode.CREATE && (
-        <PartCreateMenu
-          onAddPart={handleAddPart}
-          camera={camera}
+        <GameBoardCanvas
+          stageRef={stageRef}
           viewportSize={viewportSize}
-          parts={parts} // 追加
-        />
-      )}
-
-      <PartPropertyMenu
-        selectedPartIds={selectedPartIds}
-        parts={parts}
-        properties={properties}
-        onDuplicatePart={handleDuplicatePart}
-        onDeletePart={handleDeleteParts}
-        onDeleteImage={handleDeleteImage}
-        gameBoardMode={gameBoardMode}
-      />
-
-      {/* プレイルーム時のサイドバー */}
-      {gameBoardMode === GameBoardMode.PLAY && (
-        <PlaySidebar
+          canvasSize={canvasSize}
+          camera={camera}
+          gameBoardMode={gameBoardMode}
+          isSelectionMode={isSelectionMode}
+          cursorStyle={cursorStyle}
+          grabbingHandlers={grabbingHandlers}
+          handleWheel={handleWheel}
+          handleStageClick={handleStageClick}
+          handleCloseContextMenu={handleCloseContextMenu}
+          handleSelectionMove={handleSelectionMove}
+          handleSelectionEnd={handleSelectionEnd}
+          handleDragMove={handleDragMove}
+          handleSelectionStart={handleSelectionStart}
+          handleBackgroundClick={handleBackgroundClick}
           parts={parts}
-          onSelectPart={(partId) => selectPart(partId)}
-          selectedPartId={
-            selectedPartIds.length === 1 ? selectedPartIds[0] : null
-          }
+          propertiesMap={propertiesMap}
+          images={images}
+          selectedPartIds={selectedPartIds}
+          selectedUsersByPart={selectedUsersByPart}
+          cardVisibilityMap={cardVisibilityMap}
+          selfUser={selfUser}
           userRoles={userRoles}
+          handlePartClick={handlePartClick}
+          handlePartDragStart={handlePartDragStart}
+          handlePartDragMove={handlePartDragMove}
+          handlePartDragEnd={handlePartDragEnd}
+          handlePartContextMenu={handlePartContextMenu}
+          rectForSelection={rectForSelection}
         />
-      )}
 
-      <ZoomToolbar
-        zoomIn={handleZoomIn}
-        zoomOut={handleZoomOut}
-        canZoomIn={canZoomIn}
-        canZoomOut={canZoomOut}
-        zoomLevel={camera.scale}
-      />
+        <LeftSidebar
+          prototypeName={prototypeName}
+          prototypeId={prototypeId}
+          gameBoardMode={gameBoardMode}
+          projectId={projectId}
+          onPrototypeNameChange={setPrototypeName}
+        />
 
-      <DebugInfo
-        camera={camera}
-        prototypeName={prototypeName}
-        projectId={projectId}
-        mode={gameBoardMode}
-        parts={parts}
-        properties={properties}
-      />
+        {/* ロールメニュー - CREATEモードとPLAYモードで表示 */}
+        {(gameBoardMode === GameBoardMode.CREATE ||
+          gameBoardMode === GameBoardMode.PLAY) && (
+          <RightTopMenu
+            projectId={projectId}
+            connectedUsers={connectedUsers}
+            roleUsers={roleUsers}
+            loading={false}
+            showRoleManagementButton={gameBoardMode === GameBoardMode.CREATE}
+          />
+        )}
 
-      {/* コンテキストメニュー */}
-      <ProjectContextMenu
-        visible={showContextMenu && contextMenuPartId !== null}
-        position={menuPosition}
-        onClose={handleCloseContextMenu}
-        items={getContextMenuItems(contextMenuPartId!)}
-      />
+        {gameBoardMode === GameBoardMode.CREATE && (
+          <PartCreateMenu
+            onAddPart={handleAddPart}
+            camera={camera}
+            viewportSize={viewportSize}
+            parts={parts} // 追加
+          />
+        )}
+
+        <PartPropertyMenu
+          selectedPartIds={selectedPartIds}
+          parts={parts}
+          properties={properties}
+          onDuplicatePart={handleDuplicatePart}
+          onDeletePart={handleDeleteParts}
+          onDeleteImage={handleDeleteImage}
+          gameBoardMode={gameBoardMode}
+        />
+
+        {/* プレイルーム時のサイドバー */}
+        {gameBoardMode === GameBoardMode.PLAY && (
+          <PlaySidebar
+            parts={parts}
+            onSelectPart={(partId) => selectPart(partId)}
+            selectedPartId={
+              selectedPartIds.length === 1 ? selectedPartIds[0] : null
+            }
+            userRoles={userRoles}
+          />
+        )}
+
+        <ZoomToolbar
+          zoomIn={handleZoomIn}
+          zoomOut={handleZoomOut}
+          canZoomIn={canZoomIn}
+          canZoomOut={canZoomOut}
+          zoomLevel={camera.scale}
+        />
+
+        <DebugInfo
+          camera={camera}
+          prototypeName={prototypeName}
+          projectId={projectId}
+          mode={gameBoardMode}
+          parts={parts}
+          properties={properties}
+        />
+
+        {/* コンテキストメニュー */}
+        <ProjectContextMenu
+          visible={showContextMenu && contextMenuPartId !== null}
+          position={menuPosition}
+          onClose={handleCloseContextMenu}
+          items={getContextMenuItems(contextMenuPartId!)}
+        />
       </PartOverlayMessageProvider>
     </DebugModeProvider>
   );

--- a/frontend/src/features/prototype/components/organisms/GameBoardCanvas.tsx
+++ b/frontend/src/features/prototype/components/organisms/GameBoardCanvas.tsx
@@ -29,9 +29,7 @@ interface GameBoardCanvasProps {
     onMouseDown?: (
       e: Konva.KonvaEventObject<MouseEvent | PointerEvent>
     ) => void;
-    onMouseUp?: (
-      e: Konva.KonvaEventObject<MouseEvent | PointerEvent>
-    ) => void;
+    onMouseUp?: (e: Konva.KonvaEventObject<MouseEvent | PointerEvent>) => void;
     onMouseLeave?: (
       e: Konva.KonvaEventObject<MouseEvent | PointerEvent>
     ) => void;
@@ -139,15 +137,18 @@ export default function GameBoardCanvas({
     const map: Record<number, Record<string, string>[]> = {};
     parts.forEach((part) => {
       const partProperties = propertiesMap.get(part.id) || [];
-      map[part.id] = partProperties.reduce<Record<string, string>[]>((acc, p) => {
-        const imageId = p.imageId;
-        if (!imageId) return acc;
-        const url = images[imageId];
-        if (url) {
-          acc.push({ [imageId]: url });
-        }
-        return acc;
-      }, []);
+      map[part.id] = partProperties.reduce<Record<string, string>[]>(
+        (acc, p) => {
+          const imageId = p.imageId;
+          if (!imageId) return acc;
+          const url = images[imageId];
+          if (url) {
+            acc.push({ [imageId]: url });
+          }
+          return acc;
+        },
+        []
+      );
     });
     return map;
   }, [parts, propertiesMap, images]);

--- a/frontend/src/features/prototype/components/organisms/ProjectList.tsx
+++ b/frontend/src/features/prototype/components/organisms/ProjectList.tsx
@@ -395,7 +395,10 @@ const ProjectList: React.FC = () => {
 
       {viewMode === 'card' ? (
         <ProjectCardList
-          prototypeList={prototypeList}
+          prototypeList={prototypeList.filter(
+            (item): item is { project: Project; masterPrototype: Prototype } =>
+              !!item.masterPrototype
+          )}
           isNameEditing={(prototypeId) => isEditing(prototypeId)}
           editedName={editedName}
           setEditedName={setEditedName}

--- a/frontend/src/features/prototype/components/organisms/ProjectList.tsx
+++ b/frontend/src/features/prototype/components/organisms/ProjectList.tsx
@@ -15,7 +15,7 @@ import KibakoToggle from '@/components/atoms/KibakoToggle';
 import Loading from '@/components/organisms/Loading';
 import { ProjectContextMenu } from '@/features/prototype/components/atoms/ProjectContextMenu';
 import { EmptyProjectState } from '@/features/prototype/components/molecules/EmptyProjectState';
-import { ProjectCard } from '@/features/prototype/components/molecules/ProjectCard';
+import { ProjectCardList } from '@/features/prototype/components/molecules/ProjectCardList';
 import { ProjectTable } from '@/features/prototype/components/molecules/ProjectTable';
 import useInlineEdit from '@/hooks/useInlineEdit';
 import { deleteExpiredImagesFromIndexedDb } from '@/utils/db';
@@ -394,51 +394,25 @@ const ProjectList: React.FC = () => {
       </div>
 
       {viewMode === 'card' ? (
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8 mb-8">
-          {prototypeList.map(({ masterPrototype, project }) => {
-            if (!masterPrototype) return null;
-            const { id } = masterPrototype;
-            const isNameEditing = isEditing(id);
-
-            /**
-             * カードクリック時の処理
-             */
-            const handleCardClick = () => {
-              router.push(`/projects/${project.id}/prototypes/${id}`);
-            };
-
-            /**
-             * ProjectCard用のイベントハンドラー
-             */
-            const handleProjectCardSubmit = (
-              e: React.FormEvent<HTMLFormElement>
-            ) => handleSubmit(e, handleNameEditComplete, validatePrototypeName);
-
-            const handleProjectCardBlur = () =>
-              handleBlur(handleNameEditComplete, validatePrototypeName);
-
-            const handleProjectCardKeyDown = (
-              e: React.KeyboardEvent<HTMLInputElement>
-            ) =>
-              handleKeyDown(e, handleNameEditComplete, validatePrototypeName);
-
-            return (
-              <ProjectCard
-                key={id}
-                project={project}
-                masterPrototype={masterPrototype}
-                isNameEditing={isNameEditing}
-                editedName={editedName}
-                setEditedName={setEditedName}
-                onCardClick={handleCardClick}
-                onContextMenu={handleContextMenu}
-                onSubmit={handleProjectCardSubmit}
-                onBlur={handleProjectCardBlur}
-                onKeyDown={handleProjectCardKeyDown}
-              />
-            );
-          })}
-        </div>
+        <ProjectCardList
+          prototypeList={prototypeList}
+          isNameEditing={(prototypeId) => isEditing(prototypeId)}
+          editedName={editedName}
+          setEditedName={setEditedName}
+          onCardClick={(projectId, prototypeId) =>
+            router.push(`/projects/${projectId}/prototypes/${prototypeId}`)
+          }
+          onContextMenu={handleContextMenu}
+          onSubmit={(e) =>
+            handleSubmit(e, handleNameEditComplete, validatePrototypeName)
+          }
+          onBlur={() =>
+            handleBlur(handleNameEditComplete, validatePrototypeName)
+          }
+          onKeyDown={(e) =>
+            handleKeyDown(e, handleNameEditComplete, validatePrototypeName)
+          }
+        />
       ) : (
         <ProjectTable
           prototypeList={sortedPrototypeList}

--- a/frontend/src/features/prototype/components/organisms/ProjectList.tsx
+++ b/frontend/src/features/prototype/components/organisms/ProjectList.tsx
@@ -92,17 +92,21 @@ const ProjectList: React.FC = () => {
             !!item.masterPrototype
         )
         .sort((a, b) => {
-          const valueA =
-            sortKey === 'name'
-              ? a.masterPrototype.name
-              : a.masterPrototype.createdAt;
-          const valueB =
-            sortKey === 'name'
-              ? b.masterPrototype.name
-              : b.masterPrototype.createdAt;
-          if (valueA < valueB) return sortOrder === 'asc' ? -1 : 1;
-          if (valueA > valueB) return sortOrder === 'asc' ? 1 : -1;
-          return 0;
+          if (sortKey === 'name') {
+            const nameA = a.masterPrototype.name ?? '';
+            const nameB = b.masterPrototype.name ?? '';
+            return sortOrder === 'asc'
+              ? nameA.localeCompare(nameB, 'ja')
+              : nameB.localeCompare(nameA, 'ja');
+          } else {
+            const tA = a.masterPrototype.createdAt
+              ? new Date(a.masterPrototype.createdAt).getTime()
+              : 0;
+            const tB = b.masterPrototype.createdAt
+              ? new Date(b.masterPrototype.createdAt).getTime()
+              : 0;
+            return sortOrder === 'asc' ? tA - tB : tB - tA;
+          }
         }),
     [prototypeList, sortKey, sortOrder]
   );

--- a/frontend/src/features/prototype/contexts/PartOverlayMessageContext.tsx
+++ b/frontend/src/features/prototype/contexts/PartOverlayMessageContext.tsx
@@ -77,7 +77,7 @@ export const usePartOverlayMessage = (): PartOverlayMessageContextType => {
   const ctx = useContext(PartOverlayMessageContext);
   if (!ctx)
     throw new Error(
-      'usePartOverlayMessage must be used within PartOverlayMessageProvider'
+      'usePartOverlayMessage は PartOverlayMessageProvider の内部でのみ使用できます'
     );
   return ctx;
 };

--- a/frontend/src/features/prototype/contexts/PartOverlayMessageContext.tsx
+++ b/frontend/src/features/prototype/contexts/PartOverlayMessageContext.tsx
@@ -1,4 +1,11 @@
-import React, { createContext, useCallback, useContext, useMemo, useRef, useState } from 'react';
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 
 type PartOverlayMessageMap = Map<number, string | null>;
 
@@ -10,11 +17,17 @@ type PartOverlayMessageContextType = {
   runShuffleEffect: (partIds: number[]) => void;
 };
 
-const PartOverlayMessageContext = createContext<PartOverlayMessageContextType | undefined>(undefined);
+const PartOverlayMessageContext = createContext<
+  PartOverlayMessageContextType | undefined
+>(undefined);
 
-export const PartOverlayMessageProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+export const PartOverlayMessageProvider: React.FC<{
+  children: React.ReactNode;
+}> = ({ children }) => {
   const [messages, setMessages] = useState<PartOverlayMessageMap>(new Map());
-  const timersRef = useRef<Map<number, { step?: NodeJS.Timeout; hide?: NodeJS.Timeout }>>(new Map());
+  const timersRef = useRef<
+    Map<number, { step?: NodeJS.Timeout; hide?: NodeJS.Timeout }>
+  >(new Map());
 
   const setMessage = useCallback((partId: number, message: string | null) => {
     setMessages((prev) => {
@@ -24,30 +37,36 @@ export const PartOverlayMessageProvider: React.FC<{ children: React.ReactNode }>
     });
   }, []);
 
-  const clearMessage = useCallback((partId: number) => {
-    const timers = timersRef.current.get(partId);
-    if (timers?.step) clearTimeout(timers.step);
-    if (timers?.hide) clearTimeout(timers.hide);
-    timersRef.current.delete(partId);
-    setMessage(partId, null);
-  }, [setMessage]);
+  const clearMessage = useCallback(
+    (partId: number) => {
+      const timers = timersRef.current.get(partId);
+      if (timers?.step) clearTimeout(timers.step);
+      if (timers?.hide) clearTimeout(timers.hide);
+      timersRef.current.delete(partId);
+      setMessage(partId, null);
+    },
+    [setMessage]
+  );
 
-  const runShuffleEffect = useCallback((partIds: number[]) => {
-    // Only show the completion message, then hide shortly after
-    partIds.forEach((id) => setMessage(id, 'シャッフルしました'));
+  const runShuffleEffect = useCallback(
+    (partIds: number[]) => {
+      // Only show the completion message, then hide shortly after
+      partIds.forEach((id) => setMessage(id, 'シャッフルしました'));
 
-    const hideTimeout = setTimeout(() => {
-      partIds.forEach((id) => clearMessage(id));
-    }, 1000);
+      const hideTimeout = setTimeout(() => {
+        partIds.forEach((id) => clearMessage(id));
+      }, 1000);
 
-    // Track timers per id so we can clear if needed
-    partIds.forEach((id) => {
-      const current = timersRef.current.get(id) || {};
-      if (current.step) clearTimeout(current.step);
-      if (current.hide) clearTimeout(current.hide);
-      timersRef.current.set(id, { hide: hideTimeout });
-    });
-  }, [clearMessage, setMessage]);
+      // Track timers per id so we can clear if needed
+      partIds.forEach((id) => {
+        const current = timersRef.current.get(id) || {};
+        if (current.step) clearTimeout(current.step);
+        if (current.hide) clearTimeout(current.hide);
+        timersRef.current.set(id, { hide: hideTimeout });
+      });
+    },
+    [clearMessage, setMessage]
+  );
 
   const value = useMemo(
     () => ({ messages, setMessage, clearMessage, runShuffleEffect }),
@@ -63,6 +82,9 @@ export const PartOverlayMessageProvider: React.FC<{ children: React.ReactNode }>
 
 export const usePartOverlayMessage = (): PartOverlayMessageContextType => {
   const ctx = useContext(PartOverlayMessageContext);
-  if (!ctx) throw new Error('usePartOverlayMessage must be used within PartOverlayMessageProvider');
+  if (!ctx)
+    throw new Error(
+      'usePartOverlayMessage must be used within PartOverlayMessageProvider'
+    );
   return ctx;
 };

--- a/frontend/src/features/prototype/debug-info/components/molecules/DataTab.tsx
+++ b/frontend/src/features/prototype/debug-info/components/molecules/DataTab.tsx
@@ -19,7 +19,9 @@ const DataTab: React.FC<DataTabProps> = ({ parts, properties }) => {
         <div className="font-semibold">Parts: {parts.length}</div>
         {parts.length > 0 && (
           <div className="ml-2.5 text-xs space-y-1">
-            <div>Types: {[...new Set(parts.map((p) => p.type))].join(', ')}</div>
+            <div>
+              Types: {[...new Set(parts.map((p) => p.type))].join(', ')}
+            </div>
             <div>
               Front Side Cards:{' '}
               {
@@ -37,7 +39,10 @@ const DataTab: React.FC<DataTabProps> = ({ parts, properties }) => {
               {Math.max(...parts.map((p) => p.order)).toFixed(2)}
             </div>
             <div>Total Properties: {properties.length}</div>
-            <div>Properties with Images: {properties.filter((p) => p.imageId).length}</div>
+            <div>
+              Properties with Images:{' '}
+              {properties.filter((p) => p.imageId).length}
+            </div>
           </div>
         )}
       </div>
@@ -46,4 +51,3 @@ const DataTab: React.FC<DataTabProps> = ({ parts, properties }) => {
 };
 
 export default DataTab;
-

--- a/frontend/src/features/prototype/debug-info/components/molecules/InfoTab.tsx
+++ b/frontend/src/features/prototype/debug-info/components/molecules/InfoTab.tsx
@@ -55,7 +55,9 @@ const InfoTab: React.FC<InfoTabProps> = ({
       </div>
       <div className="mb-1">
         <div className="text-xs text-gray-300 mb-0.5">Center Position:</div>
-        <div>X: {Math.round(camera.x + window.innerWidth / 2 / camera.scale)}</div>
+        <div>
+          X: {Math.round(camera.x + window.innerWidth / 2 / camera.scale)}
+        </div>
         <div>
           Y: {Math.round(camera.y + window.innerHeight / 2 / camera.scale)}
         </div>
@@ -72,4 +74,3 @@ const InfoTab: React.FC<InfoTabProps> = ({
 };
 
 export default InfoTab;
-

--- a/frontend/src/features/prototype/debug-info/components/molecules/PartsTab.tsx
+++ b/frontend/src/features/prototype/debug-info/components/molecules/PartsTab.tsx
@@ -21,7 +21,8 @@ const PartsTab: React.FC<PartsTabProps> = ({ parts, properties }) => {
           {[...parts]
             .sort(
               (a, b) =>
-                new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime()
+                new Date(b.updatedAt).getTime() -
+                new Date(a.updatedAt).getTime()
             )
             .map((part) => {
               const partProperties = properties.filter(
@@ -36,8 +37,12 @@ const PartsTab: React.FC<PartsTabProps> = ({ parts, properties }) => {
                   <div className="font-bold text-blue-300">
                     ID: {part.id} | Type: {part.type}
                   </div>
-                  <div>Position: ({part.position.x}, {part.position.y})</div>
-                  <div>Size: {part.width} × {part.height}</div>
+                  <div>
+                    Position: ({part.position.x}, {part.position.y})
+                  </div>
+                  <div>
+                    Size: {part.width} × {part.height}
+                  </div>
                   <div>
                     Order:{' '}
                     {typeof part.order === 'number'
@@ -69,7 +74,9 @@ const PartsTab: React.FC<PartsTabProps> = ({ parts, properties }) => {
                           key={`${part.id}-${prop.side}-${prop.name}-${propIndex}`}
                           className="ml-2 mt-1 text-[10px] border-l border-kibako-white border-opacity-10 pl-1"
                         >
-                          <div className="text-green-300">Side: {prop.side}</div>
+                          <div className="text-green-300">
+                            Side: {prop.side}
+                          </div>
                           <div>Name: {prop.name}</div>
                           <div>Color: {prop.color}</div>
                           <div>Text Color: {prop.textColor}</div>

--- a/frontend/src/features/prototype/debug-info/components/molecules/PerfTab.tsx
+++ b/frontend/src/features/prototype/debug-info/components/molecules/PerfTab.tsx
@@ -99,4 +99,3 @@ const PerfTab: React.FC = () => {
 };
 
 export default PerfTab;
-

--- a/frontend/src/features/prototype/debug-info/components/organisms/DebugInfo.tsx
+++ b/frontend/src/features/prototype/debug-info/components/organisms/DebugInfo.tsx
@@ -18,7 +18,7 @@ const TABS = [
   { id: 'parts' as const, label: 'Parts' },
 ];
 
-type TabId = typeof TABS[number]['id'];
+type TabId = (typeof TABS)[number]['id'];
 
 interface DebugInfoProps {
   camera: {
@@ -96,4 +96,3 @@ const DebugInfo: React.FC<DebugInfoProps> = ({
 };
 
 export default DebugInfo;
-

--- a/frontend/src/features/prototype/hooks/__tests__/useCameraConstraints.test.ts
+++ b/frontend/src/features/prototype/hooks/__tests__/useCameraConstraints.test.ts
@@ -1,6 +1,9 @@
 import { renderHook } from '@testing-library/react';
 
-import { CAMERA_SCALE, GAME_BOARD_CENTER } from '@/features/prototype/constants';
+import {
+  CAMERA_SCALE,
+  GAME_BOARD_CENTER,
+} from '@/features/prototype/constants';
 import { useCameraConstraints } from '@/features/prototype/hooks/useCameraConstraints';
 
 describe('useCameraConstraints', () => {

--- a/frontend/src/features/prototype/hooks/__tests__/usePartReducer.test.ts
+++ b/frontend/src/features/prototype/hooks/__tests__/usePartReducer.test.ts
@@ -48,4 +48,3 @@ describe('usePartReducer', () => {
     expect(mockSocket.emit).toHaveBeenCalledWith('UPDATE_PARTS', { updates });
   });
 });
-

--- a/frontend/src/features/prototype/hooks/useCameraConstraints.ts
+++ b/frontend/src/features/prototype/hooks/useCameraConstraints.ts
@@ -1,4 +1,9 @@
-import { useCallback, useState, type Dispatch, type SetStateAction } from 'react';
+import {
+  useCallback,
+  useState,
+  type Dispatch,
+  type SetStateAction,
+} from 'react';
 
 import {
   CAMERA_SCALE,

--- a/frontend/src/features/prototype/hooks/useCameraHandlers.ts
+++ b/frontend/src/features/prototype/hooks/useCameraHandlers.ts
@@ -2,10 +2,7 @@ import type Konva from 'konva';
 import { useCallback } from 'react';
 
 import { CAMERA_SCALE } from '@/features/prototype/constants';
-import {
-  CameraPosition,
-  ViewportSize,
-} from '@/features/prototype/types';
+import { CameraPosition, ViewportSize } from '@/features/prototype/types';
 
 interface UseCameraHandlersProps {
   camera: CameraPosition;

--- a/frontend/src/features/prototype/hooks/usePrototypeSocket.ts
+++ b/frontend/src/features/prototype/hooks/usePrototypeSocket.ts
@@ -301,12 +301,14 @@ export const usePrototypeSocket = ({
 
   const selectedUsersByPart = useMemo(() => {
     const map: Record<number, ConnectedUser[]> = {};
-    Object.entries(otherSelections).forEach(([uid, { username, selectedPartIds }]) => {
-      selectedPartIds.forEach((id) => {
-        if (!map[id]) map[id] = [];
-        map[id].push({ userId: uid, username });
-      });
-    });
+    Object.entries(otherSelections).forEach(
+      ([uid, { username, selectedPartIds }]) => {
+        selectedPartIds.forEach((id) => {
+          if (!map[id]) map[id] = [];
+          map[id].push({ userId: uid, username });
+        });
+      }
+    );
     return map;
   }, [otherSelections]);
 

--- a/frontend/src/features/prototype/utils/alignment.ts
+++ b/frontend/src/features/prototype/utils/alignment.ts
@@ -34,9 +34,7 @@ export type AlignmentUpdate = {
  * @param parts - 選択されたパーツ
  * @returns 整列情報、パーツが2つ未満の場合は null
  */
-export const calculateAlignmentInfo = (
-  parts: Part[],
-): AlignmentInfo | null => {
+export const calculateAlignmentInfo = (parts: Part[]): AlignmentInfo | null => {
   if (parts.length < 2) return null;
 
   const minX = Math.min(...parts.map((p) => p.position.x));
@@ -56,12 +54,12 @@ export const calculateAlignmentInfo = (
     isLeft: parts.every((p) => p.position.x === minX),
     isRight: parts.every((p) => p.position.x + p.width === maxX),
     isHCenter: parts.every(
-      (p) => Math.round(p.position.x + p.width / 2) === centerX,
+      (p) => Math.round(p.position.x + p.width / 2) === centerX
     ),
     isTop: parts.every((p) => p.position.y === minY),
     isBottom: parts.every((p) => p.position.y + p.height === maxY),
     isVCenter: parts.every(
-      (p) => Math.round(p.position.y + p.height / 2) === centerY,
+      (p) => Math.round(p.position.y + p.height / 2) === centerY
     ),
   };
 };
@@ -76,7 +74,7 @@ export const calculateAlignmentInfo = (
 export const getAlignmentUpdates = (
   type: AlignmentType,
   parts: Part[],
-  info: AlignmentInfo,
+  info: AlignmentInfo
 ): AlignmentUpdate[] =>
   parts
     .map((p) => {

--- a/frontend/src/features/prototype/utils/partUtils.ts
+++ b/frontend/src/features/prototype/utils/partUtils.ts
@@ -80,10 +80,7 @@ export const getShadowColor = (
  * @param isActive - アクティブ状態かどうか
  * @returns 影のぼかし値（ピクセル）
  */
-export const getShadowBlur = (
-  partType: PartType,
-  isActive: boolean
-): number =>
+export const getShadowBlur = (partType: PartType, isActive: boolean): number =>
   isActive ? SHADOW_BLUR_ACTIVE : getPartStyle(partType).shadowBlur;
 
 /**

--- a/frontend/src/features/role/components/organisms/RoleManagement.tsx
+++ b/frontend/src/features/role/components/organisms/RoleManagement.tsx
@@ -177,7 +177,9 @@ const RoleManagement: React.FC = () => {
 
         <div className="flex justify-center items-center py-12">
           <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-kibako-secondary"></div>
-          <span className="ml-3 text-kibako-primary">権限情報を読み込み中...</span>
+          <span className="ml-3 text-kibako-primary">
+            権限情報を読み込み中...
+          </span>
         </div>
       </div>
     );

--- a/frontend/src/features/top/components/templates/TopPage.tsx
+++ b/frontend/src/features/top/components/templates/TopPage.tsx
@@ -34,9 +34,12 @@ const TopPage: React.FC = () => {
     if (typeof navigator === 'undefined') return;
 
     const ua = navigator.userAgent || '';
-    const isMobileUA = /Android|iPhone|iPod|iPad|Mobile|Windows Phone/i.test(ua);
+    const isMobileUA = /Android|iPhone|iPod|iPad|Mobile|Windows Phone/i.test(
+      ua
+    );
     // iPadOS 13+ は Mac と判定されるケースがあるため補助条件
-    const isIPadOS13 = navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1;
+    const isIPadOS13 =
+      navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1;
 
     setIsNonPC(isMobileUA || isIPadOS13);
   }, []);

--- a/frontend/src/utils/db.ts
+++ b/frontend/src/utils/db.ts
@@ -1,6 +1,12 @@
 import { openDB } from 'idb';
 
-import { getCachedObjectURL, setCachedObjectURL, hasCachedObjectURL, revokeObjectURLAndCleanCache, revokeMultipleObjectURLsAndCleanCache } from './imageCache';
+import {
+  getCachedObjectURL,
+  setCachedObjectURL,
+  hasCachedObjectURL,
+  revokeObjectURLAndCleanCache,
+  revokeMultipleObjectURLsAndCleanCache,
+} from './imageCache';
 
 const DB_NAME = 'BoardGamePrototype';
 const STORE_NAME = 'images';
@@ -10,7 +16,6 @@ type IndexedDbImageResult = {
   imageBlob: Blob;
   objectURL: string;
 };
-
 
 // IndexedDBの初期化関数
 export const getIndexedDb = async () => {

--- a/frontend/src/utils/imageCache.ts
+++ b/frontend/src/utils/imageCache.ts
@@ -21,4 +21,3 @@ export const revokeObjectURLAndCleanCache = (id: string): void => {
 export const revokeMultipleObjectURLsAndCleanCache = (ids: string[]): void => {
   ids.forEach((id) => revokeObjectURLAndCleanCache(id));
 };
-


### PR DESCRIPTION
## Summary
- add toggle to switch project list between card and table views
- implement sortable project table component

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc8ca58f2c8326938799690295aa4d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Project list: card/table view toggle with a sortable table and quick row actions; new ProjectTable and ProjectCardList components.
  - Part properties: image upload with progress indicator, preview, and deletion.
  - New reusable KibakoToggle control for switching views/options.

- Style
  - Presentational and layout refinements across many UI components (spacing, JSX reflow, minor DOM adjustments).

- Tests
  - Test files reformatted for consistency; no behavioral changes.

- Chores
  - ESLint cache added to .gitignore.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->