### PR TITLE
fix: replace history after project deletion

### DIFF
--- a/frontend/src/features/prototype/components/organisms/DeletePrototypeConfirmation.tsx
+++ b/frontend/src/features/prototype/components/organisms/DeletePrototypeConfirmation.tsx
@@ -103,7 +103,7 @@ const DeletePrototypeConfirmation = (): ReactElement => {
     try {
       setIsDeleting(true);
       await deleteProject(projectId);
-      router.push('/projects');
+      router.replace('/projects');
     } catch (err) {
       setError('プロトタイプの削除に失敗しました');
       console.error('Error deleting prototype:', err);


### PR DESCRIPTION
## Summary
- replace router push with replace after deleting a project to remove delete path from history

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c76a9d9234832696c2aacf9c428927

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved post-deletion navigation for prototypes. After deleting, you’re returned to the Projects page without adding an extra step in your browser history, preventing the back button from taking you to a now-deleted prototype. This streamlines the flow and avoids confusing navigation states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->