### PR TITLE
chore: restrict develop-to-main PR workflow to manual trigger

### DIFF
--- a/.github/workflows/create_develop_to_main.yml
+++ b/.github/workflows/create_develop_to_main.yml
@@ -1,15 +1,11 @@
 name: Create develop to main PR
 
 # このワークフローが実行される条件:
-# 1. developブランチへのpush時に自動実行
-# 2. 手動実行（workflow_dispatch）も可能
-# 目的：developブランチの変更を自動的にmainブランチへのPRとして作成
+# 1. 手動実行（workflow_dispatch）のみ
+# 目的：developブランチの変更をmainブランチへのPRとして作成
 # 既存のPRがある場合は重複作成を防ぐロジックが組み込まれている
 on:
-  push:
-    branches:
-      - develop  # developブランチへのpush時に自動でPR作成
-  workflow_dispatch: # Allow manual triggering for maintenance and debugging
+  workflow_dispatch: # Manual trigger only
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- run develop-to-main PR workflow only when manually triggered

## Testing
- `make ci`
- `cd backend && npm test` *(cancelled after tests passed)*
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bcb249783483268d6f2218720dab98

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated CI workflow to require manual triggering for creating pull requests from develop to main, replacing automatic runs on push.
  - Expanded workflow permissions to include pull request write access to support PR creation via the API.
  - No user-facing functionality changes; this affects release process only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->