### PR TITLE
test: add date formatting utility tests

### DIFF
--- a/frontend/src/utils/__tests__/dateFormat.test.ts
+++ b/frontend/src/utils/__tests__/dateFormat.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+
+import formatDate from '../dateFormat';
+
+describe('formatDate', () => {
+  it('formats a string date without time', () => {
+    const result = formatDate('2021-01-01');
+    expect(result).toBe('2021/01/01');
+  });
+
+  it('formats a Date object with time when withTime=true', () => {
+    const result = formatDate(new Date('2021-01-01'), true);
+    expect(result).toBe('2021/01/01 00:00:00');
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for `formatDate` utility covering string and `Date` inputs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bdc3908b948326865dfa7a440b4e82