### PR TITLE
Restrict part editing for viewers

### DIFF
--- a/frontend/src/features/prototype/components/molecules/PartOnGameBoard.tsx
+++ b/frontend/src/features/prototype/components/molecules/PartOnGameBoard.tsx
@@ -75,6 +75,7 @@ interface PartOnGameBoardProps {
     user: { id: string; username: string };
     roles: Array<{ name: string; description: string }>;
   }>;
+  canEdit: boolean;
 }
 
 /** ゲーム盤上のパーツ描画コンポーネント */
@@ -93,6 +94,7 @@ export default function PartOnGameBoard({
   selectedBy = [],
   selfUser,
   userRoles = [],
+  canEdit,
 }: PartOnGameBoardProps): React.ReactElement {
   const groupRef = useRef<Konva.Group>(null);
   const { isReversing, setIsReversing, reverseCard } = useCard(part);
@@ -127,7 +129,7 @@ export default function PartOnGameBoard({
   // 他ユーザーによるロック（自分が選択していないのに他人が選択中）
   const isLockedByOthers = selectedBy.length > 0 && !isActive;
   // ロック中は移動禁止
-  const isDraggable = !isLockedByOthers;
+  const isDraggable = !isLockedByOthers && canEdit;
 
   // カーソル制御hooks
   const {

--- a/frontend/src/features/prototype/components/organisms/GameBoardCanvas.tsx
+++ b/frontend/src/features/prototype/components/organisms/GameBoardCanvas.tsx
@@ -83,6 +83,7 @@ interface GameBoardCanvasProps {
     e: Konva.KonvaEventObject<PointerEvent>,
     partId: number
   ) => void;
+  canEdit: boolean;
   rectForSelection: {
     x: number;
     y: number;
@@ -127,6 +128,7 @@ export default function GameBoardCanvas({
   handlePartDragMove,
   handlePartDragEnd,
   handlePartContextMenu,
+  canEdit,
   rectForSelection,
 }: GameBoardCanvasProps): React.ReactElement {
   const sortedParts = useMemo(() => {
@@ -240,6 +242,7 @@ export default function GameBoardCanvas({
                 onDragMove={(e) => handlePartDragMove(e, part.id)}
                 onDragEnd={(e) => handlePartDragEnd(e, part.id)}
                 onContextMenu={(e) => handlePartContextMenu(e, part.id)}
+                canEdit={canEdit}
               />
             );
           })}

--- a/frontend/src/features/prototype/hooks/usePartDragSystem.ts
+++ b/frontend/src/features/prototype/hooks/usePartDragSystem.ts
@@ -22,6 +22,8 @@ interface UsePartDragSystemProps {
   gameBoardMode: GameBoardMode;
   // ステージのref
   stageRef: React.RefObject<Konva.Stage>;
+  // 編集可能かどうか
+  canEdit: boolean;
 }
 
 /**
@@ -32,6 +34,7 @@ export const usePartDragSystem = ({
   canvasSize,
   gameBoardMode,
   stageRef,
+  canEdit,
 }: UsePartDragSystemProps) => {
   const { dispatch } = usePartReducer();
   const { measureOperation } = usePerformanceTracker();
@@ -79,6 +82,8 @@ export const usePartDragSystem = ({
         : [partId];
       selectMultipleParts(newSelected);
 
+      if (!canEdit) return;
+
       // プレイルーム時の単一選択カード/トークンのfrontmost処理
       // 複数選択時はfrontmost処理をスキップ
       if (gameBoardMode === GameBoardMode.PLAY && newSelected.length === 1) {
@@ -108,7 +113,14 @@ export const usePartDragSystem = ({
       });
       originalPositionsRef.current = newOriginalPositions;
     },
-    [gameBoardMode, selectedPartIds, selectMultipleParts, parts, dispatch]
+    [
+      gameBoardMode,
+      selectedPartIds,
+      selectMultipleParts,
+      parts,
+      dispatch,
+      canEdit,
+    ]
   );
 
   /**
@@ -116,6 +128,8 @@ export const usePartDragSystem = ({
    */
   const handlePartDragMove = useCallback(
     (e: Konva.KonvaEventObject<DragEvent>, partId: number) => {
+      if (!canEdit) return;
+
       const stage = stageRef.current;
 
       const originalPositions = originalPositionsRef.current;
@@ -191,7 +205,7 @@ export const usePartDragSystem = ({
       // 更新処理の実行
       stage.batchDraw();
     },
-    [getConstrainedPosition, parts, selectedPartIds, stageRef]
+    [getConstrainedPosition, parts, selectedPartIds, stageRef, canEdit]
   );
 
   /**
@@ -199,7 +213,7 @@ export const usePartDragSystem = ({
    */
   const handlePartDragEnd = useCallback(
     (e: Konva.KonvaEventObject<DragEvent>, partId: number) => {
-      if (gameBoardMode === GameBoardMode.PREVIEW) return;
+      if (gameBoardMode === GameBoardMode.PREVIEW || !canEdit) return;
 
       measureOperation('Part Drag Update', () => {
         const originalPositions = originalPositionsRef.current;
@@ -261,7 +275,14 @@ export const usePartDragSystem = ({
         originalPositionsRef.current = {};
       });
     },
-    [gameBoardMode, measureOperation, parts, getConstrainedPosition, dispatch]
+    [
+      gameBoardMode,
+      measureOperation,
+      parts,
+      getConstrainedPosition,
+      dispatch,
+      canEdit,
+    ]
   );
 
   return {


### PR DESCRIPTION
## Summary
- block part modification over Socket.IO without write permission
- hide part editing UI and dragging for viewer role

## Testing
- `npm --prefix backend run lint`
- `npm --prefix backend test`
- `npm --prefix frontend run lint`
- `npm --prefix frontend test`


------
https://chatgpt.com/codex/tasks/task_e_68c0590b77788326bd0b2755fd7272b4