### PR TITLE
feat(frontend): add donation page

### DIFF
--- a/frontend/src/app/donate/page.tsx
+++ b/frontend/src/app/donate/page.tsx
@@ -1,0 +1,16 @@
+import { Metadata } from 'next';
+import React from 'react';
+
+import DonationTemplate from '@/features/donation/components/templates/DonationTemplate';
+
+export const metadata: Metadata = {
+  title: '寄付のお願い',
+  description:
+    'KIBAKO のさらなる開発を支援する寄付ページです。いただいた寄付は機能開発や運営費に充てられます。',
+};
+
+const DonatePage: React.FC = () => {
+  return <DonationTemplate />;
+};
+
+export default DonatePage;

--- a/frontend/src/app/donate/page.tsx
+++ b/frontend/src/app/donate/page.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 
 import DonationTemplate from '@/features/donation/components/templates/DonationTemplate';
 
+// ページのメタデータ（SEO用）
 export const metadata: Metadata = {
   title: '寄付のお願い',
   description:

--- a/frontend/src/app/donate/page.tsx
+++ b/frontend/src/app/donate/page.tsx
@@ -10,7 +10,11 @@ export const metadata: Metadata = {
     'KIBAKO のさらなる開発を支援する寄付ページです。いただいた寄付は機能開発や運営費に充てられます。',
 };
 
-const DonatePage: React.FC = () => {
+/**
+ * 寄付ページ（/donate）のApp Routerページコンポーネント。
+ * @returns ページ要素
+ */
+const DonatePage: React.FC = (): JSX.Element => {
   return <DonationTemplate />;
 };
 

--- a/frontend/src/app/donate/page.tsx
+++ b/frontend/src/app/donate/page.tsx
@@ -1,5 +1,5 @@
 import { Metadata } from 'next';
-import React from 'react';
+import React, { ReactElement } from 'react';
 
 import DonationTemplate from '@/features/donation/components/templates/DonationTemplate';
 
@@ -14,7 +14,7 @@ export const metadata: Metadata = {
  * 寄付ページ（/donate）のApp Routerページコンポーネント。
  * @returns ページ要素
  */
-const DonatePage: React.FC = (): JSX.Element => {
+const DonatePage: React.FC = (): ReactElement => {
   return <DonationTemplate />;
 };
 

--- a/frontend/src/components/molecules/UserMenu.tsx
+++ b/frontend/src/components/molecules/UserMenu.tsx
@@ -119,6 +119,12 @@ const UserMenu: React.FC<UserMenuProps> = ({ pathname }) => {
           >
             フィードバック
           </a>
+          <Link
+            href="/donate"
+            className="block w-full text-kibako-primary p-2 text-left hover:bg-kibako-secondary/10 transition-colors duration-200"
+          >
+            KIBAKOに寄付する
+          </Link>
           <button
             onClick={handleLogout}
             className="block w-full text-kibako-primary p-2 text-left hover:bg-kibako-secondary/10 transition-colors duration-200"

--- a/frontend/src/features/donation/components/templates/DonationTemplate.tsx
+++ b/frontend/src/features/donation/components/templates/DonationTemplate.tsx
@@ -1,4 +1,9 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
 import React from 'react';
+import { IoArrowBack } from 'react-icons/io5';
+
 import KibakoButton from '@/components/atoms/KibakoButton';
 
 /**
@@ -6,6 +11,8 @@ import KibakoButton from '@/components/atoms/KibakoButton';
  * @returns ページ要素
  */
 const DonationTemplate: React.FC = () => {
+  const router = useRouter();
+
   return (
     <main className="relative mx-auto max-w-3xl px-4 py-10">
       {/* Decorative background gradient */}
@@ -13,6 +20,17 @@ const DonationTemplate: React.FC = () => {
         aria-hidden
         className="pointer-events-none absolute inset-0 -z-10 bg-gradient-to-b from-kibako-primary/10 via-transparent to-kibako-accent/10"
       />
+
+      {/* Sticky header with back button */}
+      <div className="sticky top-20 z-sticky bg-transparent backdrop-blur-sm flex items-center gap-3 py-4 rounded-lg">
+        <button
+          onClick={() => router.back()}
+          className="p-2 hover:bg-kibako-tertiary rounded-full transition-colors"
+          title="前のページに戻る"
+        >
+          <IoArrowBack className="h-5 w-5 text-kibako-primary hover:text-kibako-primary transition-colors" />
+        </button>
+      </div>
 
       {/* Hero */}
       <section className="mb-6 text-center">
@@ -24,7 +42,8 @@ const DonationTemplate: React.FC = () => {
           KIBAKO を支援する
         </h1>
         <p className="mx-auto mt-3 max-w-2xl text-sm leading-7 text-gray-600">
-          KIBAKO はボードゲームのアイデアを試して直してまた遊ぶことができるオンライン
+          KIBAKO
+          はボードゲームのアイデアを試して直してまた遊ぶことができるオンライン
           サービスです。さらに発展させるため、日々機能の追加や改善に取り組んでいます。
         </p>
       </section>

--- a/frontend/src/features/donation/components/templates/DonationTemplate.tsx
+++ b/frontend/src/features/donation/components/templates/DonationTemplate.tsx
@@ -1,31 +1,76 @@
 import React from 'react';
+import KibakoButton from '@/components/atoms/KibakoButton';
 
 const DonationTemplate: React.FC = () => {
   return (
-    <main className="mx-auto max-w-2xl p-4 space-y-4">
-      <h1 className="text-2xl font-bold">KIBAKO を支援する</h1>
-      <p>
-        KIBAKO
-        はボードゲームのアイデアを試して直してまた遊ぶことができるオンラインサービス
-        です。さらに発展させるため、日々機能の追加や改善に取り組んでいます。
-      </p>
-      <p>
-        これからの開発を応援してくださる方は寄付をご検討ください。いただいたご支援は以下のような
-        用途に大切に使わせていただきます。
-      </p>
-      <ul className="list-inside list-disc space-y-1">
-        <li>新機能の開発や既存機能の改善</li>
-        <li>サーバーやドメインなどの運営費</li>
-        <li>外部 API やライブラリの利用料</li>
-      </ul>
-      <p>
-        現在、寄付受付の準備を進めています。準備が整い次第、このページから寄付を
-        行えるようになります。
-      </p>
-      <p>
-        ご支援いただけると大変励みになります。今後とも KIBAKO
-        をよろしくお願いいたします。
-      </p>
+    <main className="relative mx-auto max-w-3xl px-4 py-10">
+      {/* Decorative background gradient */}
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-0 -z-10 bg-gradient-to-b from-kibako-primary/10 via-transparent to-kibako-accent/10"
+      />
+
+      {/* Hero */}
+      <section className="mb-6 text-center">
+        <span className="inline-flex items-center gap-2 rounded-full border border-kibako-primary/20 bg-white/60 px-3 py-1 text-xs font-bold text-kibako-primary shadow-sm backdrop-blur">
+          <span className="h-1.5 w-1.5 rounded-full bg-kibako-accent" />
+          Support KIBAKO
+        </span>
+        <h1 className="mt-4 text-3xl font-extrabold tracking-tight text-gray-900">
+          KIBAKO を支援する
+        </h1>
+        <p className="mx-auto mt-3 max-w-2xl text-sm leading-7 text-gray-600">
+          KIBAKO はボードゲームのアイデアを試して直してまた遊ぶことができるオンライン
+          サービスです。さらに発展させるため、日々機能の追加や改善に取り組んでいます。
+        </p>
+      </section>
+
+      {/* Content card */}
+      <section className="rounded-2xl border border-black/5 bg-white/80 p-6 shadow-lg backdrop-blur">
+        <div className="grid gap-6">
+          <div>
+            <h2 className="text-lg font-bold text-gray-900">寄付の使い道</h2>
+            <p className="mt-2 text-sm text-gray-600">
+              いただいたご支援は以下の用途に大切に使わせていただきます。
+            </p>
+            <ul className="mt-3 space-y-2 text-sm text-gray-800">
+              <li className="flex items-start gap-3">
+                <span className="mt-0.5 text-base">🚀</span>
+                <span>新機能の開発や既存機能の改善</span>
+              </li>
+              <li className="flex items-start gap-3">
+                <span className="mt-0.5 text-base">🖥️</span>
+                <span>サーバーやドメインなどの運営費</span>
+              </li>
+              <li className="flex items-start gap-3">
+                <span className="mt-0.5 text-base">🔧</span>
+                <span>外部 API やライブラリの利用料</span>
+              </li>
+            </ul>
+          </div>
+
+          <div className="rounded-xl bg-kibako-primary/5 p-4 text-sm text-gray-700">
+            現在、寄付受付の準備を進めています。準備が整い次第、このページから寄付を
+            行えるようになります。
+          </div>
+
+          <div className="flex flex-col items-center justify-center gap-2 pt-2">
+            <KibakoButton
+              variant="accent"
+              size="lg"
+              disabled
+              className="w-full max-w-xs"
+            >
+              KIBAKOに寄付する
+            </KibakoButton>
+            <span className="text-xs text-gray-500">近日公開予定</span>
+          </div>
+        </div>
+
+        <p className="mt-6 text-center text-xs text-gray-500">
+          みなさまの応援が、より良い KIBAKO をつくる原動力になります。
+        </p>
+      </section>
     </main>
   );
 };

--- a/frontend/src/features/donation/components/templates/DonationTemplate.tsx
+++ b/frontend/src/features/donation/components/templates/DonationTemplate.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+
+const DonationTemplate: React.FC = () => {
+  return (
+    <main className="mx-auto max-w-2xl p-4 space-y-4">
+      <h1 className="text-2xl font-bold">KIBAKO を支援する</h1>
+      <p>
+        KIBAKO
+        はボードゲームのアイデアを試して直してまた遊ぶことができるオンラインサービス
+        です。さらに発展させるため、日々機能の追加や改善に取り組んでいます。
+      </p>
+      <p>
+        これからの開発を応援してくださる方は寄付をご検討ください。いただいたご支援は以下のような
+        用途に大切に使わせていただきます。
+      </p>
+      <ul className="list-inside list-disc space-y-1">
+        <li>新機能の開発や既存機能の改善</li>
+        <li>サーバーやドメインなどの運営費</li>
+        <li>外部 API やライブラリの利用料</li>
+      </ul>
+      <p>
+        現在、寄付受付の準備を進めています。準備が整い次第、このページから寄付を
+        行えるようになります。
+      </p>
+      <p>
+        ご支援いただけると大変励みになります。今後とも KIBAKO
+        をよろしくお願いいたします。
+      </p>
+    </main>
+  );
+};
+
+export default DonationTemplate;

--- a/frontend/src/features/donation/components/templates/DonationTemplate.tsx
+++ b/frontend/src/features/donation/components/templates/DonationTemplate.tsx
@@ -1,6 +1,10 @@
 import React from 'react';
 import KibakoButton from '@/components/atoms/KibakoButton';
 
+/**
+ * 寄付ページのテンプレート。KIBAKOへの支援内容と今後の案内を表示する静的コンポーネント。
+ * @returns ページ要素
+ */
 const DonationTemplate: React.FC = () => {
   return (
     <main className="relative mx-auto max-w-3xl px-4 py-10">


### PR DESCRIPTION
## Summary
- add placeholder donation page for future contributions
- refactor donation content into reusable template component
- tweak donation messaging to emphasize future KIBAKO development
- remove open-source wording to describe KIBAKO as an online board-game prototyping service
- add one-click "KIBAKOに寄付する" entry in user menu linking to the donate page
- remove explicit mention of Stripe from donation page copy

## Testing
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68c0ab549b7083268b3bd8a0b5a4a9fe

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a public Donate page in Japanese with localized SEO title and description explaining how to support KIBAKO.
  * Added a “KIBAKOに寄付する” link to the logged-in user menu for quick access to the donation page.
  * Added a donation info UI with back navigation, sections describing fund usage, a notice that donations are not yet accepted, and a disabled "KIBAKOに寄付する" button marked "近日公開予定."
<!-- end of auto-generated comment: release notes by coderabbit.ai -->