### PR TITLE
fix: decode uploaded filenames to prevent garbling

### DIFF
--- a/backend/src/services/imageUploadService.ts
+++ b/backend/src/services/imageUploadService.ts
@@ -38,8 +38,13 @@ export const uploadImageToS3 = async (
     );
   }
 
+  // ファイル名はブラウザからlatin1で送られるため、明示的にUTF-8へ変換
+  const originalName = Buffer.from(file.originalname, 'latin1').toString(
+    'utf8'
+  );
+
   // 拡張子ベースの簡易的なMIMEタイプ判定
-  const extension = path.extname(file.originalname).toLowerCase();
+  const extension = path.extname(originalName).toLowerCase();
   let mime: string | undefined;
   if (extension === '.jpg' || extension === '.jpeg') {
     mime = 'image/jpeg';
@@ -52,7 +57,7 @@ export const uploadImageToS3 = async (
     );
   }
 
-  const cleanName = cleanFileName(file.originalname);
+  const cleanName = cleanFileName(originalName);
   const key = generateS3KeyFromFilename(cleanName);
   const command = new PutObjectCommand({
     Bucket: bucketName,


### PR DESCRIPTION
## Summary
- decode `file.originalname` from latin1 to UTF-8 before sanitizing and uploading
- test upload service against latin1-encoded filenames

## Testing
- `cd backend && npm test`
- `cd backend && npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68beeb213ac883268a2aeca15919e9c5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Correctly handles international and non-ASCII filenames during image upload by decoding names properly.
  - Ensures accurate file extension/content type detection and sanitized display names without altering storage paths.
  - Improves reliability for uploads containing characters from languages like Japanese.

- Tests
  - Added tests covering filename encoding/decoding, sanitization, and existing JPEG upload behavior.
  - Introduced setup to ensure isolated, reliable test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->