### PR TITLE
fix: restrict project name editing to admins

### DIFF
--- a/frontend/src/features/prototype/components/molecules/LeftSidebar.tsx
+++ b/frontend/src/features/prototype/components/molecules/LeftSidebar.tsx
@@ -332,7 +332,7 @@ export default function LeftSidebar({
             prototypeId={prototypeId}
             name={prototypeName}
             onUpdated={handlePrototypeNameUpdated}
-            editable={currentRole !== 'viewer' && currentRole !== null}
+            editable={currentRole === 'admin'}
           />
         </div>
         {/* プレイルームを開いている時は開閉ボタンを非表示 */}

--- a/frontend/src/features/prototype/components/molecules/ProjectCard.tsx
+++ b/frontend/src/features/prototype/components/molecules/ProjectCard.tsx
@@ -15,6 +15,8 @@ type ProjectCardProps = {
   project: Project;
   // マスタープロトタイプ情報
   masterPrototype: Prototype;
+  // 管理者権限を持つかどうか
+  isProjectAdmin: boolean;
   // 編集関連
   isNameEditing: boolean;
   editedName: string;
@@ -37,6 +39,7 @@ type ProjectCardProps = {
 export const ProjectCard: React.FC<ProjectCardProps> = ({
   project,
   masterPrototype,
+  isProjectAdmin,
   onCardClick,
   onContextMenu,
 }) => {
@@ -76,6 +79,7 @@ export const ProjectCard: React.FC<ProjectCardProps> = ({
               truncate={false}
               bleedX={false}
               onUpdated={(newName) => setUpdatedName(newName)}
+              editable={isProjectAdmin}
             />
           </div>
         </div>

--- a/frontend/src/features/prototype/components/molecules/ProjectCardList.tsx
+++ b/frontend/src/features/prototype/components/molecules/ProjectCardList.tsx
@@ -5,6 +5,7 @@ import { ProjectCard } from '@/features/prototype/components/molecules/ProjectCa
 
 type ProjectCardListProps = {
   prototypeList: { project: Project; masterPrototype: Prototype }[];
+  projectAdminMap: Record<string, boolean>;
   // 編集状態と値
   isNameEditing: (prototypeId: string) => boolean;
   editedName: string;
@@ -23,6 +24,7 @@ type ProjectCardListProps = {
 
 export const ProjectCardList: React.FC<ProjectCardListProps> = ({
   prototypeList,
+  projectAdminMap,
   isNameEditing,
   editedName,
   setEditedName,
@@ -38,6 +40,7 @@ export const ProjectCardList: React.FC<ProjectCardListProps> = ({
         if (!masterPrototype) return null;
         const { id } = masterPrototype;
         const nameEditing = isNameEditing(id);
+        const isProjectAdmin = projectAdminMap[project.id];
 
         const handleCardClick = () => onCardClick(project.id, id);
 
@@ -46,6 +49,7 @@ export const ProjectCardList: React.FC<ProjectCardListProps> = ({
             key={id}
             project={project}
             masterPrototype={masterPrototype}
+            isProjectAdmin={isProjectAdmin}
             isNameEditing={nameEditing}
             editedName={editedName}
             setEditedName={setEditedName}

--- a/frontend/src/features/prototype/components/molecules/ProjectTable.tsx
+++ b/frontend/src/features/prototype/components/molecules/ProjectTable.tsx
@@ -100,7 +100,9 @@ export const ProjectTable: React.FC<ProjectTableProps> = ({
                   type="button"
                   aria-label="開く"
                   title="開く"
-                  onClick={() => onSelectPrototype(project.id, masterPrototype.id)}
+                  onClick={() =>
+                    onSelectPrototype(project.id, masterPrototype.id)
+                  }
                   className="p-1 rounded hover:bg-kibako-accent/20 focus:outline-none focus:ring-2 focus:ring-kibako-accent/50"
                 >
                   {renderIcon(masterPrototype.id)}
@@ -118,6 +120,7 @@ export const ProjectTable: React.FC<ProjectTableProps> = ({
                         [masterPrototype.id]: newName,
                       }))
                     }
+                    editable={projectAdminMap[project.id]}
                   />
                 </div>
               </div>
@@ -139,7 +142,9 @@ export const ProjectTable: React.FC<ProjectTableProps> = ({
                 <RowIconButton
                   ariaLabel="開く"
                   title="開く"
-                  onClick={() => onSelectPrototype(project.id, masterPrototype.id)}
+                  onClick={() =>
+                    onSelectPrototype(project.id, masterPrototype.id)
+                  }
                 >
                   <FaFolderOpen className="h-4 w-4" />
                 </RowIconButton>

--- a/frontend/src/features/prototype/components/organisms/ProjectList.tsx
+++ b/frontend/src/features/prototype/components/organisms/ProjectList.tsx
@@ -470,6 +470,7 @@ const ProjectList: React.FC = () => {
             (item): item is { project: Project; masterPrototype: Prototype } =>
               !!item.masterPrototype
           )}
+          projectAdminMap={projectAdminMap}
           isNameEditing={(prototypeId) => isEditing(prototypeId)}
           editedName={editedName}
           setEditedName={setEditedName}


### PR DESCRIPTION
## Summary
- prevent non-admin users from renaming projects in card and table views
- restrict master prototype name editing in left sidebar to admins

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bf8e6c0b14832692a9254c6e1a96ec

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Prototype name editing is now restricted to project admins across table and card views.
  * Project lists and cards are admin-aware, showing editable fields only for admins and read-only for others.

* Style
  * Minor formatting cleanups with no impact on behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->