### PR TITLE
feat: display part counts in project list

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -13,6 +13,6 @@
 
   /* Common grid for ProjectTable header/body rows */
   .project-table-grid {
-    grid-template-columns: minmax(0, 1fr) 120px 200px 120px;
+    grid-template-columns: minmax(0, 1fr) 120px 200px 80px 120px;
   }
 }

--- a/frontend/src/features/prototype/components/molecules/ProjectCard.tsx
+++ b/frontend/src/features/prototype/components/molecules/ProjectCard.tsx
@@ -15,6 +15,8 @@ type ProjectCardProps = {
   project: Project;
   // マスタープロトタイプ情報
   masterPrototype: Prototype;
+  // パーツ数
+  partCount: number;
   // 管理者権限を持つかどうか
   isProjectAdmin: boolean;
   // 編集関連
@@ -39,6 +41,7 @@ type ProjectCardProps = {
 export const ProjectCard: React.FC<ProjectCardProps> = ({
   project,
   masterPrototype,
+  partCount,
   isProjectAdmin,
   onCardClick,
   onContextMenu,
@@ -85,7 +88,10 @@ export const ProjectCard: React.FC<ProjectCardProps> = ({
           </div>
         </div>
         {/* 詳細情報 */}
-        <div className="flex justify-end mt-2">
+        <div className="flex justify-between mt-2">
+          <div className="text-left text-xs text-kibako-secondary">
+            <div>パーツ数: {partCount}</div>
+          </div>
           <div className="text-right text-xs text-kibako-secondary">
             <div>
               作成者:{' '}

--- a/frontend/src/features/prototype/components/molecules/ProjectCardList.tsx
+++ b/frontend/src/features/prototype/components/molecules/ProjectCardList.tsx
@@ -4,7 +4,11 @@ import { Prototype, Project } from '@/api/types';
 import { ProjectCard } from '@/features/prototype/components/molecules/ProjectCard';
 
 type ProjectCardListProps = {
-  prototypeList: { project: Project; masterPrototype: Prototype }[];
+  prototypeList: {
+    project: Project;
+    masterPrototype: Prototype;
+    partCount: number;
+  }[];
   projectAdminMap: Record<string, boolean>;
   // 編集状態と値
   isNameEditing: (prototypeId: string) => boolean;
@@ -36,7 +40,7 @@ export const ProjectCardList: React.FC<ProjectCardListProps> = ({
 }) => {
   return (
     <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8 mb-8">
-      {prototypeList.map(({ masterPrototype, project }) => {
+      {prototypeList.map(({ masterPrototype, project, partCount }) => {
         if (!masterPrototype) return null;
         const { id } = masterPrototype;
         const nameEditing = isNameEditing(id);
@@ -49,6 +53,7 @@ export const ProjectCardList: React.FC<ProjectCardListProps> = ({
             key={id}
             project={project}
             masterPrototype={masterPrototype}
+            partCount={partCount}
             isProjectAdmin={isProjectAdmin}
             isNameEditing={nameEditing}
             editedName={editedName}

--- a/frontend/src/features/prototype/components/molecules/ProjectTable.tsx
+++ b/frontend/src/features/prototype/components/molecules/ProjectTable.tsx
@@ -22,7 +22,11 @@ import formatDate from '@/utils/dateFormat';
 export type ProjectTableSortKey = 'name' | 'createdAt';
 
 type ProjectTableProps = {
-  prototypeList: { project: Project; masterPrototype: Prototype }[];
+  prototypeList: {
+    project: Project;
+    masterPrototype: Prototype;
+    partCount: number;
+  }[];
   sortKey: ProjectTableSortKey;
   sortOrder: 'asc' | 'desc';
   onSort: (key: ProjectTableSortKey) => void;
@@ -90,11 +94,12 @@ export const ProjectTable: React.FC<ProjectTableProps> = ({
               {renderSortIcon('createdAt')}
             </button>
           </th>
+          <th className="px-4 py-2">パーツ数</th>
           <th className="px-4 py-2 text-right">操作</th>
         </tr>
       </thead>
       <tbody className="block max-h-[60vh] overflow-y-auto scrollbar-hide [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden">
-        {prototypeList.map(({ project, masterPrototype }) => (
+        {prototypeList.map(({ project, masterPrototype, partCount }) => (
           <tr
             key={project.id}
             className="grid project-table-grid items-center border-b text-kibako-primary"
@@ -142,6 +147,9 @@ export const ProjectTable: React.FC<ProjectTableProps> = ({
               <span className="whitespace-nowrap text-xs text-kibako-secondary">
                 {formatDate(masterPrototype.createdAt, true)}
               </span>
+            </RowCell>
+            <RowCell>
+              <span className="text-xs text-kibako-secondary">{partCount}</span>
             </RowCell>
             <td className="px-4 py-2 align-middle">
               <div className="flex items-center justify-end gap-2 h-full">

--- a/frontend/src/features/prototype/components/organisms/ProjectList.tsx
+++ b/frontend/src/features/prototype/components/organisms/ProjectList.tsx
@@ -95,10 +95,19 @@ const ProjectList: React.FC = () => {
   // データ変換処理
   const prototypeList = useMemo(
     () =>
-      projectsData?.map(({ project, prototypes }) => ({
-        project,
-        masterPrototype: prototypes.find(({ type }) => type === 'MASTER'),
-      })) || [],
+      projectsData?.map(({ project, prototypes }) => {
+        const masterPrototype = prototypes.find(
+          ({ type }) => type === 'MASTER'
+        );
+        const protoWithParts = masterPrototype as Prototype & {
+          parts?: unknown[];
+        };
+        return {
+          project,
+          masterPrototype,
+          partCount: protoWithParts?.parts?.length ?? 0,
+        };
+      }) || [],
     [projectsData]
   );
 
@@ -106,8 +115,13 @@ const ProjectList: React.FC = () => {
     () =>
       prototypeList
         .filter(
-          (item): item is { project: Project; masterPrototype: Prototype } =>
-            !!item.masterPrototype
+          (
+            item
+          ): item is {
+            project: Project;
+            masterPrototype: Prototype;
+            partCount: number;
+          } => !!item.masterPrototype
         )
         .sort((a, b) => {
           if (sortKey === 'name') {
@@ -486,8 +500,13 @@ const ProjectList: React.FC = () => {
       {viewMode === 'card' ? (
         <ProjectCardList
           prototypeList={prototypeList.filter(
-            (item): item is { project: Project; masterPrototype: Prototype } =>
-              !!item.masterPrototype
+            (
+              item
+            ): item is {
+              project: Project;
+              masterPrototype: Prototype;
+              partCount: number;
+            } => !!item.masterPrototype
           )}
           projectAdminMap={projectAdminMap}
           isNameEditing={(prototypeId) => isEditing(prototypeId)}


### PR DESCRIPTION
## Summary
- show part counts on project cards
- add part count column to project table
- adjust grid layout for new table column

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bfb858bc648326ac3d1f1bce80efae