### PR TITLE
test: add uiPreferences localStorage tests

### DIFF
--- a/frontend/src/utils/__tests__/uiPreferences.test.ts
+++ b/frontend/src/utils/__tests__/uiPreferences.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+import { getUIPreference, setUIPreference } from '../uiPreferences';
+
+describe('uiPreferences', () => {
+  beforeEach(() => {
+    const store: Record<string, string> = {};
+    const localStorageMock = {
+      getItem: vi.fn((key: string) => (key in store ? store[key] : null)),
+      setItem: vi.fn((key: string, value: string) => {
+        store[key] = value;
+      }),
+      removeItem: vi.fn((key: string) => {
+        delete store[key];
+      }),
+      clear: vi.fn(() => {
+        Object.keys(store).forEach((key) => delete store[key]);
+      }),
+    };
+
+    vi.stubGlobal('window', {
+      localStorage: localStorageMock,
+    } as unknown as Window);
+  });
+
+  it('stores and retrieves projectListView preference', () => {
+    setUIPreference('projectListView', 'table');
+    expect(getUIPreference('projectListView')).toBe('table');
+  });
+});


### PR DESCRIPTION
## Summary
- add unit test for uiPreferences storing and retrieving projectListView preference

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bdc394fedc83269582a9c76b7b7099