### PR TITLE
chore: disable CodeRabbit ESLint comments

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -22,11 +22,16 @@ reviews:
 
   # ツール設定
   tools:
+    # CIで検知されるエラーは重複してコメントしないようにESLintのみ無効化
     eslint:
-      enabled: true
+      enabled: false
     semgrep:
       enabled: true
     oxc:
       enabled: true
     yamllint:
       enabled: true
+
+  # レビュー全体への追加指示
+  instructions: |
+    CIで検知されるESLintエラーにはコメントせず、高レベルなフィードバックに集中してください。


### PR DESCRIPTION
## Summary
- re-enable non-ESLint tools in CodeRabbit config while keeping ESLint disabled
- add reviewer instruction to ignore ESLint issues already caught by CI

## Testing
- `npm run lint` (backend)
- `npm run lint` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68c0d23afe2883269b0c7e11fd174175