### PR TITLE
refactor: use common Loading component in role management page

### DIFF
--- a/frontend/src/features/role/components/organisms/RoleManagement.tsx
+++ b/frontend/src/features/role/components/organisms/RoleManagement.tsx
@@ -4,6 +4,7 @@ import { useParams, useRouter } from 'next/navigation';
 import React, { useState, useMemo, useEffect, useRef } from 'react';
 import { IoArrowBack } from 'react-icons/io5';
 
+import Loading from '@/components/organisms/Loading';
 import { useRoleManagement } from '@/features/role/hooks/useRoleManagement';
 
 import Toast from '../atoms/Toast';
@@ -162,27 +163,7 @@ const RoleManagement: React.FC = () => {
 
   // ローディング中の表示
   if (loading && userRoles.length === 0) {
-    return (
-      <div className="max-w-4xl mx-auto p-4 bg-kibako-white rounded-lg shadow mt-16">
-        <div className="flex items-center relative mb-6">
-          <button
-            onClick={() => router.back()}
-            className="p-2 hover:bg-kibako-tertiary/20 rounded-full transition-colors absolute left-0"
-            title="戻る"
-          >
-            <IoArrowBack className="h-5 w-5 text-kibako-primary hover:text-kibako-primary transition-colors" />
-          </button>
-          <h2 className="text-xl font-bold w-full text-center">権限設定</h2>
-        </div>
-
-        <div className="flex justify-center items-center py-12">
-          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-kibako-secondary"></div>
-          <span className="ml-3 text-kibako-primary">
-            権限情報を読み込み中...
-          </span>
-        </div>
-      </div>
-    );
+    return <Loading />;
   }
 
   return (


### PR DESCRIPTION
## Summary
- replace custom RoleManagement loading state with shared Loading component

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68be0da0b7f483268e5cf3363490da3c