### PR TITLE
fix: type error handling for project duplication

### DIFF
--- a/frontend/src/api/endpoints/project.ts
+++ b/frontend/src/api/endpoints/project.ts
@@ -1,3 +1,5 @@
+import axios from 'axios';
+
 import axiosInstance from '../client';
 import {
   Prototype,
@@ -47,11 +49,19 @@ export const projectService = {
         `/api/projects/${projectId}/duplicate`
       );
       return response.data;
-    } catch (error: any) {
-      const status = error?.response?.status as number | undefined;
-      const msg = error?.response?.data?.message ?? error?.message ?? '';
+    } catch (error: unknown) {
+      let status: number | undefined;
+      let msg = '';
+      if (axios.isAxiosError<{ message?: string }, unknown>(error)) {
+        status = error.response?.status;
+        msg = error.response?.data?.message ?? error.message ?? '';
+      } else if (error instanceof Error) {
+        msg = error.message;
+      }
       const note = status ? ` (HTTP ${status})` : '';
-      throw new Error(`プロジェクトの複製に失敗しました${note}: ${String(msg)}`);
+      throw new Error(
+        `プロジェクトの複製に失敗しました${note}: ${String(msg)}`
+      );
     }
   },
   /**


### PR DESCRIPTION
## Summary
- replace `any` with typed error handling in project duplication endpoint

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c0d620d72c8326be0ac209cb217060