### PR TITLE
refactor: use Loading for project deletion page

### DIFF
--- a/frontend/src/features/prototype/components/organisms/DeletePrototypeConfirmation.tsx
+++ b/frontend/src/features/prototype/components/organisms/DeletePrototypeConfirmation.tsx
@@ -8,6 +8,7 @@ import { projectService } from '@/api/endpoints/project';
 import { useProject } from '@/api/hooks/useProject';
 import { Prototype, Project } from '@/api/types';
 import KibakoButton from '@/components/atoms/KibakoButton';
+import Loading from '@/components/organisms/Loading';
 import { useUser } from '@/hooks/useUser';
 
 const DeletePrototypeConfirmation = () => {
@@ -80,18 +81,7 @@ const DeletePrototypeConfirmation = () => {
   };
 
   if (isLoading) {
-    return (
-      <div className="max-w-4xl mx-auto py-16 px-4">
-        <div className="p-6 overflow-visible rounded-xl bg-gradient-to-r from-kibako-white via-kibako-white to-kibako-tertiary shadow-lg border border-kibako-tertiary/30">
-          <div className="animate-pulse flex flex-col space-y-4">
-            <div className="h-8 bg-slate-200 rounded w-1/2"></div>
-            <div className="h-4 bg-slate-200 rounded w-3/4"></div>
-            <div className="h-4 bg-slate-200 rounded w-3/4"></div>
-            <div className="h-24 bg-slate-200 rounded"></div>
-          </div>
-        </div>
-      </div>
-    );
+    return <Loading />;
   }
 
   if (error) {


### PR DESCRIPTION
## Summary
- replace skeleton UI with shared Loading component on project deletion confirmation page

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bff78b8c308326b3ecee321853a1cb