### PR TITLE
feat: add card side toggle action

### DIFF
--- a/frontend/src/features/prototype/components/molecules/PartPropertyMenuMulti.tsx
+++ b/frontend/src/features/prototype/components/molecules/PartPropertyMenuMulti.tsx
@@ -100,7 +100,11 @@ export default function PartPropertyMenuMulti({
     if (cardParts.length === 0) return 'front';
     const frontCount = cardParts.filter((p) => p.frontSide !== 'back').length;
     const backCount = cardParts.length - frontCount;
-    return frontCount >= backCount ? 'front' : 'back';
+    if (frontCount === 0) return 'front';
+    if (backCount === 0) return 'back';
+    if (frontCount > backCount) return 'front';
+    if (backCount > frontCount) return 'back';
+    return 'front';
   }, [cardParts]);
 
   const cardSideTargetLabel = useMemo(

--- a/frontend/src/features/prototype/components/molecules/PartPropertyMenuMulti.tsx
+++ b/frontend/src/features/prototype/components/molecules/PartPropertyMenuMulti.tsx
@@ -9,6 +9,7 @@ import {
   LuAlignHorizontalSpaceBetween,
   LuAlignVerticalSpaceBetween,
   LuShuffle,
+  LuFlipHorizontal,
 } from 'react-icons/lu';
 
 import { Part } from '@/api/types';
@@ -95,6 +96,33 @@ export default function PartPropertyMenuMulti({
     [distributeParts]
   );
 
+  const cardSideTarget = useMemo((): 'front' | 'back' => {
+    if (cardParts.length === 0) return 'front';
+    const frontCount = cardParts.filter((p) => p.frontSide !== 'back').length;
+    const backCount = cardParts.length - frontCount;
+    return frontCount >= backCount ? 'front' : 'back';
+  }, [cardParts]);
+
+  const cardSideTargetLabel = useMemo(
+    () =>
+      cardSideTarget === 'front' ? 'カードを表面にする' : 'カードを裏面にする',
+    [cardSideTarget]
+  );
+
+  const handleUnifyCardSides = useCallback((): void => {
+    if (cardParts.length === 0) return;
+
+    const updates = cardParts
+      .filter((p) => p.frontSide !== cardSideTarget)
+      .map((p) => ({
+        partId: p.id,
+        updatePart: { frontSide: cardSideTarget },
+      }));
+
+    if (updates.length === 0) return;
+    dispatch({ type: 'UPDATE_PARTS', payload: { updates } });
+  }, [cardParts, cardSideTarget, dispatch]);
+
   /**
    * カードのみを選択し、裏面へ反転・中央へ寄せ・順序を公平にシャッフルする
    * - フィッシャー–イェーツで無偏な順列を生成
@@ -174,6 +202,14 @@ export default function PartPropertyMenuMulti({
               icon={<LuAlignVerticalSpaceBetween className="h-5 w-5" />}
               onClick={handleDistributeVerticalEvenly}
             />
+            {cardParts.length > 0 && (
+              <PartPropertyMenuButton
+                text={cardSideTargetLabel}
+                ariaLabel={cardSideTargetLabel}
+                icon={<LuFlipHorizontal className="h-5 w-5" />}
+                onClick={handleUnifyCardSides}
+              />
+            )}
             {cardParts.length >= 2 && (
               <PartPropertyMenuButton
                 text="カードをシャッフル"


### PR DESCRIPTION
## Summary
- adjust card side toggle button to display whether it will set cards to front or back
- memoize target side for reuse in handler and label
- centralize label for card side toggle button to avoid duplication

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bf9afd293c83269601637bf7f89038

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added an “Unify Card Sides” action that sets all selected cards to the same side (front or back).
  * Button appears in the Actions section (before Shuffle) when card items are selected and shows an icon.
  * The button label adapts to suggest the side based on the current mix of card sides; ties default to front.
  * Only applies changes when needed, leaving already unified selections untouched.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->