### PR TITLE
feat: show role icon in right top menu

### DIFF
--- a/frontend/src/components/molecules/UserMenu.tsx
+++ b/frontend/src/components/molecules/UserMenu.tsx
@@ -4,6 +4,7 @@ import { useRouter } from 'next/navigation';
 import React, { useEffect, useRef, useState } from 'react';
 
 import { useAuth } from '@/api/hooks/useAuth';
+import { getRoleConfig } from '@/features/role/components/atoms/RoleBadge';
 import UserAvatar from '@/features/role/components/atoms/UserAvatar';
 import { useUser } from '@/hooks/useUser';
 
@@ -12,9 +13,10 @@ const FEEDBACK_FORM_URL = 'https://forms.gle/XjMV2WgFRCJg7cHj7';
 
 interface UserMenuProps {
   pathname: string;
+  roleName?: string;
 }
 
-const UserMenu: React.FC<UserMenuProps> = ({ pathname }) => {
+const UserMenu: React.FC<UserMenuProps> = ({ pathname, roleName }) => {
   const router = useRouter();
   const { user, setUser, isLoading } = useUser();
   const { logout } = useAuth();
@@ -60,6 +62,8 @@ const UserMenu: React.FC<UserMenuProps> = ({ pathname }) => {
       .catch((error) => console.error('Logout error:', error));
   };
 
+  const roleConfig = roleName ? getRoleConfig(roleName) : null;
+
   // ローディング時はnullを返す
   if (isLoading) {
     return null;
@@ -94,9 +98,14 @@ const UserMenu: React.FC<UserMenuProps> = ({ pathname }) => {
           {/* ユーザー名表示行 */}
           <div className="flex items-center gap-3 p-3 bg-kibako-secondary/5 border-b border-kibako-secondary/20">
             <UserAvatar username={user.username} size="sm" />
-            <span className="font-medium text-kibako-primary">
-              {user.username}
-            </span>
+            <div className="flex items-center gap-1">
+              {roleConfig && (
+                <span className={roleConfig.textColor}>{roleConfig.icon}</span>
+              )}
+              <span className="font-medium text-kibako-primary">
+                {user.username}
+              </span>
+            </div>
           </div>
 
           <Link

--- a/frontend/src/components/molecules/UserMenu.tsx
+++ b/frontend/src/components/molecules/UserMenu.tsx
@@ -4,7 +4,6 @@ import { useRouter } from 'next/navigation';
 import React, { useEffect, useRef, useState } from 'react';
 
 import { useAuth } from '@/api/hooks/useAuth';
-import { getRoleConfig } from '@/features/role/components/atoms/RoleBadge';
 import UserAvatar from '@/features/role/components/atoms/UserAvatar';
 import { useUser } from '@/hooks/useUser';
 
@@ -13,10 +12,9 @@ const FEEDBACK_FORM_URL = 'https://forms.gle/XjMV2WgFRCJg7cHj7';
 
 interface UserMenuProps {
   pathname: string;
-  roleName?: string;
 }
 
-const UserMenu: React.FC<UserMenuProps> = ({ pathname, roleName }) => {
+const UserMenu: React.FC<UserMenuProps> = ({ pathname }) => {
   const router = useRouter();
   const { user, setUser, isLoading } = useUser();
   const { logout } = useAuth();
@@ -62,8 +60,6 @@ const UserMenu: React.FC<UserMenuProps> = ({ pathname, roleName }) => {
       .catch((error) => console.error('Logout error:', error));
   };
 
-  const roleConfig = roleName ? getRoleConfig(roleName) : null;
-
   // ローディング時はnullを返す
   if (isLoading) {
     return null;
@@ -98,14 +94,9 @@ const UserMenu: React.FC<UserMenuProps> = ({ pathname, roleName }) => {
           {/* ユーザー名表示行 */}
           <div className="flex items-center gap-3 p-3 bg-kibako-secondary/5 border-b border-kibako-secondary/20">
             <UserAvatar username={user.username} size="sm" />
-            <div className="flex items-center gap-1">
-              {roleConfig && (
-                <span className={roleConfig.textColor}>{roleConfig.icon}</span>
-              )}
-              <span className="font-medium text-kibako-primary">
-                {user.username}
-              </span>
-            </div>
+            <span className="font-medium text-kibako-primary">
+              {user.username}
+            </span>
           </div>
 
           <Link

--- a/frontend/src/features/prototype/components/molecules/RightTopMenu.tsx
+++ b/frontend/src/features/prototype/components/molecules/RightTopMenu.tsx
@@ -116,20 +116,22 @@ export default function RightTopMenu({
                       title={user.username}
                     >
                       {isActive ? (
-                        <span
-                          className="inline-flex items-center gap-1 px-1 rounded border"
-                          style={{ borderColor: color }}
-                        >
+                        <span className="inline-flex items-center gap-1">
                           {roleConfig && (
                             <span className={roleConfig.textColor}>
                               {roleConfig.icon}
                             </span>
                           )}
                           <span
-                            className="inline-block w-2 h-2"
-                            style={{ backgroundColor: color }}
-                          />
-                          {user.username}
+                            className="inline-flex items-center gap-1 px-1 rounded border"
+                            style={{ borderColor: color }}
+                          >
+                            <span
+                              className="inline-block w-2 h-2"
+                              style={{ backgroundColor: color }}
+                            />
+                            {user.username}
+                          </span>
                         </span>
                       ) : (
                         <span className="inline-flex items-center gap-1">

--- a/frontend/src/features/prototype/components/molecules/RightTopMenu.tsx
+++ b/frontend/src/features/prototype/components/molecules/RightTopMenu.tsx
@@ -14,6 +14,7 @@ import ConnectedUserIcon from '@/features/prototype/components/atoms/ConnectedUs
 import { MAX_DISPLAY_USERS } from '@/features/prototype/constants/presence';
 import { ConnectedUser } from '@/features/prototype/types';
 import { getUserColor } from '@/features/prototype/utils/userColor';
+import { getRoleConfig } from '@/features/role/components/atoms/RoleBadge';
 
 interface RightTopMenuProps {
   // プロジェクト識別子
@@ -26,8 +27,6 @@ interface RightTopMenuProps {
   loading?: boolean;
   // 右側の権限管理ページリンクを表示するか
   showRoleManagementButton?: boolean;
-  // 現在のユーザーのロール名
-  currentUserRole?: string;
 }
 
 /**
@@ -41,7 +40,6 @@ export default function RightTopMenu({
   roleUsers,
   loading = false,
   showRoleManagementButton = true,
-  currentUserRole,
 }: RightTopMenuProps): ReactElement | null {
   const pathname = usePathname();
 
@@ -108,6 +106,9 @@ export default function RightTopMenu({
                   const color: string | undefined = isActive
                     ? getUserColor(user.userId, roleUsers)
                     : undefined;
+                  const roleConfig = user.roleName
+                    ? getRoleConfig(user.roleName)
+                    : null;
                   return (
                     <li
                       key={user.userId}
@@ -119,6 +120,11 @@ export default function RightTopMenu({
                           className="inline-flex items-center gap-1 px-1 rounded border"
                           style={{ borderColor: color }}
                         >
+                          {roleConfig && (
+                            <span className={roleConfig.textColor}>
+                              {roleConfig.icon}
+                            </span>
+                          )}
                           <span
                             className="inline-block w-2 h-2"
                             style={{ backgroundColor: color }}
@@ -126,7 +132,14 @@ export default function RightTopMenu({
                           {user.username}
                         </span>
                       ) : (
-                        user.username
+                        <span className="inline-flex items-center gap-1">
+                          {roleConfig && (
+                            <span className={roleConfig.textColor}>
+                              {roleConfig.icon}
+                            </span>
+                          )}
+                          {user.username}
+                        </span>
                       )}
                     </li>
                   );
@@ -152,7 +165,7 @@ export default function RightTopMenu({
       )}
 
       {/* ユーザーメニュー（右側） - 常時表示 */}
-      <UserMenu pathname={pathname} roleName={currentUserRole} />
+      <UserMenu pathname={pathname} />
     </div>
   );
 }

--- a/frontend/src/features/prototype/components/molecules/RightTopMenu.tsx
+++ b/frontend/src/features/prototype/components/molecules/RightTopMenu.tsx
@@ -26,6 +26,8 @@ interface RightTopMenuProps {
   loading?: boolean;
   // 右側の権限管理ページリンクを表示するか
   showRoleManagementButton?: boolean;
+  // 現在のユーザーのロール名
+  currentUserRole?: string;
 }
 
 /**
@@ -39,6 +41,7 @@ export default function RightTopMenu({
   roleUsers,
   loading = false,
   showRoleManagementButton = true,
+  currentUserRole,
 }: RightTopMenuProps): ReactElement | null {
   const pathname = usePathname();
 
@@ -149,7 +152,7 @@ export default function RightTopMenu({
       )}
 
       {/* ユーザーメニュー（右側） - 常時表示 */}
-      <UserMenu pathname={pathname} />
+      <UserMenu pathname={pathname} roleName={currentUserRole} />
     </div>
   );
 }

--- a/frontend/src/features/prototype/components/organisms/GameBoard.tsx
+++ b/frontend/src/features/prototype/components/organisms/GameBoard.tsx
@@ -113,6 +113,10 @@ export default function GameBoard({
     return [...active, ...inactive];
   }, [userRoles, connectedUsers]);
 
+  const currentUserRole = useMemo(() => {
+    return userRoles.find((ur) => ur.userId === currentUserId)?.roles[0]?.name;
+  }, [userRoles, currentUserId]);
+
   // 自分のユーザー情報（色付けに使用）
   const selfUser = useMemo(() => {
     return connectedUsers.find((u) => u.userId === currentUserId) || null;
@@ -559,6 +563,7 @@ export default function GameBoard({
             roleUsers={roleUsers}
             loading={false}
             showRoleManagementButton={gameBoardMode === GameBoardMode.CREATE}
+            currentUserRole={currentUserRole}
           />
         )}
 

--- a/frontend/src/features/prototype/components/organisms/GameBoard.tsx
+++ b/frontend/src/features/prototype/components/organisms/GameBoard.tsx
@@ -103,7 +103,11 @@ export default function GameBoard({
       new Map(
         (userRoles ?? []).map((ur) => [
           ur.userId,
-          { userId: ur.userId, username: ur.user.username } as ConnectedUser,
+          {
+            userId: ur.userId,
+            username: ur.user.username,
+            roleName: ur.roles[0]?.name,
+          } as ConnectedUser,
         ])
       ).values()
     );
@@ -112,10 +116,6 @@ export default function GameBoard({
     const inactive = uniqUsers.filter((u) => !connectedSet.has(u.userId));
     return [...active, ...inactive];
   }, [userRoles, connectedUsers]);
-
-  const currentUserRole = useMemo(() => {
-    return userRoles.find((ur) => ur.userId === currentUserId)?.roles[0]?.name;
-  }, [userRoles, currentUserId]);
 
   // 自分のユーザー情報（色付けに使用）
   const selfUser = useMemo(() => {
@@ -563,7 +563,6 @@ export default function GameBoard({
             roleUsers={roleUsers}
             loading={false}
             showRoleManagementButton={gameBoardMode === GameBoardMode.CREATE}
-            currentUserRole={currentUserRole}
           />
         )}
 

--- a/frontend/src/features/prototype/types/livePrototypeInformation.ts
+++ b/frontend/src/features/prototype/types/livePrototypeInformation.ts
@@ -4,4 +4,5 @@
 export type ConnectedUser = {
   userId: string;
   username: string;
+  roleName?: string;
 };

--- a/frontend/src/features/role/components/atoms/RoleBadge.tsx
+++ b/frontend/src/features/role/components/atoms/RoleBadge.tsx
@@ -7,44 +7,44 @@ interface RoleBadgeProps {
   size?: 'sm' | 'md';
 }
 
+export const getRoleConfig = (role: string) => {
+  switch (role) {
+    case 'admin':
+      return {
+        icon: <FaUserShield className="h-3 w-3" />,
+        bgColor: 'bg-kibako-danger/10',
+        textColor: 'text-kibako-danger/80',
+        label: 'Admin',
+      };
+    case 'editor':
+      return {
+        icon: <FaEdit className="h-3 w-3" />,
+        bgColor: 'bg-kibako-info/10',
+        textColor: 'text-kibako-info/80',
+        label: 'Editor',
+      };
+    case 'viewer':
+      return {
+        icon: <FaEye className="h-3 w-3" />,
+        bgColor: 'bg-kibako-tertiary/20',
+        textColor: 'text-kibako-primary/80',
+        label: 'Viewer',
+      };
+    default:
+      return {
+        icon: <FaEye className="h-3 w-3" />,
+        bgColor: 'bg-kibako-tertiary/20',
+        textColor: 'text-kibako-primary/80',
+        label: role.charAt(0).toUpperCase() + role.slice(1),
+      };
+  }
+};
+
 const RoleBadge: React.FC<RoleBadgeProps> = ({
   roleName,
   showIcon = true,
   size = 'md',
 }) => {
-  const getRoleConfig = (role: string) => {
-    switch (role) {
-      case 'admin':
-        return {
-          icon: <FaUserShield className="h-3 w-3" />,
-          bgColor: 'bg-kibako-danger/10',
-          textColor: 'text-kibako-danger/80',
-          label: 'Admin',
-        };
-      case 'editor':
-        return {
-          icon: <FaEdit className="h-3 w-3" />,
-          bgColor: 'bg-kibako-info/10',
-          textColor: 'text-kibako-info/80',
-          label: 'Editor',
-        };
-      case 'viewer':
-        return {
-          icon: <FaEye className="h-3 w-3" />,
-          bgColor: 'bg-kibako-tertiary/20',
-          textColor: 'text-kibako-primary/80',
-          label: 'Viewer',
-        };
-      default:
-        return {
-          icon: <FaEye className="h-3 w-3" />,
-          bgColor: 'bg-kibako-tertiary/20',
-          textColor: 'text-kibako-primary/80',
-          label: role.charAt(0).toUpperCase() + role.slice(1),
-        };
-    }
-  };
-
   const config = getRoleConfig(roleName);
   const sizeClasses =
     size === 'sm' ? 'text-xs px-1.5 py-0.5' : 'text-xs px-2 py-0.5';


### PR DESCRIPTION
## Summary
- show current role icon beside username in user menu
- pass role info through RightTopMenu and GameBoard
- export role config helper

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68be153c25a48326b39ca1e7d240f928