### PR TITLE
test: add image upload service tests

### DIFF
--- a/backend/src/services/imageUploadService.test.ts
+++ b/backend/src/services/imageUploadService.test.ts
@@ -27,9 +27,9 @@ const mockedGenerateKey = generateS3KeyFromFilename as unknown as ReturnType<
 >;
 
 beforeEach(() => {
-  mockedSend.mockReset();
-  mockedCleanFileName.mockReset();
-  mockedGenerateKey.mockReset();
+  mockedSend.mockClear();
+  mockedCleanFileName.mockClear();
+  mockedGenerateKey.mockClear();
 });
 
 describe('uploadImageToS3', () => {

--- a/backend/src/services/imageUploadService.test.ts
+++ b/backend/src/services/imageUploadService.test.ts
@@ -1,12 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { uploadImageToS3 } from './imageUploadService';
-import s3Client from '../config/s3Client';
-import { IMAGE_MAX_SIZE } from '../constants/file';
-import {
-  cleanFileName,
-  generateS3KeyFromFilename,
-} from '../helpers/fileHelper';
 
+// Ensure mocks are registered before importing SUT and mocked modules
 vi.mock('../config/s3Client', () => ({
   default: { send: vi.fn() },
 }));
@@ -15,6 +9,14 @@ vi.mock('../helpers/fileHelper', () => ({
   cleanFileName: vi.fn((name: string) => name),
   generateS3KeyFromFilename: vi.fn(() => 'uploads/test-image.jpg'),
 }));
+
+import { uploadImageToS3 } from './imageUploadService';
+import s3Client from '../config/s3Client';
+import { IMAGE_MAX_SIZE } from '../constants/file';
+import {
+  cleanFileName,
+  generateS3KeyFromFilename,
+} from '../helpers/fileHelper';
 
 const mockedSend = s3Client.send as unknown as ReturnType<typeof vi.fn>;
 const mockedCleanFileName = cleanFileName as unknown as ReturnType<

--- a/backend/src/services/imageUploadService.test.ts
+++ b/backend/src/services/imageUploadService.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { uploadImageToS3 } from './imageUploadService';
+import s3Client from '../config/s3Client';
+import { IMAGE_MAX_SIZE } from '../constants/file';
+import {
+  cleanFileName,
+  generateS3KeyFromFilename,
+} from '../helpers/fileHelper';
+
+vi.mock('../config/s3Client', () => ({
+  default: { send: vi.fn() },
+}));
+
+vi.mock('../helpers/fileHelper', () => ({
+  cleanFileName: vi.fn((name: string) => name),
+  generateS3KeyFromFilename: vi.fn(() => 'uploads/test-image.jpg'),
+}));
+
+const mockedSend = s3Client.send as unknown as ReturnType<typeof vi.fn>;
+const mockedCleanFileName = cleanFileName as unknown as ReturnType<
+  typeof vi.fn
+>;
+const mockedGenerateKey = generateS3KeyFromFilename as unknown as ReturnType<
+  typeof vi.fn
+>;
+
+beforeEach(() => {
+  mockedSend.mockReset();
+  mockedCleanFileName.mockReset();
+  mockedGenerateKey.mockReset();
+});
+
+describe('uploadImageToS3', () => {
+  it('uploads JPEG file and returns metadata', async () => {
+    const jpgBase64 =
+      '/9j/4AAQSkZJRgABAQAAAQABAAD/2wCEAAEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQH/wAARCAAQABADASIAAhEBAxEB/8QAFwAAAwEAAAAAAAAAAAAAAAAAAAUGB//EABUBAQEAAAAAAAAAAAAAAAAAAAEF/8QAFQEBAQAAAAAAAAAAAAAAAAAAAgP/xAAUEQEAAAAAAAAAAAAAAAAAAAAA/9oADAMBAAIRAxEAPwD8/wD/AP/Z';
+    const buffer = Buffer.from(jpgBase64, 'base64');
+    const mockFile = {
+      originalname: 'test-image.jpg',
+      size: buffer.length,
+      buffer,
+    } as unknown as Express.Multer.File;
+
+    mockedSend.mockResolvedValue({ $metadata: { httpStatusCode: 200 } });
+
+    const result = await uploadImageToS3(mockFile);
+
+    expect(mockedSend).toHaveBeenCalledOnce();
+    expect(result).toEqual({
+      displayName: 'test-image.jpg',
+      storagePath: 'uploads/test-image.jpg',
+      contentType: 'image/jpeg',
+      fileSize: buffer.length,
+    });
+  });
+
+  it('throws ValidationError when file is too large', async () => {
+    const bigFile = {
+      originalname: 'big.jpg',
+      size: IMAGE_MAX_SIZE + 1,
+      buffer: Buffer.alloc(1),
+    } as unknown as Express.Multer.File;
+
+    await expect(uploadImageToS3(bigFile)).rejects.toMatchObject({
+      statusCode: 400,
+      message: expect.stringContaining('ファイルサイズが大きすぎます'),
+    });
+    expect(mockedSend).not.toHaveBeenCalled();
+  });
+
+  it('throws ValidationError for unsupported extension', async () => {
+    const buffer = Buffer.from('GIF89a');
+    const mockFile = {
+      originalname: 'image.gif',
+      size: buffer.length,
+      buffer,
+    } as unknown as Express.Multer.File;
+
+    await expect(uploadImageToS3(mockFile)).rejects.toMatchObject({
+      statusCode: 400,
+      message: expect.stringContaining('サポートされていない画像形式'),
+    });
+    expect(mockedSend).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for imageUploadService
- cover happy-path S3 upload and validation errors for size and extension

## Testing
- `cd backend && CI=1 npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bdb1e2aed48326bcba17a812ec5c9b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added unit tests for image upload behavior covering successful JPEG uploads, file size validation, and unsupported format handling.
  * Validates returned metadata (display name, storage path, content type, file size) for valid images.
  * Confirms appropriate validation errors and that uploads are not attempted for oversized or disallowed files.
  * Increases reliability and confidence in image upload flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->