### PR TITLE
fix: keep PrototypeNameEditor layout when not editable

### DIFF
--- a/frontend/src/features/prototype/components/atoms/PrototypeNameEditor.tsx
+++ b/frontend/src/features/prototype/components/atoms/PrototypeNameEditor.tsx
@@ -81,9 +81,9 @@ export default function PrototypeNameEditor({
     return (
       <div className={`w-full ${className ?? ''}`}>
         <span
-          className={`${sizeClass} ${weightClass} text-kibako-primary ${truncate ? 'truncate' : 'whitespace-normal break-words'} ${
+          className={`block w-full text-left ${sizeClass} ${weightClass} text-kibako-primary py-1.5 min-h-8 rounded-md ${
             bleedX ? 'px-2 -mx-2' : 'px-2'
-          }`}
+          } ${truncate ? 'truncate' : 'whitespace-normal break-words'}`}
           title={titleText}
           aria-label={titleText}
         >

--- a/frontend/src/features/prototype/components/atoms/__tests__/PrototypeNameEditor.test.tsx
+++ b/frontend/src/features/prototype/components/atoms/__tests__/PrototypeNameEditor.test.tsx
@@ -25,5 +25,12 @@ describe('PrototypeNameEditor', () => {
       'title',
       'test project - 管理者のみ名前を変更できます'
     );
+    expect(nameDisplay).toHaveClass(
+      'block',
+      'w-full',
+      'py-1.5',
+      'min-h-8',
+      'truncate'
+    );
   });
 });


### PR DESCRIPTION
## Summary
- ensure PrototypeNameEditor maintains width, height and truncation when read-only
- test for consistent layout when editing is disabled

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c03fb2806c83269f8196ddae04edb0