### PR TITLE
feat: persist project list view mode

### DIFF
--- a/frontend/src/features/prototype/components/organisms/ProjectList.tsx
+++ b/frontend/src/features/prototype/components/organisms/ProjectList.tsx
@@ -19,6 +19,7 @@ import { ProjectCardList } from '@/features/prototype/components/molecules/Proje
 import { ProjectTable } from '@/features/prototype/components/molecules/ProjectTable';
 import useInlineEdit from '@/hooks/useInlineEdit';
 import { deleteExpiredImagesFromIndexedDb } from '@/utils/db';
+import { getUIPreference, setUIPreference } from '@/utils/uiPreferences';
 
 /**
  * ProjectListコンポーネントで使用される各種Stateの説明:
@@ -61,7 +62,9 @@ const ProjectList: React.FC = () => {
   const [isReloadAnimating, setIsReloadAnimating] = useState<boolean>(false);
 
   // 表示モードとソート設定
-  const [viewMode, setViewMode] = useState<'card' | 'table'>('card');
+  const [viewMode, setViewMode] = useState<'card' | 'table'>(
+    () => getUIPreference('projectListView') ?? 'card'
+  );
   const [sortKey, setSortKey] = useState<'name' | 'createdAt'>('createdAt');
   const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('desc');
 
@@ -386,7 +389,11 @@ const ProjectList: React.FC = () => {
           <span className="text-sm text-kibako-secondary">{`合計プロジェクト数: ${sortedPrototypeList.length}`}</span>
           <KibakoToggle
             checked={viewMode === 'table'}
-            onChange={(checked) => setViewMode(checked ? 'table' : 'card')}
+            onChange={(checked) => {
+              const mode = checked ? 'table' : 'card';
+              setViewMode(mode);
+              setUIPreference('projectListView', mode);
+            }}
             labelLeft={<FaTh className="w-4 h-4" aria-hidden="true" />}
             labelRight={<FaTable className="w-4 h-4" aria-hidden="true" />}
             shouldChangeBackgroud={false}

--- a/frontend/src/features/prototype/components/organisms/ProjectList.tsx
+++ b/frontend/src/features/prototype/components/organisms/ProjectList.tsx
@@ -19,7 +19,11 @@ import { ProjectCardList } from '@/features/prototype/components/molecules/Proje
 import { ProjectTable } from '@/features/prototype/components/molecules/ProjectTable';
 import useInlineEdit from '@/hooks/useInlineEdit';
 import { deleteExpiredImagesFromIndexedDb } from '@/utils/db';
-import { getUIPreference, setUIPreference } from '@/utils/uiPreferences';
+import {
+  getUIPreference,
+  setUIPreference,
+  ProjectListView,
+} from '@/utils/uiPreferences';
 
 /**
  * ProjectListコンポーネントで使用される各種Stateの説明:
@@ -61,10 +65,11 @@ const ProjectList: React.FC = () => {
   // リロードアイコンのワンショットアニメーション制御
   const [isReloadAnimating, setIsReloadAnimating] = useState<boolean>(false);
 
-  // 表示モードとソート設定
-  const [viewMode, setViewMode] = useState<'card' | 'table'>(
-    () => getUIPreference('projectListView') ?? 'card'
-  );
+  // 表示モードとソート設定（永続値を安全に復元）
+  const [viewMode, setViewMode] = useState<ProjectListView>(() => {
+    const v = getUIPreference('projectListView');
+    return v === 'card' || v === 'table' ? v : 'card';
+  });
   const [sortKey, setSortKey] = useState<'name' | 'createdAt'>('createdAt');
   const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('desc');
 

--- a/frontend/src/utils/uiPreferences.ts
+++ b/frontend/src/utils/uiPreferences.ts
@@ -1,0 +1,41 @@
+const UI_PREFERENCES_KEY = 'uiPreferences';
+
+export type UIPreferences = {
+  projectListView?: 'card' | 'table';
+  // add more preferences here
+};
+
+export const loadUIPreferences = (): UIPreferences => {
+  if (typeof window === 'undefined') return {};
+  try {
+    const stored = window.localStorage.getItem(UI_PREFERENCES_KEY);
+    return stored ? (JSON.parse(stored) as UIPreferences) : {};
+  } catch {
+    return {};
+  }
+};
+
+export const saveUIPreferences = (prefs: UIPreferences): void => {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(UI_PREFERENCES_KEY, JSON.stringify(prefs));
+  } catch {
+    // ignore write errors
+  }
+};
+
+export const getUIPreference = <K extends keyof UIPreferences>(
+  key: K
+): UIPreferences[K] | undefined => {
+  const prefs = loadUIPreferences();
+  return prefs[key];
+};
+
+export const setUIPreference = <K extends keyof UIPreferences>(
+  key: K,
+  value: UIPreferences[K]
+): void => {
+  const prefs = loadUIPreferences();
+  prefs[key] = value;
+  saveUIPreferences(prefs);
+};

--- a/frontend/src/utils/uiPreferences.ts
+++ b/frontend/src/utils/uiPreferences.ts
@@ -1,8 +1,21 @@
 const UI_PREFERENCES_KEY = 'uiPreferences';
 
+export type ProjectListView = 'card' | 'table';
+
 export type UIPreferences = {
-  projectListView?: 'card' | 'table';
+  projectListView?: ProjectListView;
   // add more preferences here
+};
+
+// Runtime validator for known preference keys/values
+const isValidPreferenceValue = <K extends keyof UIPreferences>(
+  key: K,
+  value: UIPreferences[K]
+): boolean => {
+  if (key === 'projectListView') {
+    return value === 'card' || value === 'table';
+  }
+  return true;
 };
 
 export const loadUIPreferences = (): UIPreferences => {
@@ -28,13 +41,16 @@ export const getUIPreference = <K extends keyof UIPreferences>(
   key: K
 ): UIPreferences[K] | undefined => {
   const prefs = loadUIPreferences();
-  return prefs[key];
+  const value = prefs[key];
+  return isValidPreferenceValue(key, value) ? value : undefined;
 };
 
 export const setUIPreference = <K extends keyof UIPreferences>(
   key: K,
   value: UIPreferences[K]
 ): void => {
+  // Guard against invalid/corrupted values before persisting
+  if (!isValidPreferenceValue(key, value)) return;
   const prefs = loadUIPreferences();
   prefs[key] = value;
   saveUIPreferences(prefs);


### PR DESCRIPTION
## Summary
- add uiPreferences util for future visual settings stored in localStorage
- persist ProjectList card/table view using util

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bcb7aee1cc832692e605baacbc5482

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - The project list now remembers your preferred view (Card or Table) and restores it automatically on return.
  - Preferences are saved per browser profile, persisting across sessions for a consistent experience.
  - Preference storage is resilient; if saving isn’t available (e.g., restricted environments), the app continues to work with defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->