### PR TITLE
feat: restrict project role assignment to admins

### DIFF
--- a/backend/src/routes/project.ts
+++ b/backend/src/routes/project.ts
@@ -6,6 +6,7 @@ import { ensureAuthenticated } from '../middlewares/auth';
 import {
   checkProjectReadPermission,
   checkProjectManagePermission,
+  checkProjectAdminRole,
 } from '../middlewares/permissions';
 import { getAccessiblePrototypes } from '../helpers/prototypeHelper';
 import sequelize from '../models';
@@ -934,7 +935,7 @@ router.get(
  */
 router.post(
   '/:projectId/roles',
-  checkProjectManagePermission,
+  checkProjectAdminRole,
   async (req: Request, res: Response) => {
     const { projectId } = req.params;
     const { userId, roleName } = req.body;
@@ -1020,7 +1021,7 @@ router.post(
  */
 router.delete(
   '/:projectId/roles/:userId',
-  checkProjectManagePermission,
+  checkProjectAdminRole,
   async (req: Request, res: Response) => {
     const { projectId, userId } = req.params;
 
@@ -1122,7 +1123,7 @@ router.delete(
  */
 router.put(
   '/:projectId/roles/:userId',
-  checkProjectManagePermission,
+  checkProjectAdminRole,
   async (req: Request, res: Response) => {
     const { projectId, userId } = req.params;
     const { roleName } = req.body;

--- a/frontend/src/features/role/components/molecules/RoleManagementForm.tsx
+++ b/frontend/src/features/role/components/molecules/RoleManagementForm.tsx
@@ -37,6 +37,7 @@ interface RoleManagementFormProps {
   onAddRole: () => void;
   onUpdateRole: () => void;
   loading: boolean;
+  canManageRole: boolean;
 }
 
 const RoleManagementForm: React.FC<RoleManagementFormProps> = ({
@@ -55,10 +56,15 @@ const RoleManagementForm: React.FC<RoleManagementFormProps> = ({
   onAddRole,
   onUpdateRole,
   loading,
+  canManageRole,
 }) => {
   return (
     <div className="mb-4">
-      <div className="bg-kibako-tertiary/20 border border-kibako-secondary/20 rounded-lg p-3">
+      <div
+        className={`bg-kibako-tertiary/20 border border-kibako-secondary/20 rounded-lg p-3 ${
+          canManageRole ? '' : 'opacity-50 pointer-events-none'
+        }`}
+      >
         {/* ヘッダー */}
         <div className="mb-3">
           <div className="flex items-center gap-2">
@@ -112,14 +118,14 @@ const RoleManagementForm: React.FC<RoleManagementFormProps> = ({
               <div className="flex gap-3">
                 <button
                   onClick={onCancelEdit}
-                  disabled={loading}
+                  disabled={loading || !canManageRole}
                   className="px-6 py-2 text-kibako-primary/70 border border-kibako-secondary/30 rounded-lg hover:bg-kibako-tertiary/20 transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
                 >
                   <span className="text-sm">キャンセル</span>
                 </button>
                 <button
                   onClick={onUpdateRole}
-                  disabled={loading}
+                  disabled={loading || !canManageRole}
                   className="px-6 py-2 bg-kibako-secondary hover:bg-kibako-secondary text-kibako-white rounded-md transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
                 >
                   {loading ? (
@@ -135,7 +141,7 @@ const RoleManagementForm: React.FC<RoleManagementFormProps> = ({
             ) : (
               <button
                 onClick={onAddRole}
-                disabled={!selectedUser || loading}
+                disabled={!selectedUser || loading || !canManageRole}
                 className="px-6 py-2 bg-kibako-secondary hover:bg-kibako-secondary text-kibako-white rounded-md transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
               >
                 {loading ? (

--- a/frontend/src/features/role/components/organisms/RoleManagement.tsx
+++ b/frontend/src/features/role/components/organisms/RoleManagement.tsx
@@ -44,6 +44,7 @@ const RoleManagement: React.FC = () => {
     creator,
     loading,
     canRemoveUserRole,
+    isCurrentUserAdmin,
 
     // UI状態
     roleForm,
@@ -204,6 +205,11 @@ const RoleManagement: React.FC = () => {
           {masterPrototypeName && `「${masterPrototypeName}」の`}
           ユーザー権限を管理します。
         </p>
+        {!isCurrentUserAdmin && (
+          <p className="mt-2 text-center text-kibako-primary/70">
+            権限を設定できるのはAdminユーザーのみです
+          </p>
+        )}
       </div>
 
       {/* ユーザー権限管理 */}
@@ -225,12 +231,15 @@ const RoleManagement: React.FC = () => {
           onAddRole={handleAddRoleWithReset}
           onUpdateRole={handleUpdateRoleWithReset}
           loading={loading}
+          canManageRole={isCurrentUserAdmin}
         />
 
         {/* 現在のユーザー権限一覧 */}
         <div
           className={`grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 transition-all ${
-            editMode.isEditing ? 'opacity-40 pointer-events-none' : ''
+            editMode.isEditing || !isCurrentUserAdmin
+              ? 'opacity-40 pointer-events-none'
+              : ''
           }`}
         >
           <UserRolesList


### PR DESCRIPTION
## Summary
- add admin-aware hook logic to guard role removal and expose current user admin status
- disable role management UI for non-admin users and show notice
- prevent non-admins from triggering role updates via disabled form controls

## Testing
- `npm run lint` (backend)
- `npm test` (backend)
- `npm run lint` (frontend)
- `npm test` (frontend)`

------
https://chatgpt.com/codex/tasks/task_e_68be0cf543e48326b59ce8b914988de2