### PR TITLE
chore: ignore generated swagger schemas in eslint

### DIFF
--- a/backend/eslint.config.mjs
+++ b/backend/eslint.config.mjs
@@ -24,6 +24,6 @@ export default [
     },
   },
   {
-    ignores: ['dist/**/*'],
+    ignores: ['dist/**/*', 'src/swagger-schemas.ts'],
   },
 ];


### PR DESCRIPTION
## Summary
- ignore the generated swagger schemas file in ESLint to remove unused directive warning

## Testing
- `cd backend && npm run lint`
- `cd backend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bcb33039dc83268d2a7650f0102485