### PR TITLE
fix: allow admin to delete other users' prototypes

### DIFF
--- a/frontend/src/features/prototype/components/organisms/DeletePrototypeConfirmation.tsx
+++ b/frontend/src/features/prototype/components/organisms/DeletePrototypeConfirmation.tsx
@@ -30,10 +30,6 @@ const DeletePrototypeConfirmation = () => {
         setMasterPrototype(
           project.prototypes.find(({ type }) => type === 'MASTER') || null
         );
-        // ユーザーがプロトタイプのオーナーでない場合はリダイレクト
-        if (user && project.userId !== user.id) {
-          router.push('/projects');
-        }
       } catch (err) {
         setError('プロトタイプの取得に失敗しました');
         console.error('Error fetching prototype:', err);


### PR DESCRIPTION
## Summary
- allow admins to delete any project by removing ownership redirect in delete confirmation page

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bdc0d95d1c8326a03ce85811398141

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an incorrect redirect on the prototype deletion confirmation screen that sent some users back to the projects list when they didn’t own the project. Users with access can now view the confirmation as expected.
  * No changes to the deletion UI or behavior; sign-in is still required. Navigation is now consistent for collaborators and shared access scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->