### PR TITLE
feat: support duplicating projects

### DIFF
--- a/backend/src/factories/prototypeFactory.test.ts
+++ b/backend/src/factories/prototypeFactory.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Transaction } from 'sequelize';
 
 import { duplicateProject } from './prototypeFactory';
 import PrototypeModel from '../models/Prototype';
@@ -104,7 +105,7 @@ describe('duplicateProject', () => {
     const result = await duplicateProject({
       projectId: 'proj1',
       userId: 'user2',
-      transaction: {} as any,
+      transaction: {} as unknown as Transaction,
     });
 
     expect(projectCreate).toHaveBeenCalled();

--- a/backend/src/factories/prototypeFactory.test.ts
+++ b/backend/src/factories/prototypeFactory.test.ts
@@ -72,7 +72,7 @@ describe('duplicateProject', () => {
     prototypeCreate.mockResolvedValue({
       id: 'new-master',
       projectId: 'new-project',
-      name: 'Master',
+      name: 'Master-copy',
       type: 'MASTER',
     });
     partFindAll.mockResolvedValue([
@@ -110,6 +110,10 @@ describe('duplicateProject', () => {
 
     expect(projectCreate).toHaveBeenCalled();
     expect(prototypeCreate).toHaveBeenCalled();
+    expect(prototypeCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'Master-copy' }),
+      expect.anything()
+    );
     expect(partCreate).toHaveBeenCalled();
     expect(partPropertyCreate).toHaveBeenCalled();
     expect(assignRoleMock).toHaveBeenCalled();

--- a/backend/src/factories/prototypeFactory.test.ts
+++ b/backend/src/factories/prototypeFactory.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { duplicateProject } from './prototypeFactory';
+import PrototypeModel from '../models/Prototype';
+import ProjectModel from '../models/Project';
+import PartModel from '../models/Part';
+import PartPropertyModel from '../models/PartProperty';
+import RoleModel from '../models/Role';
+import { assignRole } from '../helpers/roleHelper';
+
+vi.mock('../models/Prototype', () => ({
+  default: { findOne: vi.fn(), create: vi.fn() },
+}));
+vi.mock('../models/Project', () => ({
+  default: { create: vi.fn() },
+}));
+vi.mock('../models/Part', () => ({
+  default: { findAll: vi.fn(), create: vi.fn() },
+}));
+vi.mock('../models/PartProperty', () => ({
+  default: { findAll: vi.fn(), create: vi.fn() },
+}));
+vi.mock('../models/Role', () => ({
+  default: { findOne: vi.fn() },
+}));
+vi.mock('../helpers/roleHelper', () => ({
+  assignRole: vi.fn(),
+}));
+
+const prototypeFindOne = PrototypeModel.findOne as unknown as ReturnType<
+  typeof vi.fn
+>;
+const prototypeCreate = PrototypeModel.create as unknown as ReturnType<
+  typeof vi.fn
+>;
+const projectCreate = ProjectModel.create as unknown as ReturnType<
+  typeof vi.fn
+>;
+const partFindAll = PartModel.findAll as unknown as ReturnType<typeof vi.fn>;
+const partCreate = PartModel.create as unknown as ReturnType<typeof vi.fn>;
+const partPropertyFindAll = PartPropertyModel.findAll as unknown as ReturnType<
+  typeof vi.fn
+>;
+const partPropertyCreate = PartPropertyModel.create as unknown as ReturnType<
+  typeof vi.fn
+>;
+const roleFindOne = RoleModel.findOne as unknown as ReturnType<typeof vi.fn>;
+const assignRoleMock = assignRole as unknown as ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  prototypeFindOne.mockReset();
+  prototypeCreate.mockReset();
+  projectCreate.mockReset();
+  partFindAll.mockReset();
+  partCreate.mockReset();
+  partPropertyFindAll.mockReset();
+  partPropertyCreate.mockReset();
+  roleFindOne.mockReset();
+  assignRoleMock.mockReset();
+});
+
+describe('duplicateProject', () => {
+  it('duplicates a project with its master prototype', async () => {
+    prototypeFindOne.mockResolvedValue({
+      id: 'master1',
+      name: 'Master',
+      projectId: 'proj1',
+      type: 'MASTER',
+    });
+    projectCreate.mockResolvedValue({ id: 'new-project', userId: 'user2' });
+    prototypeCreate.mockResolvedValue({
+      id: 'new-master',
+      projectId: 'new-project',
+      name: 'Master',
+      type: 'MASTER',
+    });
+    partFindAll.mockResolvedValue([
+      {
+        id: 1,
+        type: 'card',
+        prototypeId: 'master1',
+        position: { x: 0, y: 0 },
+        width: 10,
+        height: 20,
+        order: 1,
+        frontSide: 'front',
+        ownerId: null,
+      },
+    ]);
+    partPropertyFindAll.mockResolvedValue([
+      {
+        partId: 1,
+        side: 'front',
+        name: 'name',
+        description: 'desc',
+        color: '#fff',
+        textColor: '#000',
+        imageId: null,
+      },
+    ]);
+    partCreate.mockResolvedValue({ id: 2 });
+    roleFindOne.mockResolvedValue({ id: 'role-admin' });
+
+    const result = await duplicateProject({
+      projectId: 'proj1',
+      userId: 'user2',
+      transaction: {} as any,
+    });
+
+    expect(projectCreate).toHaveBeenCalled();
+    expect(prototypeCreate).toHaveBeenCalled();
+    expect(partCreate).toHaveBeenCalled();
+    expect(partPropertyCreate).toHaveBeenCalled();
+    expect(assignRoleMock).toHaveBeenCalled();
+    expect(result.project.id).toBe('new-project');
+    expect(result.prototypes[0].id).toBe('new-master');
+  });
+});

--- a/backend/src/factories/prototypeFactory.ts
+++ b/backend/src/factories/prototypeFactory.ts
@@ -175,13 +175,18 @@ export async function duplicateProject({
   if (!adminRole) {
     throw new Error('管理者ロールが見つかりません');
   }
-  await assignRole(
-    userId,
-    adminRole.id,
-    RESOURCE_TYPES.PROJECT,
-    project.id,
-    transaction
-  );
+  try {
+    await assignRole(
+      userId,
+      adminRole.id,
+      RESOURCE_TYPES.PROJECT,
+      project.id,
+      transaction
+    );
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    throw new Error(`ロール割り当てに失敗しました: ${errorMessage}`);
+  }
 
   return {
     project,

--- a/backend/src/factories/prototypeFactory.ts
+++ b/backend/src/factories/prototypeFactory.ts
@@ -109,7 +109,7 @@ export async function duplicateProject({
   const masterPrototype = await PrototypeModel.create(
     {
       projectId: project.id,
-      name: originalMaster.name,
+      name: `${originalMaster.name}-copy`,
       type: 'MASTER',
     },
     { transaction }

--- a/backend/src/factories/prototypeFactory.ts
+++ b/backend/src/factories/prototypeFactory.ts
@@ -72,6 +72,124 @@ export async function createProject({
 }
 
 /**
+ * 既存プロジェクトを複製する
+ *
+ * @param projectId - 複製元のプロジェクトID
+ * @param userId - 新しいプロジェクトの所有者となるユーザーID
+ * @param transaction - トランザクション
+ * @returns 作成したプロジェクトとマスタープロトタイプ
+ */
+export async function duplicateProject({
+  projectId,
+  userId,
+  transaction,
+}: {
+  projectId: string;
+  userId: string;
+  transaction: Transaction;
+}) {
+  // 元のマスタープロトタイプを取得
+  const originalMaster = await PrototypeModel.findOne({
+    where: { projectId, type: 'MASTER' },
+    transaction,
+  });
+  if (!originalMaster) {
+    throw new Error('マスタープロトタイプが見つかりません');
+  }
+
+  // 新しいプロジェクトを作成
+  const project = await ProjectModel.create(
+    {
+      userId,
+    },
+    { transaction }
+  );
+
+  // 新しいマスタープロトタイプを作成（名前は元と同じ）
+  const masterPrototype = await PrototypeModel.create(
+    {
+      projectId: project.id,
+      name: originalMaster.name,
+      type: 'MASTER',
+    },
+    { transaction }
+  );
+
+  // 元のマスタープロトタイプのパーツを取得
+  const masterParts = await PartModel.findAll({
+    where: {
+      prototypeId: originalMaster.id,
+    },
+    transaction,
+  });
+
+  // パーツのプロパティを取得
+  const masterPartProperties = await PartPropertyModel.findAll({
+    where: {
+      partId: masterParts.map((part) => part.id),
+    },
+    transaction,
+  });
+
+  // 新しいパーツを作成し、IDマッピングを保持
+  const partIdMap: Record<string, number> = {};
+  for (const part of masterParts) {
+    const newPart = await PartModel.create(
+      {
+        type: part.type,
+        prototypeId: masterPrototype.id,
+        position: part.position,
+        width: part.width,
+        height: part.height,
+        order: part.order,
+        frontSide: part.frontSide,
+        ownerId: part.ownerId ?? null,
+      },
+      { transaction, returning: true }
+    );
+    partIdMap[String(part.id)] = newPart.id;
+  }
+
+  // 各パーツのプロパティを複製
+  for (const prop of masterPartProperties) {
+    const newPartId = partIdMap[String(prop.partId)];
+    if (!newPartId) continue;
+    await PartPropertyModel.create(
+      {
+        partId: newPartId,
+        side: prop.side,
+        name: prop.name,
+        description: prop.description,
+        color: prop.color,
+        textColor: prop.textColor,
+        imageId: prop.imageId,
+      },
+      { transaction }
+    );
+  }
+
+  // 新しいプロジェクトの作成者にadminロールを付与
+  const adminRole = await RoleModel.findOne({
+    where: { name: ROLE_TYPE.ADMIN },
+  });
+  if (!adminRole) {
+    throw new Error('管理者ロールが見つかりません');
+  }
+  await assignRole(
+    userId,
+    adminRole.id,
+    RESOURCE_TYPES.PROJECT,
+    project.id,
+    transaction
+  );
+
+  return {
+    project,
+    prototypes: [masterPrototype],
+  };
+}
+
+/**
  * プロトタイプバージョンを作成する（MASTERをコピーし、INSTANCEも同時に作成）
  *
  * @param projectId - プロジェクトID

--- a/backend/src/routes/project.ts
+++ b/backend/src/routes/project.ts
@@ -13,6 +13,7 @@ import sequelize from '../models';
 import {
   createProject,
   createPrototypeVersion,
+  duplicateProject,
 } from '../factories/prototypeFactory';
 import { Op } from 'sequelize';
 import { getAccessibleUsers } from '../helpers/userHelper';
@@ -27,7 +28,6 @@ import {
   NotFoundError,
   ValidationError,
   ConflictError,
-  NotImplementedError,
 } from '../errors/CustomError';
 
 const router = express.Router();
@@ -737,12 +737,21 @@ router.post(
   '/:projectId/duplicate',
   checkProjectReadPermission,
   async (req: Request, res: Response, next: NextFunction) => {
-    // const projectId = req.params.projectId;
+    const user = req.user as UserModel;
+    const { projectId } = req.params;
 
+    const transaction = await sequelize.transaction();
     try {
-      // TODO: プロジェクトの複製
-      throw new NotImplementedError('未実装');
+      const duplicated = await duplicateProject({
+        projectId,
+        userId: user.id,
+        transaction,
+      });
+
+      await transaction.commit();
+      res.json(duplicated);
     } catch (error) {
+      await transaction.rollback();
       next(error);
     }
   }

--- a/backend/swagger-output.json
+++ b/backend/swagger-output.json
@@ -792,7 +792,49 @@
                       "prototypes": {
                         "type": "array",
                         "items": {
-                          "$ref": "#/components/schemas/Prototype"
+                          "allOf": [
+                            {
+                              "$ref": "#/components/schemas/Prototype"
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "parts": {
+                                  "type": "array",
+                                  "items": {
+                                    "allOf": [
+                                      {
+                                        "$ref": "#/components/schemas/Part"
+                                      },
+                                      {
+                                        "type": "object",
+                                        "properties": {
+                                          "partProperties": {
+                                            "type": "array",
+                                            "items": {
+                                              "allOf": [
+                                                {
+                                                  "$ref": "#/components/schemas/PartProperty"
+                                                },
+                                                {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "image": {
+                                                      "$ref": "#/components/schemas/Image"
+                                                    }
+                                                  }
+                                                }
+                                              ]
+                                            }
+                                          }
+                                        }
+                                      }
+                                    ]
+                                  }
+                                }
+                              }
+                            }
+                          ]
                         }
                       }
                     }

--- a/frontend/src/api/endpoints/project.ts
+++ b/frontend/src/api/endpoints/project.ts
@@ -36,14 +36,23 @@ export const projectService = {
   },
   /**
    * プロジェクト複製
+   * @param projectId 複製元プロジェクトID
+   * @returns 新規プロジェクトとそのマスタープロトタイプ
    */
   duplicateProject: async (
     projectId: string
   ): Promise<{ project: Project; prototypes: Array<Prototype> }> => {
-    const response = await axiosInstance.post(
-      `/api/projects/${projectId}/duplicate`
-    );
-    return response.data;
+    try {
+      const response = await axiosInstance.post(
+        `/api/projects/${projectId}/duplicate`
+      );
+      return response.data;
+    } catch (error: any) {
+      const status = error?.response?.status as number | undefined;
+      const msg = error?.response?.data?.message ?? error?.message ?? '';
+      const note = status ? ` (HTTP ${status})` : '';
+      throw new Error(`プロジェクトの複製に失敗しました${note}: ${String(msg)}`);
+    }
   },
   /**
    * プロトタイプバージョン作成

--- a/frontend/src/api/endpoints/project.ts
+++ b/frontend/src/api/endpoints/project.ts
@@ -35,6 +35,17 @@ export const projectService = {
     return response.data;
   },
   /**
+   * プロジェクト複製
+   */
+  duplicateProject: async (
+    projectId: string
+  ): Promise<{ project: Project; prototypes: Array<Prototype> }> => {
+    const response = await axiosInstance.post(
+      `/api/projects/${projectId}/duplicate`
+    );
+    return response.data;
+  },
+  /**
    * プロトタイプバージョン作成
    */
   createPrototypeVersion: async (

--- a/frontend/src/api/hooks/useProject.ts
+++ b/frontend/src/api/hooks/useProject.ts
@@ -41,6 +41,18 @@ export const useProject = () => {
   );
 
   /**
+   * プロジェクト複製
+   */
+  const duplicateProject = useCallback(
+    async (projectId: string) => {
+      const result = await projectService.duplicateProject(projectId);
+      queryClient.invalidateQueries({ queryKey: ['projects'] });
+      return result;
+    },
+    [queryClient]
+  );
+
+  /**
    * プロトタイプバージョン作成
    */
   const createPrototypeVersion = useCallback(
@@ -155,5 +167,6 @@ export const useProject = () => {
     updateRoleInProject,
     createPrototypeVersion,
     deletePrototypeVersion,
+    duplicateProject,
   };
 };

--- a/frontend/src/api/hooks/useProject.ts
+++ b/frontend/src/api/hooks/useProject.ts
@@ -42,9 +42,15 @@ export const useProject = () => {
 
   /**
    * プロジェクト複製
+   * @param projectId 複製元プロジェクトID
+   * @returns 新規プロジェクトとそのマスタープロトタイプ
    */
   const duplicateProject = useCallback(
-    async (projectId: string) => {
+    async (
+      projectId: string
+    ): Promise<
+      Awaited<ReturnType<typeof projectService.duplicateProject>>
+    > => {
       const result = await projectService.duplicateProject(projectId);
       queryClient.invalidateQueries({ queryKey: ['projects'] });
       return result;

--- a/frontend/src/features/prototype/components/molecules/ProjectTable.tsx
+++ b/frontend/src/features/prototype/components/molecules/ProjectTable.tsx
@@ -42,6 +42,8 @@ export const ProjectTable: React.FC<ProjectTableProps> = ({
   const [updatedNames, setUpdatedNames] = useState<Record<string, string>>({});
   const userContext = useContext(UserContext);
   const { duplicateProject } = useProject();
+  // 行内の複製進行中状態
+  const [duplicatingId, setDuplicatingId] = useState<string | null>(null);
 
   // プロジェクト行で使用するアイコン（IDベースで安定）
   const renderIcon = (id: string) => {
@@ -154,7 +156,9 @@ export const ProjectTable: React.FC<ProjectTableProps> = ({
                 <RowIconButton
                   ariaLabel="複製"
                   title="複製"
+                  disabled={duplicatingId === project.id}
                   onClick={async () => {
+                    setDuplicatingId(project.id);
                     try {
                       const result = await duplicateProject(project.id);
                       const master = result.prototypes.find(
@@ -162,10 +166,14 @@ export const ProjectTable: React.FC<ProjectTableProps> = ({
                       );
                       if (master) {
                         onSelectPrototype(result.project.id, master.id);
+                      } else {
+                        alert('MASTERプロトタイプが見つかりませんでした。');
                       }
                     } catch (error) {
                       console.error('Failed to duplicate project', error);
                       alert('プロジェクトの複製に失敗しました。');
+                    } finally {
+                      setDuplicatingId(null);
                     }
                   }}
                 >

--- a/frontend/src/features/prototype/components/molecules/ProjectTable.tsx
+++ b/frontend/src/features/prototype/components/molecules/ProjectTable.tsx
@@ -6,8 +6,10 @@ import {
   FaSortUp,
   FaTrash,
   FaUsers,
+  FaCopy,
 } from 'react-icons/fa';
 
+import { useProject } from '@/api/hooks/useProject';
 import { Prototype, Project } from '@/api/types';
 import { UserContext } from '@/contexts/UserContext';
 import PrototypeNameEditor from '@/features/prototype/components/atoms/PrototypeNameEditor';
@@ -39,6 +41,7 @@ export const ProjectTable: React.FC<ProjectTableProps> = ({
   // 即時反映用: 名前更新が完了した行の一時表示名
   const [updatedNames, setUpdatedNames] = useState<Record<string, string>>({});
   const userContext = useContext(UserContext);
+  const { duplicateProject } = useProject();
 
   // プロジェクト行で使用するアイコン（IDベースで安定）
   const renderIcon = (id: string) => {
@@ -147,6 +150,26 @@ export const ProjectTable: React.FC<ProjectTableProps> = ({
                   }
                 >
                   <FaFolderOpen className="h-4 w-4" />
+                </RowIconButton>
+                <RowIconButton
+                  ariaLabel="複製"
+                  title="複製"
+                  onClick={async () => {
+                    try {
+                      const result = await duplicateProject(project.id);
+                      const master = result.prototypes.find(
+                        (p) => p.type === 'MASTER'
+                      );
+                      if (master) {
+                        onSelectPrototype(result.project.id, master.id);
+                      }
+                    } catch (error) {
+                      console.error('Failed to duplicate project', error);
+                      alert('プロジェクトの複製に失敗しました。');
+                    }
+                  }}
+                >
+                  <FaCopy className="h-4 w-4" />
                 </RowIconButton>
                 <RowIconLink
                   href={`/projects/${project.id}/roles`}

--- a/frontend/src/features/prototype/components/organisms/ProjectList.tsx
+++ b/frontend/src/features/prototype/components/organisms/ProjectList.tsx
@@ -41,7 +41,8 @@ const ROLE_ADMIN = 'admin' as const;
 const ProjectList: React.FC = () => {
   const router = useRouter();
   const { useUpdatePrototype } = usePrototypes();
-  const { useGetProjects, createProject, getProjectRoles } = useProject();
+  const { useGetProjects, createProject, getProjectRoles, duplicateProject } =
+    useProject();
   const { user } = useUser();
 
   // useQueryとuseMutationフックの使用
@@ -340,6 +341,24 @@ const ProjectList: React.FC = () => {
     _masterPrototype: Prototype
   ) => {
     const items = [
+      {
+        id: 'duplicate',
+        text: '複製',
+        action: async () => {
+          try {
+            const result = await duplicateProject(project.id);
+            const master = result.prototypes.find((p) => p.type === 'MASTER');
+            if (master) {
+              router.push(
+                `/projects/${result.project.id}/prototypes/${master.id}`
+              );
+            }
+          } catch (error) {
+            console.error('Failed to duplicate project', error);
+            alert('プロジェクトの複製に失敗しました。');
+          }
+        },
+      },
       {
         id: 'permissions',
         text: '権限設定',


### PR DESCRIPTION
## Summary
- implement backend API to duplicate a project along with its master prototype
- add UI actions labeled "複製" to duplicate projects in list views
- cover duplication logic with tests

## Testing
- `npm run lint` (backend)
- `npm test` (backend)
- `npm run lint` (frontend)
- `npm test` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68bf994f172083269713f04878b14191

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Duplicate an existing project from the project list and table via the “複製” action.
  - After duplication, automatically navigates to the new project’s MASTER prototype.
- API
  - Added endpoint and client support to duplicate a project.
  - useProject hook now exposes duplicateProject for easy integration.
- Tests
  - Added comprehensive unit tests covering the project duplication flow and expected results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->