### PR TITLE
fix: z-index issue for header user menu

### DIFF
--- a/frontend/src/components/molecules/UserMenu.tsx
+++ b/frontend/src/components/molecules/UserMenu.tsx
@@ -84,13 +84,13 @@ const UserMenu: React.FC<UserMenuProps> = ({ pathname }) => {
   }
 
   return (
-    <div className="relative z-dropdown" ref={menuRef}>
+    <div className="relative z-overlay" ref={menuRef}>
       <button onClick={() => setShowMenu(!showMenu)}>
         <UserAvatar username={user.username} size="lg" />
       </button>
 
       {showMenu && (
-        <div className="absolute right-0 top-full w-48 flex flex-col mt-2 shadow-xl rounded-lg overflow-hidden bg-kibako-tertiary border border-kibako-secondary/30">
+        <div className="absolute right-0 top-full z-overlay w-48 flex flex-col mt-2 shadow-xl rounded-lg overflow-hidden bg-kibako-tertiary border border-kibako-secondary/30">
           {/* ユーザー名表示行 */}
           <div className="flex items-center gap-3 p-3 bg-kibako-secondary/5 border-b border-kibako-secondary/20">
             <UserAvatar username={user.username} size="sm" />

--- a/frontend/src/components/organisms/Header.tsx
+++ b/frontend/src/components/organisms/Header.tsx
@@ -22,7 +22,7 @@ const Header: React.FC = () => {
   };
 
   return (
-    <header className="sticky top-0 z-sticky bg-kibako-primary/80 px-8 flex justify-between items-center h-20 backdrop-blur-sm">
+    <header className="sticky top-0 z-overlay bg-kibako-primary/80 px-8 flex justify-between items-center h-20 backdrop-blur-sm">
       <button onClick={goToTop}>
         <div className="flex gap-2">
           <GiWoodenCrate className="text-4xl drop-shadow-xl transform -rotate-6 text-kibako-white" />


### PR DESCRIPTION
Fix z-index so the header user menu renders above overlapping elements.

- Scope: frontend UI header menu layering
- Change: increase stacking context to bring menu to front

Please run `make dev` locally to verify UI behavior.

