### PR TITLE
fix: show spinner on delete confirmation button

### DIFF
--- a/frontend/src/features/prototype/components/organisms/DeletePrototypeConfirmation.tsx
+++ b/frontend/src/features/prototype/components/organisms/DeletePrototypeConfirmation.tsx
@@ -3,6 +3,7 @@
 import { useParams, useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
 import { IoArrowBack, IoTrash } from 'react-icons/io5';
+import { RiLoaderLine } from 'react-icons/ri';
 
 import { projectService } from '@/api/endpoints/project';
 import { useProject } from '@/api/hooks/useProject';
@@ -174,10 +175,18 @@ const DeletePrototypeConfirmation = () => {
             onClick={handleDelete}
             disabled={!isAdmin || isDeleting}
             title={!isAdmin ? '管理者権限が必要です' : undefined}
-            isLoading={isDeleting}
           >
-            <IoTrash className="w-5 h-5" />
-            削除する
+            {isDeleting ? (
+              <>
+                <RiLoaderLine className="w-5 h-5 animate-spin" />
+                <span className="text-sm">削除する</span>
+              </>
+            ) : (
+              <>
+                <IoTrash className="w-5 h-5" />
+                <span className="text-sm">削除する</span>
+              </>
+            )}
           </KibakoButton>
         </div>
         {!isAdmin && (


### PR DESCRIPTION
## Summary
- display animated loader on delete confirmation button using same style as project creation
- keep button label "削除する" while disabled during deletion

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bff805e43c8326b51a1004ff7e617c