### PR TITLE
fix: show help panel only for beginners in master create

### DIFF
--- a/frontend/src/features/prototype/components/molecules/LeftSidebar.tsx
+++ b/frontend/src/features/prototype/components/molecules/LeftSidebar.tsx
@@ -76,6 +76,9 @@ export default function LeftSidebar({
   const masterPrototype: Prototype | undefined = prototypes.find(
     ({ type }) => type === 'MASTER'
   );
+  const currentPrototype: Prototype | undefined = prototypes.find(
+    ({ id }) => id === prototypeId
+  );
 
   /**
    * 戻るボタンの処理
@@ -353,7 +356,13 @@ export default function LeftSidebar({
       {!isLeftSidebarMinimized &&
         gameBoardMode !== GameBoardMode.PLAY &&
         renderSidebarContent()}
-      <GameBoardHelpPanel defaultExpanded={needTutorial} />
+      <GameBoardHelpPanel
+        defaultExpanded={
+          needTutorial &&
+          gameBoardMode === GameBoardMode.CREATE &&
+          currentPrototype?.type === 'MASTER'
+        }
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- show help panel to new users only when opening the master prototype in Create mode

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c0cdd4c6bc832688406ef0f25a281e