### PR TITLE
fix: remove focus ring from button styles

### DIFF
--- a/frontend/src/components/atoms/KibakoButton.tsx
+++ b/frontend/src/components/atoms/KibakoButton.tsx
@@ -3,7 +3,7 @@ import { ButtonHTMLAttributes, ReactNode } from 'react';
 import { twMerge } from 'tailwind-merge';
 
 export const buttonStyles = cva(
-  'inline-flex items-center justify-center text-sm font-bold rounded-xl shadow-sm transition-all duration-300 transform focus:outline-none focus:ring-2 focus:ring-kibako-primary disabled:opacity-80 disabled:cursor-not-allowed',
+  'inline-flex items-center justify-center text-sm font-bold rounded-xl shadow-sm transition-all duration-300 transform focus:outline-none disabled:opacity-80 disabled:cursor-not-allowed',
   {
     variants: {
       variant: {


### PR DESCRIPTION
## Summary
- remove focus ring from buttons to prevent border change on press

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bcad88b3088326acb80cbad3cced48

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - Updated button focus styling by removing the focus ring effect, altering how focused buttons appear.
  - Visual change only; interaction, loading states, and size/variant options remain the same.
  - Affects all places where the standard button component is used.
  - No impact on public APIs or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->