### PR TITLE
refactor: move distribution actions to alignment icons

### DIFF
--- a/frontend/src/features/prototype/components/molecules/PartPropertyMenuMulti.tsx
+++ b/frontend/src/features/prototype/components/molecules/PartPropertyMenuMulti.tsx
@@ -45,7 +45,8 @@ export default function PartPropertyMenuMulti({
     () => selectedParts.filter((p) => p.type === 'card'),
     [selectedParts]
   );
-  const showActionSection = selectedParts.length >= 2;
+  // カード関連アクションの表示はカードが含まれるときのみ
+  const showActionSection = cardParts.length > 0;
 
   const alignParts = useCallback(
     (type: AlignmentType): void => {
@@ -195,25 +196,11 @@ export default function PartPropertyMenuMulti({
           <p className="text-kibako-white">アクション</p>
           <div className="grid grid-cols-1 gap-2">
             <PartPropertyMenuButton
-              text="水平方向に等間隔に配置"
-              ariaLabel="水平方向に等間隔に配置"
-              icon={<LuAlignHorizontalSpaceBetween className="h-5 w-5" />}
-              onClick={handleDistributeHorizontalEvenly}
+              text={cardSideTargetLabel}
+              ariaLabel={cardSideTargetLabel}
+              icon={<LuFlipHorizontal className="h-5 w-5" />}
+              onClick={handleUnifyCardSides}
             />
-            <PartPropertyMenuButton
-              text="垂直方向に等間隔に配置"
-              ariaLabel="垂直方向に等間隔に配置"
-              icon={<LuAlignVerticalSpaceBetween className="h-5 w-5" />}
-              onClick={handleDistributeVerticalEvenly}
-            />
-            {cardParts.length > 0 && (
-              <PartPropertyMenuButton
-                text={cardSideTargetLabel}
-                ariaLabel={cardSideTargetLabel}
-                icon={<LuFlipHorizontal className="h-5 w-5" />}
-                onClick={handleUnifyCardSides}
-              />
-            )}
             {cardParts.length >= 2 && (
               <PartPropertyMenuButton
                 text="カードをシャッフル"
@@ -226,7 +213,7 @@ export default function PartPropertyMenuMulti({
         </>
       )}
       <p className="text-kibako-white">整列</p>
-      <div className="grid grid-cols-3 gap-2">
+      <div className="grid grid-cols-4 gap-2">
         <PartPropertyMenuButton
           text=""
           ariaLabel="水平: 左揃え"
@@ -253,6 +240,13 @@ export default function PartPropertyMenuMulti({
         />
         <PartPropertyMenuButton
           text=""
+          ariaLabel="水平方向に等間隔に配置"
+          title="水平方向に等間隔に配置"
+          icon={<LuAlignHorizontalSpaceBetween className="h-5 w-5" />}
+          onClick={handleDistributeHorizontalEvenly}
+        />
+        <PartPropertyMenuButton
+          text=""
           ariaLabel="垂直: 上揃え"
           title="上揃え（垂直）"
           icon={<LuAlignStartHorizontal className="h-5 w-5" />}
@@ -274,6 +268,13 @@ export default function PartPropertyMenuMulti({
           icon={<LuAlignEndHorizontal className="h-5 w-5" />}
           onClick={handleAlignBottom}
           disabled={alignInfo?.isBottom}
+        />
+        <PartPropertyMenuButton
+          text=""
+          ariaLabel="垂直方向に等間隔に配置"
+          title="垂直方向に等間隔に配置"
+          icon={<LuAlignVerticalSpaceBetween className="h-5 w-5" />}
+          onClick={handleDistributeVerticalEvenly}
         />
       </div>
     </div>


### PR DESCRIPTION
## Summary
- relocate even distribution controls into alignment section
- show distribution options as icon-only with title tooltips
- hide card actions section unless cards selected

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bfae63fb7483268868a17b1fcb6e9c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added horizontal and vertical distribution actions to the alignment panel.
  * Consolidated card-side controls into a single dynamic action with clear labeling and icon.
* **Refactor**
  * Action section now appears when at least one card is selected; shuffle remains available with two or more.
  * Alignment grid expanded from 3 to 4 columns to accommodate new actions.
  * Retained existing alignment controls (left/center/right; top/center/bottom) alongside the new distribution options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->