### PR TITLE
feat: add OS-aware keyboard shortcuts

### DIFF
--- a/frontend/src/features/prototype/components/molecules/GameBoardHelpPanel.tsx
+++ b/frontend/src/features/prototype/components/molecules/GameBoardHelpPanel.tsx
@@ -7,6 +7,7 @@
 import { useState, useEffect } from 'react';
 import { IoClose, IoInformationCircleOutline } from 'react-icons/io5';
 
+import { KEYBOARD_SHORTCUTS } from '@/features/prototype/constants';
 import {
   SHORTCUTS,
   PARTS_INFO,
@@ -38,7 +39,7 @@ export default function GameBoardHelpPanel({
       }
 
       // Shift + ? (Shift + / キー)でショートカットメニューを開閉
-      if (event.shiftKey && event.key === '?') {
+      if (KEYBOARD_SHORTCUTS.help.match?.(event)) {
         setIsExpanded((prev) => !prev);
       }
     };
@@ -58,7 +59,7 @@ export default function GameBoardHelpPanel({
           onClick={() => setIsExpanded(!isExpanded)}
           className="flex items-center justify-center rounded-full bg-kibako-primary p-1.5 shadow-md hover:bg-kibako-primary transition-all"
           aria-label={isExpanded ? 'ヘルプを閉じる' : 'ヘルプを開く'}
-          title="操作ヘルプ (Shift+?)"
+          title={`操作ヘルプ (${KEYBOARD_SHORTCUTS.help.label})`}
         >
           <IoInformationCircleOutline className="h-4 w-4 text-kibako-white" />
         </button>

--- a/frontend/src/features/prototype/components/molecules/PartPropertyMenuSingle.tsx
+++ b/frontend/src/features/prototype/components/molecules/PartPropertyMenuSingle.tsx
@@ -9,7 +9,7 @@ import NumberInput from '@/components/atoms/NumberInput';
 import TextInput from '@/components/atoms/TextInput';
 import ColorPicker from '@/features/prototype/components/atoms/ColorPicker';
 import PartPropertyMenuButton from '@/features/prototype/components/atoms/PartPropertyMenuButton';
-import { COLORS } from '@/features/prototype/constants';
+import { COLORS, KEYBOARD_SHORTCUTS } from '@/features/prototype/constants';
 import { usePartReducer } from '@/features/prototype/hooks/usePartReducer';
 import {
   DeleteImageProps,
@@ -180,7 +180,7 @@ export default function PartPropertyMenuSingle({
             text="複製"
             icon={<FaRegCopy className="h-3 w-3" />}
             onClick={onDuplicatePart}
-            title="Cmd/Ctrl + D"
+            title={KEYBOARD_SHORTCUTS.duplicatePart.label}
           />
           <PartPropertyMenuButton
             text="削除"
@@ -188,7 +188,7 @@ export default function PartPropertyMenuSingle({
             onClick={() => {
               onDeletePart();
             }}
-            title="Delete / Backspace"
+            title={KEYBOARD_SHORTCUTS.deleteParts.label}
           />
         </div>
       )}

--- a/frontend/src/features/prototype/constants/helpInfo.ts
+++ b/frontend/src/features/prototype/constants/helpInfo.ts
@@ -2,45 +2,9 @@
  * ヘルプ情報に関する定数
  */
 
-import type {
-  ShortcutInfo,
-  PartInfo,
-  OperationInfo,
-} from '@/features/prototype/types/helpInfo';
+import type { PartInfo, OperationInfo } from '@/features/prototype/types/helpInfo';
+export { SHORTCUTS } from './shortcutKeys';
 
-// ショートカット情報の定義
-export const SHORTCUTS: ShortcutInfo[] = [
-  {
-    id: 'help',
-    key: 'Shift + ?',
-    description: 'ヘルプパネルを開閉する。',
-  },
-  {
-    id: 'space-drag',
-    key: 'Space + ドラッグ',
-    description: '選択モード時に一時的にゲームボードを移動する。',
-  },
-  {
-    id: 'multi-select',
-    key: 'Shift + クリック',
-    description: '複数のパーツを選択する。',
-  },
-  {
-    id: 'delete',
-    key: 'Delete / Backspace',
-    description: '選択中のパーツを全て削除する。',
-  },
-  {
-    id: 'duplicate',
-    key: 'Cmd/Ctrl + D',
-    description: '選択中のパーツ1つを複製する。',
-  },
-  {
-    id: 'zoom',
-    key: 'Cmd/Ctrl + ホイール',
-    description: 'ボードを拡大縮小する。',
-  },
-];
 
 // パーツ操作情報の定義
 export const PARTS_INFO: PartInfo[] = [

--- a/frontend/src/features/prototype/constants/index.ts
+++ b/frontend/src/features/prototype/constants/index.ts
@@ -2,5 +2,6 @@ export * from './animation';
 export * from './camera';
 export * from './gameBoard';
 export * from './helpInfo';
+export * from './shortcutKeys';
 export * from './part';
 export * from './presence';

--- a/frontend/src/features/prototype/constants/shortcutKeys.ts
+++ b/frontend/src/features/prototype/constants/shortcutKeys.ts
@@ -1,0 +1,76 @@
+import type { ShortcutInfo } from '@/features/prototype/types/helpInfo';
+import { IS_MAC } from '@/utils/os';
+
+type ShortcutDef = {
+  id: string;
+  label: string;
+  description: string;
+  match?: (e: KeyboardEvent) => boolean;
+  showInHelp: boolean;
+};
+
+const MODIFIER_KEY = IS_MAC ? 'Cmd' : 'Ctrl';
+
+export const KEYBOARD_SHORTCUTS: Record<string, ShortcutDef> = {
+  help: {
+    id: 'help',
+    label: 'Shift + ?',
+    description: 'ヘルプパネルを開閉する。',
+    match: (e: KeyboardEvent) => e.shiftKey && e.key === '?',
+    showInHelp: true,
+  },
+  spaceDrag: {
+    id: 'space-drag',
+    label: 'Space + ドラッグ',
+    description: '選択モード時に一時的にゲームボードを移動する。',
+    showInHelp: true,
+  },
+  multiSelect: {
+    id: 'multi-select',
+    label: 'Shift + クリック',
+    description: '複数のパーツを選択する。',
+    showInHelp: true,
+  },
+  deleteParts: {
+    id: 'delete',
+    label: 'Delete / Backspace',
+    description: '選択中のパーツを全て削除する。',
+    match: (e: KeyboardEvent) =>
+      (e.key === 'Delete' || e.key === 'Backspace') &&
+      !e.metaKey &&
+      !e.ctrlKey &&
+      !e.altKey &&
+      !e.shiftKey,
+    showInHelp: true,
+  },
+  duplicatePart: {
+    id: 'duplicate',
+    label: `${MODIFIER_KEY} + D`,
+    description: '選択中のパーツ1つを複製する。',
+    match: (e: KeyboardEvent) =>
+      (IS_MAC ? e.metaKey && !e.ctrlKey : e.ctrlKey && !e.metaKey) &&
+      !e.altKey &&
+      !e.shiftKey &&
+      e.key.toLowerCase() === 'd',
+    showInHelp: true,
+  },
+  zoomBoard: {
+    id: 'zoom',
+    label: `${MODIFIER_KEY} + ホイール`,
+    description: 'ボードを拡大縮小する。',
+    showInHelp: true,
+  },
+  debugToggle: {
+    id: 'debug-toggle',
+    label: `${MODIFIER_KEY} + I`,
+    description: 'デバッグ情報の表示/非表示を切り替える。',
+    match: (e: KeyboardEvent) =>
+      (IS_MAC ? e.metaKey && !e.ctrlKey : e.ctrlKey && !e.metaKey) &&
+      e.key.toLowerCase() === 'i',
+    showInHelp: false,
+  },
+} as const;
+
+export const SHORTCUTS: ShortcutInfo[] = Object.values(KEYBOARD_SHORTCUTS)
+  .filter((s) => s.showInHelp)
+  .map(({ id, label, description }) => ({ id, key: label, description }));

--- a/frontend/src/features/prototype/contexts/DebugModeContext.tsx
+++ b/frontend/src/features/prototype/contexts/DebugModeContext.tsx
@@ -7,6 +7,7 @@ import React, {
   ReactNode,
 } from 'react';
 
+import { KEYBOARD_SHORTCUTS } from '@/features/prototype/constants';
 import { isInputFieldFocused } from '@/utils/inputFocus';
 
 interface DebugModeContextType {
@@ -36,8 +37,8 @@ export const DebugModeProvider: React.FC<{ children: ReactNode }> = ({
         return;
       }
 
-      // Cmd+i または Ctrl+i でデバッグ情報の表示/非表示を切り替え
-      if ((e.metaKey || e.ctrlKey) && e.key === 'i') {
+      // デバッグ情報の表示/非表示を切り替え
+      if (KEYBOARD_SHORTCUTS.debugToggle.match?.(e)) {
         e.preventDefault();
         toggleDebugInfo();
       }

--- a/frontend/src/features/prototype/debug-info/components/organisms/DebugInfo.tsx
+++ b/frontend/src/features/prototype/debug-info/components/organisms/DebugInfo.tsx
@@ -3,6 +3,7 @@
 import React, { useState } from 'react';
 
 import { Part, PartProperty } from '@/api/types';
+import { KEYBOARD_SHORTCUTS } from '@/features/prototype/constants';
 import { useDebugMode } from '@/features/prototype/hooks/useDebugMode';
 import { GameBoardMode } from '@/features/prototype/types';
 
@@ -89,7 +90,7 @@ const DebugInfo: React.FC<DebugInfoProps> = ({
       <div className="flex-1 overflow-y-auto">{renderTabContent()}</div>
 
       <div className="text-[11px] mt-2 pt-2 border-t border-kibako-white border-opacity-20">
-        Press Cmd+i (Mac) or Ctrl+i (Windows) to toggle debug panel
+        Press {KEYBOARD_SHORTCUTS.debugToggle.label} to toggle debug panel
       </div>
     </div>
   );

--- a/frontend/src/features/prototype/hooks/useGameBoardShortcut.ts
+++ b/frontend/src/features/prototype/hooks/useGameBoardShortcut.ts
@@ -1,5 +1,6 @@
 import { useEffect } from 'react';
 
+import { KEYBOARD_SHORTCUTS } from '@/features/prototype/constants';
 import { GameBoardMode } from '@/features/prototype/types';
 import { isInputFieldFocused } from '@/utils/inputFocus';
 
@@ -7,7 +8,7 @@ import { isInputFieldFocused } from '@/utils/inputFocus';
 /**
  * 汎用のゲームボードショートカットフック
  * - Delete / Backspace: 選択パーツを削除（CREATEモード）
- * - Cmd/Ctrl + D: 選択パーツを複製（CREATEモード）
+ * - Cmd または Ctrl + D: 選択パーツを複製（CREATEモード）
  */
 export function useGameBoardShortcuts(
   handleDeleteParts: () => Promise<void> | void,
@@ -29,10 +30,8 @@ export function useGameBoardShortcuts(
       // 入力中は無視
       if (isInputFieldFocused()) return;
 
-      // --- 削除処理 (Delete / Backspace, 修飾キー併用は無視) ---
-      if (e.key === 'Delete' || e.key === 'Backspace') {
-        if (e.metaKey || e.ctrlKey || e.altKey || e.shiftKey) return;
-
+      // --- 削除処理 ---
+      if (KEYBOARD_SHORTCUTS.deleteParts.match?.(e)) {
         e.preventDefault();
         if (isDeletingRef.current) return;
 
@@ -53,14 +52,8 @@ export function useGameBoardShortcuts(
         return;
       }
 
-      // --- 複製処理 (Cmd/Ctrl + D) ---
-      // key は小文字の 'd' になることがあるため toLowerCase で比較
-      if (
-        (e.metaKey || e.ctrlKey) &&
-        !e.altKey &&
-        !e.shiftKey &&
-        e.key.toLowerCase() === 'd'
-      ) {
+      // --- 複製処理 ---
+      if (KEYBOARD_SHORTCUTS.duplicatePart.match?.(e)) {
         // ハンドラが未定義なら無視
         if (!handleDuplicatePart) return;
 

--- a/frontend/src/utils/os.ts
+++ b/frontend/src/utils/os.ts
@@ -1,0 +1,6 @@
+export const IS_MAC =
+  typeof navigator !== 'undefined' &&
+  /Mac|iPod|iPhone|iPad/.test(navigator.platform);
+
+export const IS_WINDOWS =
+  typeof navigator !== 'undefined' && /Win/.test(navigator.platform);


### PR DESCRIPTION
## Summary
- detect platform to tailor shortcut labels and handlers
- centralize shortcut definitions
- update help panel, part menus, and debug mode to use new shortcuts

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bcedff99188326a0736088c07c9d7f