### PR TITLE
refactor: use Loading component in ClientLayout

### DIFF
--- a/frontend/src/components/layouts/ClientLayout.tsx
+++ b/frontend/src/components/layouts/ClientLayout.tsx
@@ -6,6 +6,7 @@ import React, { useEffect } from 'react';
 
 import { WoodenCrateBackground } from '@/components/atoms/WoodenCrateBackground';
 import Header from '@/components/organisms/Header';
+import Loading from '@/components/organisms/Loading';
 import { useClientPathInfo } from '@/hooks/useClientPathInfo';
 import { useIsPC } from '@/hooks/useIsPC';
 
@@ -44,11 +45,7 @@ export default function ClientLayout({
   // デバイスチェック中は読み込み表示を返すことで、
   // サーバーサイドレンダリングとの整合性を保つ
   if (!isReady && pathname !== '/') {
-    return (
-      <div className="flex items-center justify-center min-h-screen">
-        <p>読み込み中...</p>
-      </div>
-    );
+    return <Loading />;
   }
 
   return (


### PR DESCRIPTION
## Summary
- replace hardcoded loading text with Loading component in ClientLayout

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd9a08c760832687cf19f4217af66d