### PR TITLE
feat: show tooltip reason when prototype name is not editable

### DIFF
--- a/frontend/src/features/prototype/components/atoms/PrototypeNameEditor.tsx
+++ b/frontend/src/features/prototype/components/atoms/PrototypeNameEditor.tsx
@@ -24,6 +24,8 @@ interface PrototypeNameEditorProps {
   weight?: 'normal' | 'medium' | 'semibold' | 'bold';
   /** 編集可能かどうか */
   editable?: boolean;
+  /** 編集不可の場合に表示する理由 */
+  notEditableReason?: string;
 }
 
 export default function PrototypeNameEditor({
@@ -36,6 +38,7 @@ export default function PrototypeNameEditor({
   size = 'xs',
   weight = 'medium',
   editable = true,
+  notEditableReason = '管理者のみ名前を変更できます',
 }: PrototypeNameEditorProps) {
   const { useUpdatePrototype } = usePrototypes();
   const updatePrototypeMutation = useUpdatePrototype();
@@ -72,13 +75,17 @@ export default function PrototypeNameEditor({
           : 'font-bold';
 
   if (!editable) {
+    const titleText = notEditableReason
+      ? `${name} - ${notEditableReason}`
+      : name;
     return (
       <div className={`w-full ${className ?? ''}`}>
         <span
           className={`${sizeClass} ${weightClass} text-kibako-primary ${truncate ? 'truncate' : 'whitespace-normal break-words'} ${
             bleedX ? 'px-2 -mx-2' : 'px-2'
           }`}
-          title={name}
+          title={titleText}
+          aria-label={titleText}
         >
           {name}
         </span>

--- a/frontend/src/features/prototype/components/atoms/__tests__/PrototypeNameEditor.test.tsx
+++ b/frontend/src/features/prototype/components/atoms/__tests__/PrototypeNameEditor.test.tsx
@@ -1,0 +1,29 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+
+import PrototypeNameEditor from '../PrototypeNameEditor';
+
+describe('PrototypeNameEditor', () => {
+  it('shows reason when editing is disabled', () => {
+    const queryClient = new QueryClient();
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <PrototypeNameEditor
+          prototypeId="p1"
+          name="test project"
+          onUpdated={() => {}}
+          editable={false}
+          notEditableReason="管理者のみ名前を変更できます"
+        />
+      </QueryClientProvider>
+    );
+
+    const nameDisplay = screen.getByText('test project');
+    expect(nameDisplay).toHaveAttribute(
+      'title',
+      'test project - 管理者のみ名前を変更できます'
+    );
+  });
+});

--- a/frontend/src/features/prototype/components/molecules/LeftSidebar.tsx
+++ b/frontend/src/features/prototype/components/molecules/LeftSidebar.tsx
@@ -333,6 +333,7 @@ export default function LeftSidebar({
             name={prototypeName}
             onUpdated={handlePrototypeNameUpdated}
             editable={currentRole === 'admin'}
+            notEditableReason="管理者のみ名前を変更できます"
           />
         </div>
         {/* プレイルームを開いている時は開閉ボタンを非表示 */}

--- a/frontend/src/features/prototype/components/molecules/ProjectCard.tsx
+++ b/frontend/src/features/prototype/components/molecules/ProjectCard.tsx
@@ -80,6 +80,7 @@ export const ProjectCard: React.FC<ProjectCardProps> = ({
               bleedX={false}
               onUpdated={(newName) => setUpdatedName(newName)}
               editable={isProjectAdmin}
+              notEditableReason="管理者のみ名前を変更できます"
             />
           </div>
         </div>

--- a/frontend/src/features/prototype/components/molecules/ProjectTable.tsx
+++ b/frontend/src/features/prototype/components/molecules/ProjectTable.tsx
@@ -121,6 +121,7 @@ export const ProjectTable: React.FC<ProjectTableProps> = ({
                       }))
                     }
                     editable={projectAdminMap[project.id]}
+                    notEditableReason="管理者のみ名前を変更できます"
                   />
                 </div>
               </div>


### PR DESCRIPTION
## Summary
- display explanation via `notEditableReason` when prototype names can't be edited
- show admin-only message in project listings and sidebar when editing disabled
- add test for disabled tooltip

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bf9b8c2e748326968343f3a0b46072