### PR TITLE
test: silence permission error logs

### DIFF
--- a/backend/src/middlewares/permissions.test.ts
+++ b/backend/src/middlewares/permissions.test.ts
@@ -112,6 +112,9 @@ describe('checkProjectOwner', () => {
     } as unknown as Request;
     const res = createRes();
     const next = vi.fn();
+    const consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
 
     mockedFindByPk.mockRejectedValue(new Error('DB failure'));
 
@@ -122,6 +125,8 @@ describe('checkProjectOwner', () => {
       message: '予期せぬエラーが発生しました',
     });
     expect(next).not.toHaveBeenCalled();
+
+    consoleErrorSpy.mockRestore();
   });
 });
 
@@ -202,6 +207,9 @@ describe('checkPermission factory and wrappers', () => {
     } as unknown as Request;
     const res = createRes();
     const next = vi.fn();
+    const consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
 
     mockedHasPermission.mockRejectedValue(new Error('RBAC failure'));
 
@@ -218,5 +226,7 @@ describe('checkPermission factory and wrappers', () => {
       message: '予期せぬエラーが発生しました',
     });
     expect(next).not.toHaveBeenCalled();
+
+    consoleErrorSpy.mockRestore();
   });
 });


### PR DESCRIPTION
## Summary
- silence console.error output in permissions middleware tests

## Testing
- `npm run lint`
- `CI=1 npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bcc4f98d0c83269bb3b7ab9c0e2f91