### PR TITLE
test: add os detection utility tests

### DIFF
--- a/frontend/src/utils/__tests__/os.test.ts
+++ b/frontend/src/utils/__tests__/os.test.ts
@@ -1,0 +1,22 @@
+import { vi } from 'vitest';
+
+describe('os utils', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.resetModules();
+  });
+
+  test('detects macOS platform', async () => {
+    vi.spyOn(navigator, 'platform', 'get').mockReturnValue('MacIntel');
+    const { IS_MAC, IS_WINDOWS } = await import('../os');
+    expect(IS_MAC).toBe(true);
+    expect(IS_WINDOWS).toBe(false);
+  });
+
+  test('detects Windows platform', async () => {
+    vi.spyOn(navigator, 'platform', 'get').mockReturnValue('Win32');
+    const { IS_MAC, IS_WINDOWS } = await import('../os');
+    expect(IS_MAC).toBe(false);
+    expect(IS_WINDOWS).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for OS utilities that mock `navigator.platform` to verify `IS_MAC` and `IS_WINDOWS`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bdc3912460832699e957383a4b78e4