### PR TITLE
fix(top): remove z-sticky from TopPage to respect header layering

### DIFF
--- a/frontend/src/features/top/components/templates/TopPage.tsx
+++ b/frontend/src/features/top/components/templates/TopPage.tsx
@@ -93,7 +93,7 @@ const TopPage: React.FC = () => {
 
           {/* メインアイコン */}
           <motion.div
-            className="relative z-sticky bg-gradient-to-br from-amber-500 to-amber-700 p-6 rounded-full shadow-2xl"
+            className="relative z-10 bg-gradient-to-br from-amber-500 to-amber-700 p-6 rounded-full shadow-2xl"
             whileHover={{
               rotate: [-5, 5, -5, 5, 0],
               transition: { duration: 0.5 },
@@ -210,7 +210,7 @@ const TopPage: React.FC = () => {
           />
         </div>
 
-        <div className="container mx-auto px-4 relative z-sticky">
+        <div className="container mx-auto px-4 relative z-10">
           <motion.div
             initial={{ scale: 0.9, opacity: 0 }}
             animate={{ scale: 1, opacity: 1 }}
@@ -308,7 +308,7 @@ const TopPage: React.FC = () => {
         className="relative"
       >
         <div className="absolute inset-0 bg-amber-600 opacity-5 -skew-y-6 transform origin-top-left z-base rounded-3xl"></div>
-        <div className="container-fluid w-full max-w-[1800px] mx-auto px-4 py-12 md:py-24 relative z-sticky">
+        <div className="container-fluid w-full max-w-[1800px] mx-auto px-4 py-12 md:py-24 relative z-10">
           <AnimatePresence>
             {isLoaded && (
               <motion.div
@@ -503,7 +503,7 @@ const TopPage: React.FC = () => {
       {/* 使い方セクション */}
       <div className="py-16 relative">
         <div className="absolute inset-0 bg-amber-200 opacity-30 transform -skew-y-3 origin-top z-base rounded-3xl"></div>
-        <div className="container-fluid max-w-[1800px] mx-auto px-4 relative z-sticky">
+        <div className="container-fluid max-w-[1800px] mx-auto px-4 relative z-10">
           <motion.h2
             initial={{ opacity: 0 }}
             whileInView={{ opacity: 1 }}
@@ -583,7 +583,7 @@ const TopPage: React.FC = () => {
           <div className="absolute top-1/2 left-1/3 w-20 h-20 bg-amber-50 rounded-full"></div>
         </motion.div>
 
-        <div className="container-fluid max-w-[1800px] mx-auto px-4 relative z-sticky">
+        <div className="container-fluid max-w-[1800px] mx-auto px-4 relative z-10">
           <div className="text-center">
             <motion.h2
               initial={{ y: 30, opacity: 0 }}


### PR DESCRIPTION
概要
- TopPage内でヘッダー専用の `z-sticky`（=200）を使用していた箇所を撤廃し、必要箇所のみローカルな `z-10` に置き換えました。
- これにより、ヘッダー（`sticky top-0 z-sticky`）およびヘッダー内ドロップダウン（`z-dropdown`=250）がページ装飾より確実に前面に出るようになります。

変更点
- frontend/src/features/top/components/templates/TopPage.tsx
  - ロゴラッパー、キャッチコピー、ヒーロー、使い方、終盤CTAの各コンテナから `z-sticky` を除去し `z-10` に統一。

背景・原因
- Tailwind設定で `z-sticky: 200` は本来ヘッダー用。TopPage側が同値の `z-sticky` を多用していたため、ヘッダーと同レベルで競合し、装飾がヘッダーやドロップダウンの前に出る可能性がありました。
- Framer Motionのtransformによるスタッキングコンテキスト生成も重なり、意図しない前後関係が発生しやすい状態でした。

期待される効果
- スクロール中や装飾重なり時でもヘッダーとユーザーメニューが常に前面に表示され、クリック等の操作が遮られません。
- ページ内部の背景（z-0）/前景（z-10）の相対関係は維持されます。

メモ
- 必要であればTopPage以外で `z-sticky` を使用している箇所（例: FloatingActionButtonなど）も、用途に応じ `z-10`/`z-20` へ整理可能です。