### PR TITLE
feat: add sort dropdown to project list

### DIFF
--- a/frontend/src/components/atoms/SortDropdown.tsx
+++ b/frontend/src/components/atoms/SortDropdown.tsx
@@ -71,9 +71,13 @@ const sortOptions: SortOption[] = [
   },
 ];
 
+/** ソート条件選択用ドロップダウンのProps */
 interface SortDropdownProps {
+  /** 現在のソート対象キー */
   sortKey: SortKey;
+  /** 現在のソート順（昇順/降順） */
   sortOrder: SortOrder;
+  /** 選択変更時に呼ばれるコールバック */
   onChange: (key: SortKey, order: SortOrder) => void;
 }
 

--- a/frontend/src/components/atoms/SortDropdown.tsx
+++ b/frontend/src/components/atoms/SortDropdown.tsx
@@ -88,7 +88,7 @@ const SortDropdown: React.FC<SortDropdownProps> = ({
 }) => {
   const currentValue = `${sortKey}_${sortOrder}` as const;
 
-  const handleChange = (e: ChangeEvent<HTMLSelectElement>) => {
+  const handleChange = (e: ChangeEvent<HTMLSelectElement>): void => {
     const selected = sortOptions.find((o) => o.value === e.target.value);
     if (selected) {
       onChange(selected.key, selected.order);

--- a/frontend/src/components/atoms/SortDropdown.tsx
+++ b/frontend/src/components/atoms/SortDropdown.tsx
@@ -10,11 +10,20 @@ export type SortKey =
 // 並び順の型（昇順 or 降順）
 export type SortOrder = 'asc' | 'desc';
 
-/** ドロップダウンの選択肢定義（表示ラベルとキー/順の組） */
+/**
+ * ドロップダウンの選択肢定義（表示ラベルとキー/順の組）
+ * UI label ↔ internal mapping.
+ * Example / 例:
+ * { label: '作成日時(新しい順)', value: 'createdAt_desc', key: 'createdAt', order: 'desc' }
+ */
 export interface SortOption {
+  /** 表示用ラベル / Display label */
   label: string;
+  /** 内部値（<SortKey>_<SortOrder>）/ Internal value template */
   value: `${SortKey}_${SortOrder}`;
+  /** 並び替え対象キー / Sort field */
   key: SortKey;
+  /** 並び順 / Sort direction */
   order: SortOrder;
 }
 

--- a/frontend/src/components/atoms/SortDropdown.tsx
+++ b/frontend/src/components/atoms/SortDropdown.tsx
@@ -10,6 +10,7 @@ export type SortKey =
 // 並び順の型（昇順 or 降順）
 export type SortOrder = 'asc' | 'desc';
 
+/** ドロップダウンの選択肢定義（表示ラベルとキー/順の組） */
 export interface SortOption {
   label: string;
   value: `${SortKey}_${SortOrder}`;

--- a/frontend/src/components/atoms/SortDropdown.tsx
+++ b/frontend/src/components/atoms/SortDropdown.tsx
@@ -1,0 +1,106 @@
+import { ChangeEvent } from 'react';
+
+export type SortKey =
+  | 'name'
+  | 'createdAt'
+  | 'partCount'
+  | 'roomCount'
+  | 'creator';
+export type SortOrder = 'asc' | 'desc';
+
+export interface SortOption {
+  label: string;
+  value: `${SortKey}_${SortOrder}`;
+  key: SortKey;
+  order: SortOrder;
+}
+
+const sortOptions: SortOption[] = [
+  {
+    label: '作成日時(新しい順)',
+    value: 'createdAt_desc',
+    key: 'createdAt',
+    order: 'desc',
+  },
+  {
+    label: '作成日時(古い順)',
+    value: 'createdAt_asc',
+    key: 'createdAt',
+    order: 'asc',
+  },
+  { label: '名前(昇順)', value: 'name_asc', key: 'name', order: 'asc' },
+  { label: '名前(降順)', value: 'name_desc', key: 'name', order: 'desc' },
+  {
+    label: 'パーツ数(多い順)',
+    value: 'partCount_desc',
+    key: 'partCount',
+    order: 'desc',
+  },
+  {
+    label: 'パーツ数(少ない順)',
+    value: 'partCount_asc',
+    key: 'partCount',
+    order: 'asc',
+  },
+  {
+    label: 'ルーム数(多い順)',
+    value: 'roomCount_desc',
+    key: 'roomCount',
+    order: 'desc',
+  },
+  {
+    label: 'ルーム数(少ない順)',
+    value: 'roomCount_asc',
+    key: 'roomCount',
+    order: 'asc',
+  },
+  {
+    label: '作成者(昇順)',
+    value: 'creator_asc',
+    key: 'creator',
+    order: 'asc',
+  },
+  {
+    label: '作成者(降順)',
+    value: 'creator_desc',
+    key: 'creator',
+    order: 'desc',
+  },
+];
+
+interface SortDropdownProps {
+  sortKey: SortKey;
+  sortOrder: SortOrder;
+  onChange: (key: SortKey, order: SortOrder) => void;
+}
+
+const SortDropdown: React.FC<SortDropdownProps> = ({
+  sortKey,
+  sortOrder,
+  onChange,
+}) => {
+  const currentValue = `${sortKey}_${sortOrder}` as const;
+
+  const handleChange = (e: ChangeEvent<HTMLSelectElement>) => {
+    const selected = sortOptions.find((o) => o.value === e.target.value);
+    if (selected) {
+      onChange(selected.key, selected.order);
+    }
+  };
+
+  return (
+    <select
+      value={currentValue}
+      onChange={handleChange}
+      className="rounded border border-kibako-secondary/30 bg-white px-2 py-1 text-sm"
+    >
+      {sortOptions.map((option) => (
+        <option key={option.value} value={option.value}>
+          {option.label}
+        </option>
+      ))}
+    </select>
+  );
+};
+
+export default SortDropdown;

--- a/frontend/src/components/atoms/SortDropdown.tsx
+++ b/frontend/src/components/atoms/SortDropdown.tsx
@@ -89,17 +89,33 @@ const SortDropdown: React.FC<SortDropdownProps> = ({
   };
 
   return (
-    <select
-      value={currentValue}
-      onChange={handleChange}
-      className="rounded border border-kibako-secondary/30 bg-white px-2 py-1 text-sm"
-    >
-      {sortOptions.map((option) => (
-        <option key={option.value} value={option.value}>
-          {option.label}
-        </option>
-      ))}
-    </select>
+    <div className="relative inline-block">
+      <select
+        value={currentValue}
+        onChange={handleChange}
+        aria-label="並び替え"
+        className="appearance-none rounded-md border border-kibako-secondary/30 bg-kibako-white px-3 py-2 pr-9 text-sm text-kibako-primary shadow-sm hover:border-kibako-accent/60 focus:outline-none focus:ring-2 focus:ring-kibako-accent/40 focus:border-kibako-accent/70 transition-colors"
+      >
+        {sortOptions.map((option) => (
+          <option key={option.value} value={option.value}>
+            {option.label}
+          </option>
+        ))}
+      </select>
+      <svg
+        className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 h-4 w-4 text-kibako-secondary"
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 20 20"
+        fill="currentColor"
+        aria-hidden="true"
+      >
+        <path
+          fillRule="evenodd"
+          d="M5.23 7.21a.75.75 0 011.06.02L10 10.17l3.71-2.94a.75.75 0 11.94 1.16l-4.24 3.36a.75.75 0 01-.94 0L5.21 8.39a.75.75 0 01.02-1.18z"
+          clipRule="evenodd"
+        />
+      </svg>
+    </div>
   );
 };
 

--- a/frontend/src/components/atoms/SortDropdown.tsx
+++ b/frontend/src/components/atoms/SortDropdown.tsx
@@ -1,11 +1,13 @@
 import { ChangeEvent } from 'react';
 
+// 並び替え対象キーの型（UI/ソートロジックで共有）
 export type SortKey =
   | 'name'
   | 'createdAt'
   | 'partCount'
   | 'roomCount'
   | 'creator';
+// 並び順の型（昇順 or 降順）
 export type SortOrder = 'asc' | 'desc';
 
 export interface SortOption {

--- a/frontend/src/features/prototype/components/molecules/ProjectTable.tsx
+++ b/frontend/src/features/prototype/components/molecules/ProjectTable.tsx
@@ -1,13 +1,5 @@
 import React, { useState } from 'react';
-import {
-  FaFolderOpen,
-  FaSort,
-  FaSortDown,
-  FaSortUp,
-  FaTrash,
-  FaUsers,
-  FaCopy,
-} from 'react-icons/fa';
+import { FaFolderOpen, FaTrash, FaUsers, FaCopy } from 'react-icons/fa';
 
 import { useProject } from '@/api/hooks/useProject';
 import { Prototype, Project } from '@/api/types';
@@ -18,8 +10,6 @@ import RowIconLink from '@/features/prototype/components/atoms/RowIconLink';
 import { getProjectIcon } from '@/features/prototype/utils/getProjectIcon';
 import formatDate from '@/utils/dateFormat';
 
-export type ProjectTableSortKey = 'name' | 'createdAt';
-
 type ProjectTableProps = {
   prototypeList: {
     project: Project;
@@ -27,9 +17,6 @@ type ProjectTableProps = {
     partCount: number;
     roomCount: number;
   }[];
-  sortKey: ProjectTableSortKey;
-  sortOrder: 'asc' | 'desc';
-  onSort: (key: ProjectTableSortKey) => void;
   onSelectPrototype: (projectId: string, prototypeId: string) => void;
   projectAdminMap: Record<string, boolean>;
   projectCreatorMap: Record<string, string>;
@@ -37,9 +24,6 @@ type ProjectTableProps = {
 
 export const ProjectTable: React.FC<ProjectTableProps> = ({
   prototypeList,
-  sortKey,
-  sortOrder,
-  onSort,
   onSelectPrototype,
   projectAdminMap,
   projectCreatorMap,
@@ -56,47 +40,20 @@ export const ProjectTable: React.FC<ProjectTableProps> = ({
     return <Icon className="h-5 w-5 text-kibako-secondary" />;
   };
 
-  const renderSortIcon = (key: ProjectTableSortKey) => {
-    const base = 'inline align-middle text-sm';
-    if (sortKey !== key)
-      return <FaSort className={base + ' text-kibako-secondary'} />;
-    return sortOrder === 'asc' ? (
-      <FaSortUp className={base + ' text-kibako-accent'} />
-    ) : (
-      <FaSortDown className={base + ' text-kibako-accent'} />
-    );
-  };
-
   return (
     <table className="w-full table-auto text-left text-sm rounded-xl border border-kibako-secondary/30 overflow-hidden shadow-sm bg-kibako-white">
       <thead className="bg-kibako-primary text-kibako-white">
         <tr className="grid project-table-grid items-center">
           <th className="px-4 py-2">
-            <button
-              type="button"
-              onClick={() => onSort('name')}
-              className="inline-flex items-center gap-2 font-semibold"
-            >
-              <span className="inline-flex items-center gap-2">
-                <FaFolderOpen className="text-base" />
-                <span>プロジェクト名</span>
-              </span>
-              {renderSortIcon('name')}
-            </button>
+            <span className="inline-flex items-center gap-2 font-semibold">
+              <FaFolderOpen className="text-base" />
+              <span>プロジェクト名</span>
+            </span>
           </th>
           <th className="px-4 py-2">パーツ数</th>
           <th className="px-4 py-2">ルーム数</th>
           <th className="px-4 py-2">作成者</th>
-          <th className="px-4 py-2">
-            <button
-              type="button"
-              onClick={() => onSort('createdAt')}
-              className="inline-flex items-center gap-2 font-semibold"
-            >
-              <span>作成日時</span>
-              {renderSortIcon('createdAt')}
-            </button>
-          </th>
+          <th className="px-4 py-2">作成日時</th>
           <th className="px-4 py-2 text-left">操作</th>
         </tr>
       </thead>


### PR DESCRIPTION
## Summary
- expand SortDropdown with update, part count, room count, and creator options
- centralize project sorting in ProjectList with new key handling
- drop updated date sort option to avoid confusion

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c0b2db636c83268def5df130f4caca

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added a sort dropdown in the project list header to sort by name, created date, part count, room count, or creator, ascending or descending.
  - Sorting now applies consistently to both card and table views and supports creator-based ordering.

- Refactor
  - Centralized sorting logic within the project list; table headers no longer offer per-column sorting and are now static.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->