### PR TITLE
style: increase hover contrast for project name editor

### DIFF
--- a/frontend/src/features/prototype/components/atoms/PrototypeNameEditor.tsx
+++ b/frontend/src/features/prototype/components/atoms/PrototypeNameEditor.tsx
@@ -78,7 +78,7 @@ export default function PrototypeNameEditor({
           {/* 表示モード（ボタンで編集開始） */}
           <button
             type="button"
-            className="w-full text-left truncate cursor-pointer px-1 -mx-1 rounded-md hover:bg-kibako-tertiary transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-kibako-primary focus-visible:ring-offset-2 focus-visible:ring-offset-kibako-white"
+            className="w-full text-left truncate cursor-pointer px-1 -mx-1 rounded-md hover:bg-kibako-secondary/30 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-kibako-primary focus-visible:ring-offset-2 focus-visible:ring-offset-kibako-white"
             title={name}
             aria-label={`「${name}」を編集`}
             onClick={() => startEditing(prototypeId, name)}


### PR DESCRIPTION
## Summary
- increase hover background contrast for project name edit button

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bcf71b5c788326a1158de9394b7868

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined the hover background color of the edit button in the prototype name editor for improved visual consistency with the current design palette.
  * Enhances clarity and discoverability of the edit action with a subtler, more cohesive hover state.
  * Desktop hover interaction only; touch behavior remains unchanged.
  * No functional changes or settings affected—purely a UI polish update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->