### PR TITLE
feat(frontend): hide header user options on non-PC devices

### DIFF
--- a/frontend/src/components/layouts/ClientLayout.tsx
+++ b/frontend/src/components/layouts/ClientLayout.tsx
@@ -21,6 +21,9 @@ const queryClient = new QueryClient({
   },
 });
 
+/**
+ * クライアント専用レイアウト。非PCデバイスはトップへリダイレクトする。
+ */
 export default function ClientLayout({
   children,
 }: Readonly<{
@@ -34,7 +37,7 @@ export default function ClientLayout({
   useEffect(() => {
     if (!isReady) return;
     if (!isPC && pathname !== '/') {
-      router.push('/');
+      router.replace('/');
     }
   }, [isPC, isReady, pathname, router]);
 
@@ -43,7 +46,7 @@ export default function ClientLayout({
   if (!isReady && pathname !== '/') {
     return (
       <div className="flex items-center justify-center min-h-screen">
-        <p>Loading...</p>
+        <p>読み込み中...</p>
       </div>
     );
   }

--- a/frontend/src/components/layouts/ClientLayout.tsx
+++ b/frontend/src/components/layouts/ClientLayout.tsx
@@ -2,12 +2,12 @@
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
-import React, { useEffect, useState } from 'react';
-import * as UAParser from 'ua-parser-js';
+import React, { useEffect } from 'react';
 
 import { WoodenCrateBackground } from '@/components/atoms/WoodenCrateBackground';
 import Header from '@/components/organisms/Header';
 import { useClientPathInfo } from '@/hooks/useClientPathInfo';
+import { useIsPC } from '@/hooks/useIsPC';
 
 // QueryClientの設定
 const queryClient = new QueryClient({
@@ -28,38 +28,19 @@ export default function ClientLayout({
 }>) {
   const router = useRouter();
   const { pathname, isGameBoardPath } = useClientPathInfo();
-  // 初期値をfalseにすることでSSRとクライアント側のレンダリングを一致させる
-  const [isCheckingDevice, setIsCheckingDevice] = useState(false);
-  const [shouldRedirect, setShouldRedirect] = useState(false);
+  const { isPC, isReady } = useIsPC();
 
+  // 非PCデバイスはトップページへ戻す
   useEffect(() => {
-    // クライアントサイドでのみデバイスチェックを実行
-    if (typeof window !== 'undefined' && pathname !== '/') {
-      setIsCheckingDevice(true);
-
-      const parser = new UAParser.UAParser();
-      const result = parser.getResult();
-      const deviceType = result.device.type;
-
-      // モバイルまたはタブレットの場合にリダイレクトフラグを設定
-      if (deviceType === 'mobile' || deviceType === 'tablet') {
-        setShouldRedirect(true);
-      }
-
-      setIsCheckingDevice(false);
-    }
-  }, [pathname]);
-
-  // リダイレクトが必要な場合は実行
-  useEffect(() => {
-    if (shouldRedirect && pathname !== '/') {
+    if (!isReady) return;
+    if (!isPC && pathname !== '/') {
       router.push('/');
     }
-  }, [shouldRedirect, pathname, router]);
+  }, [isPC, isReady, pathname, router]);
 
   // デバイスチェック中は読み込み表示を返すことで、
   // サーバーサイドレンダリングとの整合性を保つ
-  if (isCheckingDevice) {
+  if (!isReady && pathname !== '/') {
     return (
       <div className="flex items-center justify-center min-h-screen">
         <p>Loading...</p>

--- a/frontend/src/components/organisms/Header.tsx
+++ b/frontend/src/components/organisms/Header.tsx
@@ -32,6 +32,7 @@ const Header: React.FC = () => {
         </div>
       </button>
 
+      {/* PC のみユーザーメニューを表示 */}
       {isReady && isPC && <UserMenu pathname={pathname} />}
     </header>
   );

--- a/frontend/src/components/organisms/Header.tsx
+++ b/frontend/src/components/organisms/Header.tsx
@@ -1,13 +1,23 @@
 'use client';
 import { usePathname, useRouter } from 'next/navigation';
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { GiWoodenCrate } from 'react-icons/gi';
+import * as UAParser from 'ua-parser-js';
 
 import UserMenu from '@/components/molecules/UserMenu';
 
 const Header: React.FC = () => {
   const router = useRouter();
   const pathname = usePathname();
+  const [isPC, setIsPC] = useState(false);
+
+  useEffect(() => {
+    const parser = new UAParser.UAParser();
+    const deviceType = parser.getResult().device.type;
+    if (!deviceType) {
+      setIsPC(true);
+    }
+  }, []);
 
   /**
    * トップページへ遷移する
@@ -30,7 +40,7 @@ const Header: React.FC = () => {
         </div>
       </button>
 
-      <UserMenu pathname={pathname} />
+      {isPC && <UserMenu pathname={pathname} />}
     </header>
   );
 };

--- a/frontend/src/components/organisms/Header.tsx
+++ b/frontend/src/components/organisms/Header.tsx
@@ -1,23 +1,15 @@
 'use client';
 import { usePathname, useRouter } from 'next/navigation';
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import { GiWoodenCrate } from 'react-icons/gi';
-import * as UAParser from 'ua-parser-js';
 
 import UserMenu from '@/components/molecules/UserMenu';
+import { useIsPC } from '@/hooks/useIsPC';
 
 const Header: React.FC = () => {
   const router = useRouter();
   const pathname = usePathname();
-  const [isPC, setIsPC] = useState(false);
-
-  useEffect(() => {
-    const parser = new UAParser.UAParser();
-    const deviceType = parser.getResult().device.type;
-    if (!deviceType) {
-      setIsPC(true);
-    }
-  }, []);
+  const { isPC, isReady } = useIsPC();
 
   /**
    * トップページへ遷移する
@@ -40,7 +32,7 @@ const Header: React.FC = () => {
         </div>
       </button>
 
-      {isPC && <UserMenu pathname={pathname} />}
+      {isReady && isPC && <UserMenu pathname={pathname} />}
     </header>
   );
 };

--- a/frontend/src/features/top/components/templates/TopPage.tsx
+++ b/frontend/src/features/top/components/templates/TopPage.tsx
@@ -16,9 +16,12 @@ import CatchCopyCard from '@/features/top/components/molecules/CatchCopyCard';
 import MiniGameBoard from '@/features/top/components/organisms/MiniGameBoard';
 import { useIsPC } from '@/hooks/useIsPC';
 
+/**
+ * トップページのランディング。PC限定UIの案内やヒーロー/特徴/案内セクションを含む。
+ */
 const TopPage: React.FC = () => {
-  const [isLoaded, setIsLoaded] = useState(false);
   const { isPC, isReady } = useIsPC();
+  const [isLoaded, setIsLoaded] = useState(false);
   const { scrollYProgress } = useScroll();
 
   // パララックス効果のための変換値
@@ -30,6 +33,7 @@ const TopPage: React.FC = () => {
     setIsLoaded(true);
   }, []);
 
+  // 非PCデバイスの場合にのみ案内を表示する判定
   const isNonPC = isReady && !isPC;
 
   // カード要素のバリアント

--- a/frontend/src/features/top/components/templates/TopPage.tsx
+++ b/frontend/src/features/top/components/templates/TopPage.tsx
@@ -14,10 +14,11 @@ import FloatingActionButton from '@/features/top/components/atoms/FloatingAction
 import ShareLinkButton from '@/features/top/components/atoms/ShareLinkButton';
 import CatchCopyCard from '@/features/top/components/molecules/CatchCopyCard';
 import MiniGameBoard from '@/features/top/components/organisms/MiniGameBoard';
+import { useIsPC } from '@/hooks/useIsPC';
 
 const TopPage: React.FC = () => {
   const [isLoaded, setIsLoaded] = useState(false);
-  const [isNonPC, setIsNonPC] = useState(false);
+  const { isPC, isReady } = useIsPC();
   const { scrollYProgress } = useScroll();
 
   // パララックス効果のための変換値
@@ -29,20 +30,7 @@ const TopPage: React.FC = () => {
     setIsLoaded(true);
   }, []);
 
-  // 非PCデバイス判定（モバイル/タブレット想定）
-  useEffect(() => {
-    if (typeof navigator === 'undefined') return;
-
-    const ua = navigator.userAgent || '';
-    const isMobileUA = /Android|iPhone|iPod|iPad|Mobile|Windows Phone/i.test(
-      ua
-    );
-    // iPadOS 13+ は Mac と判定されるケースがあるため補助条件
-    const isIPadOS13 =
-      navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1;
-
-    setIsNonPC(isMobileUA || isIPadOS13);
-  }, []);
+  const isNonPC = isReady && !isPC;
 
   // カード要素のバリアント
   const cardVariants = {

--- a/frontend/src/hooks/useIsPC.ts
+++ b/frontend/src/hooks/useIsPC.ts
@@ -5,9 +5,9 @@ import { isPCFromNavigator } from '@/utils/device';
  * React hook to detect if the current device is a PC (desktop).
  * Provides an `isReady` flag to avoid SSR hydration mismatches.
  */
-export function useIsPC() {
+export function useIsPC(): Readonly<{ isPC: boolean; isReady: boolean }> {
   const [isPC, setIsPC] = useState<boolean>(true);
-  const [isReady, setIsReady] = useState(false);
+  const [isReady, setIsReady] = useState<boolean>(false);
 
   useEffect(() => {
     const result = isPCFromNavigator();
@@ -22,4 +22,3 @@ export function useIsPC() {
 
   return { isPC, isReady } as const;
 }
-

--- a/frontend/src/hooks/useIsPC.ts
+++ b/frontend/src/hooks/useIsPC.ts
@@ -3,8 +3,8 @@ import { useEffect, useState } from 'react';
 import { isPCFromNavigator } from '@/utils/device';
 
 /**
- * React hook to detect if the current device is a PC (desktop).
- * Provides an `isReady` flag to avoid SSR hydration mismatches.
+ * 現在のデバイスがPCかどうかを判定するフック。
+ * SSRのハイドレーション不整合を避けるため `isReady` を提供する。
  */
 export function useIsPC(): Readonly<{ isPC: boolean; isReady: boolean }> {
   const [isPC, setIsPC] = useState<boolean>(true);

--- a/frontend/src/hooks/useIsPC.ts
+++ b/frontend/src/hooks/useIsPC.ts
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+
 import { isPCFromNavigator } from '@/utils/device';
 
 /**

--- a/frontend/src/hooks/useIsPC.ts
+++ b/frontend/src/hooks/useIsPC.ts
@@ -1,0 +1,25 @@
+import { useEffect, useState } from 'react';
+import { isPCFromNavigator } from '@/utils/device';
+
+/**
+ * React hook to detect if the current device is a PC (desktop).
+ * Provides an `isReady` flag to avoid SSR hydration mismatches.
+ */
+export function useIsPC() {
+  const [isPC, setIsPC] = useState<boolean>(true);
+  const [isReady, setIsReady] = useState(false);
+
+  useEffect(() => {
+    const result = isPCFromNavigator();
+    if (result === null) {
+      // Cannot determine in SSR; keep default and just mark ready
+      setIsPC(true);
+    } else {
+      setIsPC(result);
+    }
+    setIsReady(true);
+  }, []);
+
+  return { isPC, isReady } as const;
+}
+

--- a/frontend/src/utils/device.ts
+++ b/frontend/src/utils/device.ts
@@ -1,0 +1,54 @@
+import * as UAParser from 'ua-parser-js';
+
+/**
+ * Determine if the current device should be treated as a PC (desktop).
+ * Combines UAParser detection with iPadOS 13+ and generic mobile UA heuristics.
+ *
+ * @param ua - User agent string
+ * @param opts - Optional platform and touch info for better accuracy
+ */
+export function isPCFromUA(
+  ua: string,
+  opts?: { platform?: string; maxTouchPoints?: number }
+): boolean {
+  const parser = new UAParser.UAParser(ua);
+  const result = parser.getResult();
+  const deviceType = result.device.type; // 'mobile' | 'tablet' | 'console' | 'smarttv' | 'wearable' | 'embedded' | 'desktop' | undefined
+
+  const platform = opts?.platform;
+  const maxTouchPoints = opts?.maxTouchPoints ?? 0;
+
+  // iPadOS 13+ may masquerade as Mac; detect via touch points
+  if (platform === 'MacIntel' && maxTouchPoints > 1) {
+    return false; // treat as non-PC (tablet)
+  }
+
+  // Fallback: broad mobile UA check
+  const isMobileUA = /Android|iPhone|iPod|iPad|Mobile|Windows Phone/i.test(ua);
+  if (isMobileUA) {
+    return false;
+  }
+
+  // UAParser: if specific non-desktop device type is detected, treat as non-PC
+  if (deviceType && deviceType !== 'desktop') {
+    return false;
+  }
+
+  // Default to PC
+  return true;
+}
+
+/**
+ * Convenience wrapper using the global navigator if available.
+ * Returns null when not runnable (e.g., during SSR).
+ */
+export function isPCFromNavigator(): boolean | null {
+  if (typeof navigator === 'undefined') return null;
+  const ua = navigator.userAgent || '';
+  const platform = navigator.platform;
+  const maxTouchPoints = (navigator as any).maxTouchPoints as
+    | number
+    | undefined;
+  return isPCFromUA(ua, { platform, maxTouchPoints });
+}
+

--- a/frontend/src/utils/device.ts
+++ b/frontend/src/utils/device.ts
@@ -13,7 +13,7 @@ export function isPCFromUA(
 ): boolean {
   const parser = new UAParser.UAParser(ua);
   const result = parser.getResult();
-  const deviceType = result.device.type; // 'mobile' | 'tablet' | 'console' | 'smarttv' | 'wearable' | 'embedded' | 'desktop' | undefined
+  const deviceType = result.device.type; // 'mobile' | 'tablet' | 'console' | 'smarttv' | 'wearable' | 'embedded' | undefined
 
   const platform = opts?.platform;
   const maxTouchPoints = opts?.maxTouchPoints ?? 0;
@@ -29,8 +29,9 @@ export function isPCFromUA(
     return false;
   }
 
-  // UAParser: if specific non-desktop device type is detected, treat as non-PC
-  if (deviceType && deviceType !== 'desktop') {
+  // UAParser: if a specific device type is detected, treat as non-PC
+  // (UAParser typically leaves desktop as undefined)
+  if (deviceType) {
     return false;
   }
 
@@ -51,4 +52,3 @@ export function isPCFromNavigator(): boolean | null {
     | undefined;
   return isPCFromUA(ua, { platform, maxTouchPoints });
 }
-

--- a/frontend/src/utils/device.ts
+++ b/frontend/src/utils/device.ts
@@ -1,4 +1,4 @@
-import * as UAParser from 'ua-parser-js';
+import { UAParser, type IResult } from 'ua-parser-js';
 
 /**
  * Determine if the current device should be treated as a PC (desktop).
@@ -11,8 +11,8 @@ export function isPCFromUA(
   ua: string,
   opts?: { platform?: string; maxTouchPoints?: number }
 ): boolean {
-  const parser = new UAParser.UAParser(ua);
-  const result = parser.getResult();
+  const parser = new UAParser(ua);
+  const result: IResult = parser.getResult();
   const deviceType = result.device.type; // 'mobile' | 'tablet' | 'console' | 'smarttv' | 'wearable' | 'embedded' | undefined
 
   const platform = opts?.platform;
@@ -47,8 +47,7 @@ export function isPCFromNavigator(): boolean | null {
   if (typeof navigator === 'undefined') return null;
   const ua = navigator.userAgent || '';
   const platform = navigator.platform;
-  const maxTouchPoints = (navigator as any).maxTouchPoints as
-    | number
-    | undefined;
+  const maxTouchPoints =
+    'maxTouchPoints' in navigator ? navigator.maxTouchPoints : undefined;
   return isPCFromUA(ua, { platform, maxTouchPoints });
 }

--- a/frontend/src/utils/device.ts
+++ b/frontend/src/utils/device.ts
@@ -1,11 +1,11 @@
 import { UAParser, type IResult } from 'ua-parser-js';
 
 /**
- * Determine if the current device should be treated as a PC (desktop).
- * Combines UAParser detection with iPadOS 13+ and generic mobile UA heuristics.
+ * デバイスをPCとして扱うべきかを判定する。
+ * UAParserの結果に加え、iPadOS13+の擬装検出・モバイルUAの簡易判定を組み合わせる。
  *
- * @param ua - User agent string
- * @param opts - Optional platform and touch info for better accuracy
+ * @param ua ユーザーエージェント文字列
+ * @param opts 追加情報（platform / maxTouchPoints）
  */
 export function isPCFromUA(
   ua: string,
@@ -40,8 +40,8 @@ export function isPCFromUA(
 }
 
 /**
- * Convenience wrapper using the global navigator if available.
- * Returns null when not runnable (e.g., during SSR).
+ * グローバルの navigator が利用可能な場合のラッパー。
+ * SSR 等で判定不能な場合は null を返す。
  */
 export function isPCFromNavigator(): boolean | null {
   if (typeof navigator === 'undefined') return null;


### PR DESCRIPTION
## Summary
- hide login button & user menu on mobile/tablet by checking UA

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bcc5c283788326b7f41f20053d6a4a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Header shows the User Menu only for desktop devices once device detection is ready; mobile/tablet see a simplified header.
  - PC‑only pages now redirect non‑desktop users back to the home page.
  - PC‑only sections (e.g., top page UI) are gated to avoid flicker or layout mismatch during detection readiness.
- **Bug Fixes**
  - Improved loading/ready handling to prevent server/client rendering mismatches and unwanted flashes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->