### PR TITLE
feat: restrict project deletion to admins

### DIFF
--- a/backend/src/routes/project.ts
+++ b/backend/src/routes/project.ts
@@ -433,7 +433,7 @@ router.get(
  */
 router.delete(
   '/:projectId',
-  checkProjectManagePermission,
+  checkProjectAdminRole,
   async (req: Request, res: Response, next: NextFunction) => {
     const projectId = req.params.projectId;
 

--- a/frontend/src/features/prototype/components/atoms/RowIconButton.tsx
+++ b/frontend/src/features/prototype/components/atoms/RowIconButton.tsx
@@ -6,6 +6,7 @@ type RowIconButtonProps = {
   onClick?: () => void;
   variant?: 'neutral' | 'danger';
   className?: string;
+  disabled?: boolean;
   children: React.ReactNode;
 };
 
@@ -15,6 +16,7 @@ const RowIconButton: React.FC<RowIconButtonProps> = ({
   onClick,
   variant = 'neutral',
   className = '',
+  disabled = false,
   children,
 }) => {
   const base =
@@ -25,6 +27,7 @@ const RowIconButton: React.FC<RowIconButtonProps> = ({
     'border border-red-200 bg-white text-red-600 hover:bg-red-100 hover:border-red-400 hover:text-red-700 hover:shadow focus:ring-2 focus:ring-red-300';
 
   const variantClass = variant === 'danger' ? danger : neutral;
+  const disabledClass = disabled ? ' opacity-50 cursor-not-allowed' : '';
 
   return (
     <button
@@ -32,7 +35,9 @@ const RowIconButton: React.FC<RowIconButtonProps> = ({
       aria-label={ariaLabel}
       title={title}
       onClick={onClick}
-      className={`${base} ${variantClass} ${className}`}
+      disabled={disabled}
+      aria-disabled={disabled}
+      className={`${base} ${variantClass}${disabledClass} ${className}`}
     >
       {children}
     </button>

--- a/frontend/src/features/prototype/components/molecules/ProjectTable.tsx
+++ b/frontend/src/features/prototype/components/molecules/ProjectTable.tsx
@@ -25,6 +25,7 @@ type ProjectTableProps = {
   sortOrder: 'asc' | 'desc';
   onSort: (key: ProjectTableSortKey) => void;
   onSelectPrototype: (projectId: string, prototypeId: string) => void;
+  projectAdminMap: Record<string, boolean>;
 };
 
 export const ProjectTable: React.FC<ProjectTableProps> = ({
@@ -33,6 +34,7 @@ export const ProjectTable: React.FC<ProjectTableProps> = ({
   sortOrder,
   onSort,
   onSelectPrototype,
+  projectAdminMap,
 }) => {
   // 即時反映用: 名前更新が完了した行の一時表示名
   const [updatedNames, setUpdatedNames] = useState<Record<string, string>>({});
@@ -148,14 +150,16 @@ export const ProjectTable: React.FC<ProjectTableProps> = ({
                 >
                   <FaUsers className="h-4 w-4" />
                 </RowIconLink>
-                <RowIconLink
-                  href={`/projects/${project.id}/delete`}
-                  ariaLabel="削除"
-                  title="削除"
-                  variant="danger"
-                >
-                  <FaTrash className="h-4 w-4" />
-                </RowIconLink>
+                {projectAdminMap[project.id] && (
+                  <RowIconLink
+                    href={`/projects/${project.id}/delete`}
+                    ariaLabel="削除"
+                    title="削除"
+                    variant="danger"
+                  >
+                    <FaTrash className="h-4 w-4" />
+                  </RowIconLink>
+                )}
               </div>
             </td>
           </tr>

--- a/frontend/src/features/prototype/components/molecules/ProjectTable.tsx
+++ b/frontend/src/features/prototype/components/molecules/ProjectTable.tsx
@@ -150,7 +150,7 @@ export const ProjectTable: React.FC<ProjectTableProps> = ({
                 >
                   <FaUsers className="h-4 w-4" />
                 </RowIconLink>
-                {projectAdminMap[project.id] && (
+                {projectAdminMap[project.id] ? (
                   <RowIconLink
                     href={`/projects/${project.id}/delete`}
                     ariaLabel="削除"
@@ -159,6 +159,15 @@ export const ProjectTable: React.FC<ProjectTableProps> = ({
                   >
                     <FaTrash className="h-4 w-4" />
                   </RowIconLink>
+                ) : (
+                  <RowIconButton
+                    ariaLabel="削除"
+                    title="削除は管理者のみ可能です"
+                    variant="danger"
+                    disabled
+                  >
+                    <FaTrash className="h-4 w-4" />
+                  </RowIconButton>
                 )}
               </div>
             </td>

--- a/frontend/src/features/prototype/components/organisms/DeletePrototypeConfirmation.tsx
+++ b/frontend/src/features/prototype/components/organisms/DeletePrototypeConfirmation.tsx
@@ -17,10 +17,10 @@ const DeletePrototypeConfirmation = () => {
   const [masterPrototype, setMasterPrototype] = useState<Prototype | null>(
     null
   );
-  const [isLoading, setIsLoading] = useState(true);
-  const [isDeleting, setIsDeleting] = useState(false);
+  const [isLoading, setIsLoading] = useState<boolean>(true);
+  const [isDeleting, setIsDeleting] = useState<boolean>(false);
   const [error, setError] = useState<string | null>(null);
-  const [isAdmin, setIsAdmin] = useState(false);
+  const [isAdmin, setIsAdmin] = useState<boolean>(false);
 
   useEffect(() => {
     const fetchProject = async () => {


### PR DESCRIPTION
## Summary
- hide project delete actions unless user has admin role
- disable deletion UI when non-admin and enforce admin-only deletion on backend

## Testing
- `npm run lint` (backend)
- `npm test` (backend)
- `npm run lint` (frontend)
- `npm test` (frontend)`

------
https://chatgpt.com/codex/tasks/task_e_68bf7860ba6c8326ba2dbefb30ce69b9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Per-project admin detection in project lists and tables.
  - Delete option shown only to admins across project views.
  - Delete confirmation disables action for non-admins and shows a warning about required admin privileges.
  - Buttons support a disabled state with appropriate styling and accessibility attributes.

- Bug Fixes
  - Server now enforces that only project admins can delete projects.

- Chores
  - Components updated to accept and propagate per-project admin status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->