### PR TITLE
fix: prevent self role changes

### DIFF
--- a/frontend/src/features/role/components/molecules/UserRoleCard.tsx
+++ b/frontend/src/features/role/components/molecules/UserRoleCard.tsx
@@ -29,6 +29,10 @@ interface UserRoleCardProps {
   editMode: boolean;
 }
 
+/**
+ * 編集ボタンのタイトルを返す
+ * @returns タイトル文字列
+ */
 const getEditButtonTitle = ({
   isCreator,
   isSelf,
@@ -39,10 +43,14 @@ const getEditButtonTitle = ({
   isSelf: boolean;
   loading: boolean;
   editMode: boolean;
-}) => {
+}): string => {
+  // プロジェクト作成者の場合
   if (isCreator) return 'プロジェクト作成者の権限は変更できません';
+  // 自分自身の場合
   if (isSelf) return '自分の権限は変更できません';
+  // ローディング中の場合
   if (loading) return '処理中...';
+  // 編集モード中の場合
   if (editMode) return '編集モード中は変更できません';
   return '権限を変更';
 };

--- a/frontend/src/features/role/components/molecules/UserRoleCard.tsx
+++ b/frontend/src/features/role/components/molecules/UserRoleCard.tsx
@@ -19,6 +19,7 @@ interface UserRoleWithDetails {
 interface UserRoleCardProps {
   userRole: UserRoleWithDetails;
   isCreator: boolean;
+  isSelf: boolean;
   isLastAdmin: boolean;
   canRemove: boolean;
   removeReason: string;
@@ -28,9 +29,45 @@ interface UserRoleCardProps {
   editMode: boolean;
 }
 
+const getEditButtonTitle = ({
+  isCreator,
+  isSelf,
+  loading,
+  editMode,
+}: {
+  isCreator: boolean;
+  isSelf: boolean;
+  loading: boolean;
+  editMode: boolean;
+}) => {
+  if (isCreator) return 'プロジェクト作成者の権限は変更できません';
+  if (isSelf) return '自分の権限は変更できません';
+  if (loading) return '処理中...';
+  if (editMode) return '編集モード中は変更できません';
+  return '権限を変更';
+};
+
+const getRemoveButtonTitle = ({
+  canRemove,
+  removeReason,
+  loading,
+  editMode,
+}: {
+  canRemove: boolean;
+  removeReason: string;
+  loading: boolean;
+  editMode: boolean;
+}) => {
+  if (loading) return '処理中...';
+  if (editMode) return '編集モード中は削除できません';
+  if (canRemove) return '権限を削除';
+  return removeReason;
+};
+
 const UserRoleCard: React.FC<UserRoleCardProps> = ({
   userRole,
   isCreator,
+  isSelf,
   isLastAdmin: _isLastAdmin, // 現在未使用のため_プレフィックスを追加
   canRemove,
   removeReason,
@@ -40,6 +77,18 @@ const UserRoleCard: React.FC<UserRoleCardProps> = ({
   editMode,
 }) => {
   const primaryRole = userRole.roles[0];
+  const editTitle = getEditButtonTitle({
+    isCreator,
+    isSelf,
+    loading,
+    editMode,
+  });
+  const removeTitle = getRemoveButtonTitle({
+    canRemove,
+    removeReason,
+    loading,
+    editMode,
+  });
 
   return (
     <div
@@ -72,29 +121,13 @@ const UserRoleCard: React.FC<UserRoleCardProps> = ({
               onEdit(userRole.userId, userRole.user.username, primaryRole.name)
             }
             className={`p-2 rounded transition-colors ${
-              !isCreator && !loading && !editMode
-                ? 'text-kibako-primary/60 hover:text-kibako-secondary hover:bg-kibako-tertiary'
+              !isCreator && !isSelf && !loading && !editMode
+                ? 'text-kibako-primary/60 hover:text-kibako-secondary hover:bg-kibako-tertiary/40'
                 : 'text-kibako-secondary/50 cursor-not-allowed'
             }`}
-            title={
-              isCreator
-                ? 'プロジェクト作成者の権限は変更できません'
-                : loading
-                  ? '処理中...'
-                  : editMode
-                    ? '編集モード中は変更できません'
-                    : '権限を変更'
-            }
-            aria-label={
-              isCreator
-                ? 'プロジェクト作成者の権限は変更できません'
-                : loading
-                  ? '処理中...'
-                  : editMode
-                    ? '編集モード中は変更できません'
-                    : '権限を変更'
-            }
-            disabled={loading || isCreator || editMode}
+            title={editTitle}
+            aria-label={editTitle}
+            disabled={loading || isCreator || isSelf || editMode}
           >
             <AiOutlineUserSwitch className="h-4 w-4" />
           </button>
@@ -107,24 +140,8 @@ const UserRoleCard: React.FC<UserRoleCardProps> = ({
                 ? 'text-kibako-primary/60 hover:text-kibako-danger hover:bg-kibako-danger/30'
                 : 'text-kibako-secondary/50 cursor-not-allowed'
             }`}
-            title={
-              loading
-                ? '処理中...'
-                : editMode
-                  ? '編集モード中は削除できません'
-                  : canRemove
-                    ? '権限を削除'
-                    : removeReason
-            }
-            aria-label={
-              loading
-                ? '処理中...'
-                : editMode
-                  ? '編集モード中は削除できません'
-                  : canRemove
-                    ? '権限を削除'
-                    : removeReason
-            }
+            title={removeTitle}
+            aria-label={removeTitle}
             disabled={loading || !canRemove || editMode}
           >
             {loading ? (

--- a/frontend/src/features/role/components/molecules/UserRoleCard.tsx
+++ b/frontend/src/features/role/components/molecules/UserRoleCard.tsx
@@ -142,6 +142,7 @@ const UserRoleCard: React.FC<UserRoleCardProps> = ({
 
           {/* 削除ボタン */}
           <button
+            type="button"
             onClick={() => onRemove(userRole.userId)}
             className={`p-2 rounded transition-colors ${
               canRemove && !loading && !editMode

--- a/frontend/src/features/role/components/molecules/UserRolesList.tsx
+++ b/frontend/src/features/role/components/molecules/UserRolesList.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { FaUserShield } from 'react-icons/fa';
 
 import { User } from '@/api/types/data-contracts';
+import { useUser } from '@/hooks/useUser';
 
 import UserRoleCard from './UserRoleCard';
 
@@ -36,6 +37,7 @@ const UserRolesList: React.FC<UserRolesListProps> = ({
   loading,
   editMode,
 }) => {
+  const { user: currentUser } = useUser();
   if (userRoles.length === 0 && !loading) {
     return (
       <div className="col-span-full flex flex-col items-center justify-center py-12 text-kibako-secondary">
@@ -55,6 +57,7 @@ const UserRolesList: React.FC<UserRolesListProps> = ({
       {userRoles.map((userRole) => {
         const removeCheck = canRemoveUserRole(userRole.userId, userRoles);
         const isCreator = creator && creator.id === userRole.userId;
+        const isSelf = currentUser?.id === userRole.userId;
         const hasAdminRole = userRole.roles.some(
           (role) => role.name === 'admin'
         );
@@ -68,6 +71,7 @@ const UserRolesList: React.FC<UserRolesListProps> = ({
             key={userRole.userId}
             userRole={userRole}
             isCreator={!!isCreator}
+            isSelf={!!isSelf}
             isLastAdmin={isLastAdmin}
             canRemove={removeCheck.canRemove}
             removeReason={removeCheck.reason}

--- a/frontend/src/features/role/components/molecules/__tests__/UserRoleCard.test.tsx
+++ b/frontend/src/features/role/components/molecules/__tests__/UserRoleCard.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+import UserRoleCard from '../UserRoleCard';
+
+const baseUserRole = {
+  userId: 'current-user',
+  user: {
+    id: 'current-user',
+    username: 'me',
+    createdAt: '',
+    updatedAt: '',
+  },
+  roles: [{ name: 'editor', description: '' }],
+};
+
+describe('UserRoleCard', () => {
+  it('disables editing your own role with explanation', () => {
+    render(
+      <UserRoleCard
+        userRole={baseUserRole}
+        isCreator={false}
+        isSelf={true}
+        isLastAdmin={false}
+        canRemove={false}
+        removeReason="自分の権限は削除できません"
+        onEdit={vi.fn()}
+        onRemove={vi.fn()}
+        loading={false}
+        editMode={false}
+      />
+    );
+
+    const editButton = screen.getByRole('button', {
+      name: '自分の権限は変更できません',
+    });
+    expect(editButton).toBeDisabled();
+    expect(editButton).toHaveAttribute('title', '自分の権限は変更できません');
+  });
+
+  it('disables deleting your own role with explanation', () => {
+    render(
+      <UserRoleCard
+        userRole={baseUserRole}
+        isCreator={false}
+        isSelf={true}
+        isLastAdmin={false}
+        canRemove={false}
+        removeReason="自分の権限は削除できません"
+        onEdit={vi.fn()}
+        onRemove={vi.fn()}
+        loading={false}
+        editMode={false}
+      />
+    );
+
+    const deleteButton = screen.getByRole('button', {
+      name: '自分の権限は削除できません',
+    });
+    expect(deleteButton).toBeDisabled();
+    expect(deleteButton).toHaveAttribute('title', '自分の権限は削除できません');
+  });
+});

--- a/frontend/src/features/role/hooks/__tests__/useRoleManagement.test.ts
+++ b/frontend/src/features/role/hooks/__tests__/useRoleManagement.test.ts
@@ -1,0 +1,62 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { useRoleManagement } from '../useRoleManagement';
+
+vi.mock('@/hooks/useUser', () => ({
+  useUser: () => ({ user: { id: 'current-user', username: 'me' } }),
+}));
+
+const getProjectRoles = vi.fn().mockResolvedValue([]);
+const addRoleToProject = vi.fn();
+const removeRoleFromProject = vi.fn();
+const updateRoleInProject = vi.fn();
+const getProject = vi.fn().mockResolvedValue({ userId: 'creator-id' });
+
+vi.mock('@/api/hooks/useProject', () => ({
+  useProject: () => ({
+    getProjectRoles,
+    addRoleToProject,
+    removeRoleFromProject,
+    updateRoleInProject,
+    getProject,
+  }),
+}));
+
+const searchUsers = vi
+  .fn()
+  .mockResolvedValue([{ id: 'creator-id', username: 'creator' }]);
+
+vi.mock('@/api/hooks/useUsers', () => ({
+  useUsers: () => ({
+    searchUsers,
+  }),
+}));
+
+describe('useRoleManagement', () => {
+  it('disables deleting your own role', async () => {
+    const userRoles = [
+      {
+        userId: 'current-user',
+        user: {
+          id: 'current-user',
+          username: 'me',
+          createdAt: '',
+          updatedAt: '',
+        },
+        roles: [{ name: 'editor', description: '' }],
+      },
+    ];
+
+    const { result } = renderHook(() => useRoleManagement('project-1'));
+
+    await waitFor(() => {
+      const check = result.current.canRemoveUserRole('current-user', userRoles);
+      expect(check.reason).not.toBe('ユーザー情報が取得できません');
+    });
+
+    const check = result.current.canRemoveUserRole('current-user', userRoles);
+    expect(check.canRemove).toBe(false);
+    expect(check.reason).toBe('自分の権限は削除できません');
+  });
+});

--- a/frontend/src/features/role/hooks/useRoleManagement.ts
+++ b/frontend/src/features/role/hooks/useRoleManagement.ts
@@ -178,6 +178,7 @@ export const useRoleManagement = (projectId: string) => {
         return { canRemove: false, reason: 'ユーザー情報が取得できません' };
       }
 
+      // Admin 権限のみ削除操作が可能
       if (!isCurrentUserAdmin) {
         return {
           canRemove: false,
@@ -185,6 +186,12 @@ export const useRoleManagement = (projectId: string) => {
         };
       }
 
+      // 自分自身の権限は削除不可
+      if (currentUser.id === targetUserId) {
+        return { canRemove: false, reason: '自分の権限は削除できません' };
+      }
+
+      // プロジェクトの作成者の場合は削除不可
       if (projectDetail.userId === targetUserId) {
         return {
           canRemove: false,

--- a/frontend/src/features/role/hooks/useRoleManagement.ts
+++ b/frontend/src/features/role/hooks/useRoleManagement.ts
@@ -178,17 +178,17 @@ export const useRoleManagement = (projectId: string) => {
         return { canRemove: false, reason: 'ユーザー情報が取得できません' };
       }
 
+      // 自分自身の権限は削除不可（このチェックを最優先）
+      if (currentUser.id === targetUserId) {
+        return { canRemove: false, reason: '自分の権限は削除できません' };
+      }
+
       // Admin 権限のみ削除操作が可能
       if (!isCurrentUserAdmin) {
         return {
           canRemove: false,
           reason: '権限を設定できるのはAdminユーザーのみです',
         };
-      }
-
-      // 自分自身の権限は削除不可
-      if (currentUser.id === targetUserId) {
-        return { canRemove: false, reason: '自分の権限は削除できません' };
       }
 
       // プロジェクトの作成者の場合は削除不可


### PR DESCRIPTION
## Summary
- avoid deleting your own role by disabling removal and edit actions for the current user with accessible feedback
- extract role card button title helpers and add regression tests covering self-role removal and editing safeguards

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68be1340646c8326a3fef8a601afaa19

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented users from editing or removing their own role. Edit/delete buttons are disabled when viewing your own role, ensuring consistent protection across role management.

* **Improvements**
  * Added clear, localized (Japanese) tooltips and aria-labels explaining why actions are disabled, improving clarity and accessibility.

* **Tests**
  * Added unit tests covering self-edit and self-removal restrictions and corresponding messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->