### PR TITLE
feat: add spread layout buttons

### DIFF
--- a/frontend/src/features/prototype/components/molecules/PartPropertyMenuMulti.tsx
+++ b/frontend/src/features/prototype/components/molecules/PartPropertyMenuMulti.tsx
@@ -10,6 +10,8 @@ import {
   LuAlignVerticalSpaceBetween,
   LuShuffle,
   LuFlipHorizontal,
+  LuStretchHorizontal,
+  LuStretchVertical,
 } from 'react-icons/lu';
 
 import { Part } from '@/api/types';
@@ -21,6 +23,7 @@ import {
   calculateAlignmentInfo,
   getAlignmentUpdates,
   getEvenDistributionUpdates,
+  getSpreadUpdates,
   AlignmentType,
 } from '@/features/prototype/utils/alignment';
 
@@ -95,6 +98,25 @@ export default function PartPropertyMenuMulti({
   const handleDistributeVerticalEvenly = useCallback(
     () => distributeParts('vertical'),
     [distributeParts]
+  );
+
+  const spreadParts = useCallback(
+    (axis: 'horizontal' | 'vertical'): void => {
+      if (!alignInfo) return;
+      const updates = getSpreadUpdates(axis, selectedParts, alignInfo);
+      if (updates.length === 0) return;
+      dispatch({ type: 'UPDATE_PARTS', payload: { updates } });
+    },
+    [alignInfo, selectedParts, dispatch]
+  );
+
+  const handleSpreadHorizontal = useCallback(
+    () => spreadParts('horizontal'),
+    [spreadParts]
+  );
+  const handleSpreadVertical = useCallback(
+    () => spreadParts('vertical'),
+    [spreadParts]
   );
 
   const cardSideTarget = useMemo((): 'front' | 'back' => {
@@ -275,6 +297,20 @@ export default function PartPropertyMenuMulti({
           title="垂直方向に等間隔に配置"
           icon={<LuAlignVerticalSpaceBetween className="h-5 w-5" />}
           onClick={handleDistributeVerticalEvenly}
+        />
+        <PartPropertyMenuButton
+          text=""
+          ariaLabel="横に展開する"
+          title="横方向に、重ならないように広げる"
+          icon={<LuStretchHorizontal className="h-5 w-5" />}
+          onClick={handleSpreadHorizontal}
+        />
+        <PartPropertyMenuButton
+          text=""
+          ariaLabel="縦に展開する"
+          title="縦方向に、重ならないように広げる"
+          icon={<LuStretchVertical className="h-5 w-5" />}
+          onClick={handleSpreadVertical}
         />
       </div>
     </div>

--- a/frontend/src/features/prototype/components/molecules/PartPropertyMenuMulti.tsx
+++ b/frontend/src/features/prototype/components/molecules/PartPropertyMenuMulti.tsx
@@ -115,10 +115,12 @@ export default function PartPropertyMenuMulti({
     [alignInfo, selectedParts, dispatch]
   );
 
+  /** 横方向に展開する */
   const handleSpreadHorizontal = useCallback(
     () => spreadParts('horizontal'),
     [spreadParts]
   );
+  /** 縦方向に展開する */
   const handleSpreadVertical = useCallback(
     () => spreadParts('vertical'),
     [spreadParts]

--- a/frontend/src/features/prototype/components/molecules/PartPropertyMenuMulti.tsx
+++ b/frontend/src/features/prototype/components/molecules/PartPropertyMenuMulti.tsx
@@ -100,8 +100,13 @@ export default function PartPropertyMenuMulti({
     [distributeParts]
   );
 
+  /**
+   * 選択パーツを指定軸に沿って展開する
+   * @param axis 'horizontal' | 'vertical'
+   */
   const spreadParts = useCallback(
     (axis: 'horizontal' | 'vertical'): void => {
+      // 整列情報がない場合は何もしない
       if (!alignInfo) return;
       const updates = getSpreadUpdates(axis, selectedParts, alignInfo);
       if (updates.length === 0) return;

--- a/frontend/src/features/prototype/components/molecules/PartPropertyMenuMulti.tsx
+++ b/frontend/src/features/prototype/components/molecules/PartPropertyMenuMulti.tsx
@@ -302,14 +302,14 @@ export default function PartPropertyMenuMulti({
           text=""
           ariaLabel="横に展開する"
           title="横方向に、重ならないように広げる"
-          icon={<LuStretchHorizontal className="h-5 w-5" />}
+          icon={<LuStretchVertical className="h-5 w-5" />}
           onClick={handleSpreadHorizontal}
         />
         <PartPropertyMenuButton
           text=""
           ariaLabel="縦に展開する"
           title="縦方向に、重ならないように広げる"
-          icon={<LuStretchVertical className="h-5 w-5" />}
+          icon={<LuStretchHorizontal className="h-5 w-5" />}
           onClick={handleSpreadVertical}
         />
       </div>

--- a/frontend/src/features/prototype/utils/alignment.ts
+++ b/frontend/src/features/prototype/utils/alignment.ts
@@ -1,6 +1,9 @@
 import { Part } from '@/api/types';
 import { GAME_BOARD_SIZE } from '@/features/prototype/constants/gameBoard';
 
+/** スプレッド時のデフォルト間隔(px) */
+export const DEFAULT_SPREAD_GAP = 20;
+
 export type AlignmentType =
   | 'left'
   | 'right'
@@ -173,7 +176,7 @@ export const getSpreadUpdates = (
   axis: DistributionAxis,
   parts: Part[],
   info: AlignmentInfo,
-  gap = 20
+  gap = DEFAULT_SPREAD_GAP
 ): AlignmentUpdate[] => {
   const sorted = [...parts].sort((a, b) =>
     axis === 'horizontal'

--- a/frontend/src/features/prototype/utils/alignment.ts
+++ b/frontend/src/features/prototype/utils/alignment.ts
@@ -1,5 +1,5 @@
 import { Part } from '@/api/types';
-import { GAME_BOARD_SIZE } from '@/features/prototype/constants';
+import { GAME_BOARD_SIZE } from '@/features/prototype/constants/gameBoard';
 
 export type AlignmentType =
   | 'left'


### PR DESCRIPTION
## Summary
- add utility to spread parts horizontally or vertically within board bounds
- expose horizontal/vertical spread buttons in multi-part menu

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bfc13366a483268357702567c711e6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added horizontal and vertical distribute controls in the “整列” menu to evenly space selected parts with a consistent default gap.
  * New toolbar buttons with clear icons, tooltips, and accessible labels for quick X/Y spreading.
  * Distribution centers selection, respects board boundaries, and adjusts gap to fit (allowing overlap if necessary); action runs only when a valid selection yields actual position changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->