### PR TITLE
feat: show project creator names in project list

### DIFF
--- a/frontend/src/features/prototype/components/molecules/ProjectCard.tsx
+++ b/frontend/src/features/prototype/components/molecules/ProjectCard.tsx
@@ -1,8 +1,7 @@
-import React, { useContext, useState } from 'react';
+import React, { useState } from 'react';
 import type { IconType } from 'react-icons';
 
 import { Prototype, Project } from '@/api/types';
-import { UserContext } from '@/contexts/UserContext';
 import PrototypeNameEditor from '@/features/prototype/components/atoms/PrototypeNameEditor';
 import { getProjectIcon } from '@/features/prototype/utils/getProjectIcon';
 import formatDate from '@/utils/dateFormat';
@@ -21,6 +20,8 @@ type ProjectCardProps = {
   roomCount: number;
   // 管理者権限を持つかどうか
   isProjectAdmin: boolean;
+  // 作成者名
+  creatorName?: string;
   // 編集関連
   isNameEditing: boolean;
   editedName: string;
@@ -46,12 +47,10 @@ export const ProjectCard: React.FC<ProjectCardProps> = ({
   partCount,
   roomCount,
   isProjectAdmin,
+  creatorName,
   onCardClick,
   onContextMenu,
 }) => {
-  // UserContextからユーザー情報を取得
-  const userContext = useContext(UserContext);
-
   const { id, name, createdAt } = masterPrototype;
   const IconComponent: IconType = getProjectIcon(id);
   const [updatedName, setUpdatedName] = useState<string | null>(null);
@@ -97,12 +96,7 @@ export const ProjectCard: React.FC<ProjectCardProps> = ({
             <div>ルーム数: {roomCount}</div>
           </div>
           <div className="text-right text-xs text-kibako-secondary">
-            <div>
-              作成者:{' '}
-              {userContext?.user?.id === project.userId
-                ? '自分'
-                : '他のユーザー'}
-            </div>
+            <div>作成者: {creatorName || '不明'}</div>
             <div>作成日時: {formatDate(createdAt, true)}</div>
           </div>
         </div>

--- a/frontend/src/features/prototype/components/molecules/ProjectCardList.tsx
+++ b/frontend/src/features/prototype/components/molecules/ProjectCardList.tsx
@@ -11,6 +11,7 @@ type ProjectCardListProps = {
     roomCount: number;
   }[];
   projectAdminMap: Record<string, boolean>;
+  projectCreatorMap: Record<string, string>;
   // 編集状態と値
   isNameEditing: (prototypeId: string) => boolean;
   editedName: string;
@@ -30,6 +31,7 @@ type ProjectCardListProps = {
 export const ProjectCardList: React.FC<ProjectCardListProps> = ({
   prototypeList,
   projectAdminMap,
+  projectCreatorMap,
   isNameEditing,
   editedName,
   setEditedName,
@@ -41,33 +43,37 @@ export const ProjectCardList: React.FC<ProjectCardListProps> = ({
 }) => {
   return (
     <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8 mb-8">
-      {prototypeList.map(({ masterPrototype, project, partCount, roomCount }) => {
-        if (!masterPrototype) return null;
-        const { id } = masterPrototype;
-        const nameEditing = isNameEditing(id);
-        const isProjectAdmin = projectAdminMap[project.id];
+      {prototypeList.map(
+        ({ masterPrototype, project, partCount, roomCount }) => {
+          if (!masterPrototype) return null;
+          const { id } = masterPrototype;
+          const nameEditing = isNameEditing(id);
+          const isProjectAdmin = projectAdminMap[project.id];
+          const creatorName = projectCreatorMap[project.id];
 
-        const handleCardClick = () => onCardClick(project.id, id);
+          const handleCardClick = () => onCardClick(project.id, id);
 
-        return (
-          <ProjectCard
-            key={id}
-            project={project}
-            masterPrototype={masterPrototype}
-            partCount={partCount}
-            roomCount={roomCount}
-            isProjectAdmin={isProjectAdmin}
-            isNameEditing={nameEditing}
-            editedName={editedName}
-            setEditedName={setEditedName}
-            onCardClick={handleCardClick}
-            onContextMenu={onContextMenu}
-            onSubmit={onSubmit}
-            onBlur={onBlur}
-            onKeyDown={onKeyDown}
-          />
-        );
-      })}
+          return (
+            <ProjectCard
+              key={id}
+              project={project}
+              masterPrototype={masterPrototype}
+              partCount={partCount}
+              roomCount={roomCount}
+              isProjectAdmin={isProjectAdmin}
+              creatorName={creatorName}
+              isNameEditing={nameEditing}
+              editedName={editedName}
+              setEditedName={setEditedName}
+              onCardClick={handleCardClick}
+              onContextMenu={onContextMenu}
+              onSubmit={onSubmit}
+              onBlur={onBlur}
+              onKeyDown={onKeyDown}
+            />
+          );
+        }
+      )}
     </div>
   );
 };

--- a/frontend/src/features/prototype/components/molecules/ProjectTable.tsx
+++ b/frontend/src/features/prototype/components/molecules/ProjectTable.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState } from 'react';
+import React, { useState } from 'react';
 import {
   FaFolderOpen,
   FaSort,
@@ -11,7 +11,6 @@ import {
 
 import { useProject } from '@/api/hooks/useProject';
 import { Prototype, Project } from '@/api/types';
-import { UserContext } from '@/contexts/UserContext';
 import PrototypeNameEditor from '@/features/prototype/components/atoms/PrototypeNameEditor';
 import RowCell from '@/features/prototype/components/atoms/RowCell';
 import RowIconButton from '@/features/prototype/components/atoms/RowIconButton';
@@ -33,6 +32,7 @@ type ProjectTableProps = {
   onSort: (key: ProjectTableSortKey) => void;
   onSelectPrototype: (projectId: string, prototypeId: string) => void;
   projectAdminMap: Record<string, boolean>;
+  projectCreatorMap: Record<string, string>;
 };
 
 export const ProjectTable: React.FC<ProjectTableProps> = ({
@@ -42,10 +42,10 @@ export const ProjectTable: React.FC<ProjectTableProps> = ({
   onSort,
   onSelectPrototype,
   projectAdminMap,
+  projectCreatorMap,
 }) => {
   // 即時反映用: 名前更新が完了した行の一時表示名
   const [updatedNames, setUpdatedNames] = useState<Record<string, string>>({});
-  const userContext = useContext(UserContext);
   const { duplicateProject } = useProject();
   // 行内の複製進行中状態
   const [duplicatingId, setDuplicatingId] = useState<string | null>(null);
@@ -101,128 +101,132 @@ export const ProjectTable: React.FC<ProjectTableProps> = ({
         </tr>
       </thead>
       <tbody className="block max-h-[60vh] overflow-y-auto scrollbar-hide [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden">
-        {prototypeList.map(({ project, masterPrototype, partCount, roomCount }) => (
-          <tr
-            key={project.id}
-            className="grid project-table-grid items-center border-b text-kibako-primary"
-          >
-            <RowCell className="overflow-hidden">
-              <div className="flex items-center gap-3 min-w-0 w-full overflow-hidden">
-                <button
-                  type="button"
-                  aria-label="開く"
-                  title="開く"
-                  onClick={() =>
-                    onSelectPrototype(project.id, masterPrototype.id)
-                  }
-                  className="p-1 rounded hover:bg-kibako-accent/20 focus:outline-none focus:ring-2 focus:ring-kibako-accent/50"
-                >
-                  {renderIcon(masterPrototype.id)}
-                </button>
-                <div className="min-w-0 flex-1 overflow-hidden">
-                  <PrototypeNameEditor
-                    prototypeId={masterPrototype.id}
-                    name={
-                      updatedNames[masterPrototype.id] ?? masterPrototype.name
+        {prototypeList.map(
+          ({ project, masterPrototype, partCount, roomCount }) => (
+            <tr
+              key={project.id}
+              className="grid project-table-grid items-center border-b text-kibako-primary"
+            >
+              <RowCell className="overflow-hidden">
+                <div className="flex items-center gap-3 min-w-0 w-full overflow-hidden">
+                  <button
+                    type="button"
+                    aria-label="開く"
+                    title="開く"
+                    onClick={() =>
+                      onSelectPrototype(project.id, masterPrototype.id)
                     }
-                    bleedX={false}
-                    onUpdated={(newName) =>
-                      setUpdatedNames((prev) => ({
-                        ...prev,
-                        [masterPrototype.id]: newName,
-                      }))
-                    }
-                    editable={projectAdminMap[project.id]}
-                    notEditableReason="管理者のみ名前を変更できます"
-                  />
-                </div>
-              </div>
-            </RowCell>
-            <RowCell>
-              <span className="ml-auto text-right text-xs text-kibako-secondary">{partCount}</span>
-            </RowCell>
-            <RowCell>
-              <span className="ml-auto text-right text-xs text-kibako-secondary">{roomCount}</span>
-            </RowCell>
-            <RowCell>
-              <span className="text-xs text-kibako-secondary">
-                {userContext?.user?.id === project.userId
-                  ? '自分'
-                  : '他のユーザー'}
-              </span>
-            </RowCell>
-            <RowCell>
-              <span className="whitespace-nowrap text-xs text-kibako-secondary">
-                {formatDate(masterPrototype.createdAt, true)}
-              </span>
-            </RowCell>
-            <td className="px-4 py-2 align-middle">
-              <div className="flex items-center justify-end gap-2 h-full">
-                <RowIconButton
-                  ariaLabel="開く"
-                  title="開く"
-                  onClick={() =>
-                    onSelectPrototype(project.id, masterPrototype.id)
-                  }
-                >
-                  <FaFolderOpen className="h-4 w-4" />
-                </RowIconButton>
-                <RowIconButton
-                  ariaLabel="複製"
-                  title="複製"
-                  disabled={duplicatingId === project.id}
-                  onClick={async () => {
-                    setDuplicatingId(project.id);
-                    try {
-                      const result = await duplicateProject(project.id);
-                      const master = result.prototypes.find(
-                        (p) => p.type === 'MASTER'
-                      );
-                      if (master) {
-                        onSelectPrototype(result.project.id, master.id);
-                      } else {
-                        alert('MASTERプロトタイプが見つかりませんでした。');
+                    className="p-1 rounded hover:bg-kibako-accent/20 focus:outline-none focus:ring-2 focus:ring-kibako-accent/50"
+                  >
+                    {renderIcon(masterPrototype.id)}
+                  </button>
+                  <div className="min-w-0 flex-1 overflow-hidden">
+                    <PrototypeNameEditor
+                      prototypeId={masterPrototype.id}
+                      name={
+                        updatedNames[masterPrototype.id] ?? masterPrototype.name
                       }
-                    } catch (error) {
-                      console.error('Failed to duplicate project', error);
-                      alert('プロジェクトの複製に失敗しました。');
-                    } finally {
-                      setDuplicatingId(null);
-                    }
-                  }}
-                >
-                  <FaCopy className="h-4 w-4" />
-                </RowIconButton>
-                <RowIconLink
-                  href={`/projects/${project.id}/roles`}
-                  ariaLabel="権限設定"
-                  title="権限設定"
-                >
-                  <FaUsers className="h-4 w-4" />
-                </RowIconLink>
-                {projectAdminMap[project.id] ? (
-                  <RowIconLink
-                    href={`/projects/${project.id}/delete`}
-                    ariaLabel="削除"
-                    title="削除"
-                    variant="danger"
-                  >
-                    <FaTrash className="h-4 w-4" />
-                  </RowIconLink>
-                ) : (
+                      bleedX={false}
+                      onUpdated={(newName) =>
+                        setUpdatedNames((prev) => ({
+                          ...prev,
+                          [masterPrototype.id]: newName,
+                        }))
+                      }
+                      editable={projectAdminMap[project.id]}
+                      notEditableReason="管理者のみ名前を変更できます"
+                    />
+                  </div>
+                </div>
+              </RowCell>
+              <RowCell>
+                <span className="ml-auto text-right text-xs text-kibako-secondary">
+                  {partCount}
+                </span>
+              </RowCell>
+              <RowCell>
+                <span className="ml-auto text-right text-xs text-kibako-secondary">
+                  {roomCount}
+                </span>
+              </RowCell>
+              <RowCell>
+                <span className="text-xs text-kibako-secondary">
+                  {projectCreatorMap[project.id] || '不明'}
+                </span>
+              </RowCell>
+              <RowCell>
+                <span className="whitespace-nowrap text-xs text-kibako-secondary">
+                  {formatDate(masterPrototype.createdAt, true)}
+                </span>
+              </RowCell>
+              <td className="px-4 py-2 align-middle">
+                <div className="flex items-center justify-end gap-2 h-full">
                   <RowIconButton
-                    ariaLabel="削除"
-                    title="削除は管理者のみ可能です"
-                    variant="danger"
-                    disabled
+                    ariaLabel="開く"
+                    title="開く"
+                    onClick={() =>
+                      onSelectPrototype(project.id, masterPrototype.id)
+                    }
                   >
-                    <FaTrash className="h-4 w-4" />
+                    <FaFolderOpen className="h-4 w-4" />
                   </RowIconButton>
-                )}
-              </div>
-            </td>
-          </tr>
-        ))}
+                  <RowIconButton
+                    ariaLabel="複製"
+                    title="複製"
+                    disabled={duplicatingId === project.id}
+                    onClick={async () => {
+                      setDuplicatingId(project.id);
+                      try {
+                        const result = await duplicateProject(project.id);
+                        const master = result.prototypes.find(
+                          (p) => p.type === 'MASTER'
+                        );
+                        if (master) {
+                          onSelectPrototype(result.project.id, master.id);
+                        } else {
+                          alert('MASTERプロトタイプが見つかりませんでした。');
+                        }
+                      } catch (error) {
+                        console.error('Failed to duplicate project', error);
+                        alert('プロジェクトの複製に失敗しました。');
+                      } finally {
+                        setDuplicatingId(null);
+                      }
+                    }}
+                  >
+                    <FaCopy className="h-4 w-4" />
+                  </RowIconButton>
+                  <RowIconLink
+                    href={`/projects/${project.id}/roles`}
+                    ariaLabel="権限設定"
+                    title="権限設定"
+                  >
+                    <FaUsers className="h-4 w-4" />
+                  </RowIconLink>
+                  {projectAdminMap[project.id] ? (
+                    <RowIconLink
+                      href={`/projects/${project.id}/delete`}
+                      ariaLabel="削除"
+                      title="削除"
+                      variant="danger"
+                    >
+                      <FaTrash className="h-4 w-4" />
+                    </RowIconLink>
+                  ) : (
+                    <RowIconButton
+                      ariaLabel="削除"
+                      title="削除は管理者のみ可能です"
+                      variant="danger"
+                      disabled
+                    >
+                      <FaTrash className="h-4 w-4" />
+                    </RowIconButton>
+                  )}
+                </div>
+              </td>
+            </tr>
+          )
+        )}
       </tbody>
     </table>
   );


### PR DESCRIPTION
## Summary
- show project creator username on project list cards and table
- derive creator names from project roles

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c018541d64832696b64b4b44715c35

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Project creator names are now shown across cards, lists, and tables (fallback: 不明).
  * Inline project name editing is always available directly in the table.
  * Duplicate action provides clearer in-progress feedback and completion handling.
* **Style**
  * Table rows use an updated grid layout for improved readability.
  * Creator column displays human-readable names instead of IDs.
  * Delete action clearly indicates when it’s unavailable for non-admin users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->