### PR TITLE
fix: hide playroom settings panel when no hand parts

### DIFF
--- a/frontend/src/features/prototype/components/molecules/PlaySidebar.tsx
+++ b/frontend/src/features/prototype/components/molecules/PlaySidebar.tsx
@@ -113,6 +113,10 @@ export default function PlaySidebar({
     setSelectedHandId(selectedPart?.type === 'hand' ? selectedPartId : null);
   }, [selectedPartId, parts]);
 
+  if (hands.length === 0) {
+    return null;
+  }
+
   return (
     <div className="fixed top-20 left-4 flex w-[18rem] flex-col rounded-xl shadow-lg border border-kibako-tertiary/40 bg-gradient-to-r from-kibako-white to-kibako-tertiary max-h-[calc(100vh-32px)] overflow-y-auto">
       {/* ヘッダー */}


### PR DESCRIPTION
## Summary
- hide PlaySidebar when there are no hand parts so Playroom settings panel is not shown

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bfdab255c0832681a99d49c5310529