### PR TITLE
fix: restrict viewer role actions

### DIFF
--- a/backend/src/middlewares/permissions.ts
+++ b/backend/src/middlewares/permissions.ts
@@ -240,6 +240,16 @@ export const checkProjectManagePermission: AsyncMiddleware = checkPermission(
 );
 
 /**
+ * プロジェクトの編集権限ミドルウェア
+ * @returns Express ミドルウェア
+ */
+export const checkProjectWritePermission: AsyncMiddleware = checkPermission(
+  RESOURCE_TYPES.PROJECT,
+  PERMISSION_ACTIONS.WRITE,
+  'projectId'
+);
+
+/**
  * プロトタイプの編集権限ミドルウェア
  * @returns Express ミドルウェア
  */

--- a/backend/src/routes/project.ts
+++ b/backend/src/routes/project.ts
@@ -6,6 +6,7 @@ import { ensureAuthenticated } from '../middlewares/auth';
 import {
   checkProjectReadPermission,
   checkProjectManagePermission,
+  checkProjectWritePermission,
   checkProjectAdminRole,
 } from '../middlewares/permissions';
 import { getAccessiblePrototypes } from '../helpers/prototypeHelper';
@@ -570,7 +571,7 @@ router.get(
  */
 router.post(
   '/:projectId/invite',
-  checkProjectReadPermission,
+  checkProjectManagePermission,
   async (req: Request, res: Response, next: NextFunction) => {
     const projectId = req.params.projectId;
     const guestIds = req.body.guestIds;
@@ -668,7 +669,7 @@ router.post(
  */
 router.delete(
   '/:projectId/invite/:guestId',
-  checkProjectReadPermission,
+  checkProjectManagePermission,
   async (req: Request, res: Response, next: NextFunction) => {
     const projectId = req.params.projectId;
     const guestId = req.params.guestId;
@@ -735,7 +736,7 @@ router.delete(
  */
 router.post(
   '/:projectId/duplicate',
-  checkProjectReadPermission,
+  checkProjectWritePermission,
   async (req: Request, res: Response, next: NextFunction) => {
     const user = req.user as UserModel;
     const { projectId } = req.params;

--- a/frontend/src/features/prototype/components/molecules/ProjectTable.tsx
+++ b/frontend/src/features/prototype/components/molecules/ProjectTable.tsx
@@ -33,6 +33,7 @@ type ProjectTableProps = {
   onSort: (key: ProjectTableSortKey) => void;
   onSelectPrototype: (projectId: string, prototypeId: string) => void;
   projectAdminMap: Record<string, boolean>;
+  projectRoleMap: Record<string, string>;
 };
 
 export const ProjectTable: React.FC<ProjectTableProps> = ({
@@ -42,6 +43,7 @@ export const ProjectTable: React.FC<ProjectTableProps> = ({
   onSort,
   onSelectPrototype,
   projectAdminMap,
+  projectRoleMap,
 }) => {
   // 即時反映用: 名前更新が完了した行の一時表示名
   const [updatedNames, setUpdatedNames] = useState<Record<string, string>>({});
@@ -49,6 +51,7 @@ export const ProjectTable: React.FC<ProjectTableProps> = ({
   const { duplicateProject } = useProject();
   // 行内の複製進行中状態
   const [duplicatingId, setDuplicatingId] = useState<string | null>(null);
+  const ROLE_VIEWER = 'viewer' as const;
 
   // プロジェクト行で使用するアイコン（IDベースで安定）
   const renderIcon = (id: string) => {
@@ -101,128 +104,154 @@ export const ProjectTable: React.FC<ProjectTableProps> = ({
         </tr>
       </thead>
       <tbody className="block max-h-[60vh] overflow-y-auto scrollbar-hide [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden">
-        {prototypeList.map(({ project, masterPrototype, partCount, roomCount }) => (
-          <tr
-            key={project.id}
-            className="grid project-table-grid items-center border-b text-kibako-primary"
-          >
-            <RowCell className="overflow-hidden">
-              <div className="flex items-center gap-3 min-w-0 w-full overflow-hidden">
-                <button
-                  type="button"
-                  aria-label="開く"
-                  title="開く"
-                  onClick={() =>
-                    onSelectPrototype(project.id, masterPrototype.id)
-                  }
-                  className="p-1 rounded hover:bg-kibako-accent/20 focus:outline-none focus:ring-2 focus:ring-kibako-accent/50"
-                >
-                  {renderIcon(masterPrototype.id)}
-                </button>
-                <div className="min-w-0 flex-1 overflow-hidden">
-                  <PrototypeNameEditor
-                    prototypeId={masterPrototype.id}
-                    name={
-                      updatedNames[masterPrototype.id] ?? masterPrototype.name
+        {prototypeList.map(
+          ({ project, masterPrototype, partCount, roomCount }) => (
+            <tr
+              key={project.id}
+              className="grid project-table-grid items-center border-b text-kibako-primary"
+            >
+              <RowCell className="overflow-hidden">
+                <div className="flex items-center gap-3 min-w-0 w-full overflow-hidden">
+                  <button
+                    type="button"
+                    aria-label="開く"
+                    title="開く"
+                    onClick={() =>
+                      onSelectPrototype(project.id, masterPrototype.id)
                     }
-                    bleedX={false}
-                    onUpdated={(newName) =>
-                      setUpdatedNames((prev) => ({
-                        ...prev,
-                        [masterPrototype.id]: newName,
-                      }))
-                    }
-                    editable={projectAdminMap[project.id]}
-                    notEditableReason="管理者のみ名前を変更できます"
-                  />
-                </div>
-              </div>
-            </RowCell>
-            <RowCell>
-              <span className="ml-auto text-right text-xs text-kibako-secondary">{partCount}</span>
-            </RowCell>
-            <RowCell>
-              <span className="ml-auto text-right text-xs text-kibako-secondary">{roomCount}</span>
-            </RowCell>
-            <RowCell>
-              <span className="text-xs text-kibako-secondary">
-                {userContext?.user?.id === project.userId
-                  ? '自分'
-                  : '他のユーザー'}
-              </span>
-            </RowCell>
-            <RowCell>
-              <span className="whitespace-nowrap text-xs text-kibako-secondary">
-                {formatDate(masterPrototype.createdAt, true)}
-              </span>
-            </RowCell>
-            <td className="px-4 py-2 align-middle">
-              <div className="flex items-center justify-end gap-2 h-full">
-                <RowIconButton
-                  ariaLabel="開く"
-                  title="開く"
-                  onClick={() =>
-                    onSelectPrototype(project.id, masterPrototype.id)
-                  }
-                >
-                  <FaFolderOpen className="h-4 w-4" />
-                </RowIconButton>
-                <RowIconButton
-                  ariaLabel="複製"
-                  title="複製"
-                  disabled={duplicatingId === project.id}
-                  onClick={async () => {
-                    setDuplicatingId(project.id);
-                    try {
-                      const result = await duplicateProject(project.id);
-                      const master = result.prototypes.find(
-                        (p) => p.type === 'MASTER'
-                      );
-                      if (master) {
-                        onSelectPrototype(result.project.id, master.id);
-                      } else {
-                        alert('MASTERプロトタイプが見つかりませんでした。');
+                    className="p-1 rounded hover:bg-kibako-accent/20 focus:outline-none focus:ring-2 focus:ring-kibako-accent/50"
+                  >
+                    {renderIcon(masterPrototype.id)}
+                  </button>
+                  <div className="min-w-0 flex-1 overflow-hidden">
+                    <PrototypeNameEditor
+                      prototypeId={masterPrototype.id}
+                      name={
+                        updatedNames[masterPrototype.id] ?? masterPrototype.name
                       }
-                    } catch (error) {
-                      console.error('Failed to duplicate project', error);
-                      alert('プロジェクトの複製に失敗しました。');
-                    } finally {
-                      setDuplicatingId(null);
-                    }
-                  }}
-                >
-                  <FaCopy className="h-4 w-4" />
-                </RowIconButton>
-                <RowIconLink
-                  href={`/projects/${project.id}/roles`}
-                  ariaLabel="権限設定"
-                  title="権限設定"
-                >
-                  <FaUsers className="h-4 w-4" />
-                </RowIconLink>
-                {projectAdminMap[project.id] ? (
-                  <RowIconLink
-                    href={`/projects/${project.id}/delete`}
-                    ariaLabel="削除"
-                    title="削除"
-                    variant="danger"
-                  >
-                    <FaTrash className="h-4 w-4" />
-                  </RowIconLink>
-                ) : (
+                      bleedX={false}
+                      onUpdated={(newName) =>
+                        setUpdatedNames((prev) => ({
+                          ...prev,
+                          [masterPrototype.id]: newName,
+                        }))
+                      }
+                      editable={projectAdminMap[project.id]}
+                      notEditableReason="管理者のみ名前を変更できます"
+                    />
+                  </div>
+                </div>
+              </RowCell>
+              <RowCell>
+                <span className="ml-auto text-right text-xs text-kibako-secondary">
+                  {partCount}
+                </span>
+              </RowCell>
+              <RowCell>
+                <span className="ml-auto text-right text-xs text-kibako-secondary">
+                  {roomCount}
+                </span>
+              </RowCell>
+              <RowCell>
+                <span className="text-xs text-kibako-secondary">
+                  {userContext?.user?.id === project.userId
+                    ? '自分'
+                    : '他のユーザー'}
+                </span>
+              </RowCell>
+              <RowCell>
+                <span className="whitespace-nowrap text-xs text-kibako-secondary">
+                  {formatDate(masterPrototype.createdAt, true)}
+                </span>
+              </RowCell>
+              <td className="px-4 py-2 align-middle">
+                <div className="flex items-center justify-end gap-2 h-full">
                   <RowIconButton
-                    ariaLabel="削除"
-                    title="削除は管理者のみ可能です"
-                    variant="danger"
-                    disabled
+                    ariaLabel="開く"
+                    title="開く"
+                    onClick={() =>
+                      onSelectPrototype(project.id, masterPrototype.id)
+                    }
                   >
-                    <FaTrash className="h-4 w-4" />
+                    <FaFolderOpen className="h-4 w-4" />
                   </RowIconButton>
-                )}
-              </div>
-            </td>
-          </tr>
-        ))}
+                  {projectRoleMap[project.id] !== ROLE_VIEWER ? (
+                    <RowIconButton
+                      ariaLabel="複製"
+                      title="複製"
+                      disabled={duplicatingId === project.id}
+                      onClick={async () => {
+                        setDuplicatingId(project.id);
+                        try {
+                          const result = await duplicateProject(project.id);
+                          const master = result.prototypes.find(
+                            (p) => p.type === 'MASTER'
+                          );
+                          if (master) {
+                            onSelectPrototype(result.project.id, master.id);
+                          } else {
+                            alert('MASTERプロトタイプが見つかりませんでした。');
+                          }
+                        } catch (error) {
+                          console.error('Failed to duplicate project', error);
+                          alert('プロジェクトの複製に失敗しました。');
+                        } finally {
+                          setDuplicatingId(null);
+                        }
+                      }}
+                    >
+                      <FaCopy className="h-4 w-4" />
+                    </RowIconButton>
+                  ) : (
+                    <RowIconButton
+                      ariaLabel="複製"
+                      title="複製は閲覧者には許可されていません"
+                      disabled
+                    >
+                      <FaCopy className="h-4 w-4" />
+                    </RowIconButton>
+                  )}
+                  {projectAdminMap[project.id] ? (
+                    <RowIconLink
+                      href={`/projects/${project.id}/roles`}
+                      ariaLabel="権限設定"
+                      title="権限設定"
+                    >
+                      <FaUsers className="h-4 w-4" />
+                    </RowIconLink>
+                  ) : (
+                    <RowIconButton
+                      ariaLabel="権限設定"
+                      title="権限設定は管理者のみ可能です"
+                      disabled
+                    >
+                      <FaUsers className="h-4 w-4" />
+                    </RowIconButton>
+                  )}
+                  {projectAdminMap[project.id] ? (
+                    <RowIconLink
+                      href={`/projects/${project.id}/delete`}
+                      ariaLabel="削除"
+                      title="削除"
+                      variant="danger"
+                    >
+                      <FaTrash className="h-4 w-4" />
+                    </RowIconLink>
+                  ) : (
+                    <RowIconButton
+                      ariaLabel="削除"
+                      title="削除は管理者のみ可能です"
+                      variant="danger"
+                      disabled
+                    >
+                      <FaTrash className="h-4 w-4" />
+                    </RowIconButton>
+                  )}
+                </div>
+              </td>
+            </tr>
+          )
+        )}
       </tbody>
     </table>
   );


### PR DESCRIPTION
## Summary
- guard project routes with write/manage permissions
- hide management controls from viewer role

## Testing
- `npm run lint` (backend)
- `npm test` (backend)
- `npm run lint` (frontend)
- `npm test` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68c0002b55648326be91ba85232e4ad4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced per-project roles (Admin, Editor, Viewer) in the project list and table. Actions (duplicate, manage permissions, delete) are now gated by role, with disabled buttons and helpful messages when unavailable.
  - Viewers can browse but cannot duplicate; Admins can manage permissions and delete; Editors have limited actions.
  - Strengthened server-side permissions: inviting/removing guests now requires manage rights; duplicating a project requires write rights. Added a dedicated project write-permission check to align UI and backend behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->