### PR TITLE
fix: place selection toggle beside zoom controls

### DIFF
--- a/frontend/src/features/prototype/components/atoms/SelectionModeToggleButton.tsx
+++ b/frontend/src/features/prototype/components/atoms/SelectionModeToggleButton.tsx
@@ -11,31 +11,29 @@ export default function SelectionModeToggleButton({
   onToggle,
 }: SelectionModeToggleButtonProps) {
   return (
-    <div className="absolute bottom-4 left-4 z-overlay flex flex-col gap-2">
-      <div className="relative group">
-        <button
-          className={`relative p-3 rounded-full shadow-md transition-all duration-300 ${
-            !isSelectionMode
-              ? 'bg-kibako-primary text-kibako-white ring-2 ring-kibako-accent ring-offset-2 shadow-lg'
-              : 'bg-gray-300 text-gray-500 hover:bg-gray-400'
+    <div className="relative group">
+      <button
+        className={`relative p-3 rounded-full shadow-md transition-all duration-300 ${
+          !isSelectionMode
+            ? 'bg-kibako-primary text-kibako-white ring-2 ring-kibako-accent ring-offset-2 shadow-lg'
+            : 'bg-gray-300 text-gray-500 hover:bg-gray-400'
+        }`}
+        onClick={onToggle}
+        aria-label={
+          isSelectionMode ? 'パンモードに切り替え' : '選択モードに切り替え'
+        }
+      >
+        <MdPanTool
+          className={`w-6 h-6 transition-transform duration-300 ${
+            !isSelectionMode ? 'scale-110' : 'scale-100'
           }`}
-          onClick={onToggle}
-          aria-label={
-            isSelectionMode ? 'パンモードに切り替え' : '選択モードに切り替え'
-          }
-        >
-          <MdPanTool
-            className={`w-6 h-6 transition-transform duration-300 ${
-              !isSelectionMode ? 'scale-110' : 'scale-100'
-            }`}
-          />
-        </button>
-        {/* ツールチップ */}
-        <div className="absolute left-0 bottom-full mb-1 bg-kibako-primary text-kibako-white text-[10px] px-1.5 py-0.5 rounded whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity duration-200 pointer-events-none z-tooltip">
-          {!isSelectionMode
-            ? 'ボードをドラッグ&ドロップで移動できるモードをオフにする'
-            : 'ボードをドラッグ&ドロップで移動できるモードをオンにする'}
-        </div>
+        />
+      </button>
+      {/* ツールチップ */}
+      <div className="absolute left-0 bottom-full mb-1 bg-kibako-primary text-kibako-white text-[10px] px-1.5 py-0.5 rounded whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity duration-200 pointer-events-none z-tooltip">
+        {!isSelectionMode
+          ? 'ボードをドラッグ&ドロップで移動できるモードをオフにする'
+          : 'ボードをドラッグ&ドロップで移動できるモードをオンにする'}
       </div>
     </div>
   );

--- a/frontend/src/features/prototype/components/molecules/ZoomToolbar.tsx
+++ b/frontend/src/features/prototype/components/molecules/ZoomToolbar.tsx
@@ -25,15 +25,13 @@ export default function ZoomToolbar({
   const zoomPercentage = Math.floor(zoomValue * 100);
 
   return (
-    <div className="fixed bottom-4 right-4 z-overlay flex items-center justify-center rounded-xl bg-kibako-white shadow-lg border border-kibako-secondary/20 p-2">
-      <div className="flex items-center justify-center gap-2">
-        <div className="flex items-center justify-center">
-          <ZoomOutButton onClick={zoomOut} disabled={!canZoomOut} />
-          <div className="mx-3 px-3 py-1 text-sm font-semibold text-kibako-primary bg-kibako-tertiary/20 rounded-lg min-w-[50px] text-center border border-kibako-secondary/20">
-            {`${zoomPercentage}`}%
-          </div>
-          <ZoomInButton onClick={zoomIn} disabled={!canZoomIn} />
+    <div className="flex items-center justify-center rounded-xl bg-kibako-white shadow-lg border border-kibako-secondary/20 p-2">
+      <div className="flex items-center justify-center">
+        <ZoomOutButton onClick={zoomOut} disabled={!canZoomOut} />
+        <div className="mx-3 px-3 py-1 text-sm font-semibold text-kibako-primary bg-kibako-tertiary/20 rounded-lg min-w-[50px] text-center border border-kibako-secondary/20">
+          {`${zoomPercentage}`}%
         </div>
+        <ZoomInButton onClick={zoomIn} disabled={!canZoomIn} />
       </div>
     </div>
   );

--- a/frontend/src/features/prototype/components/organisms/GameBoard.tsx
+++ b/frontend/src/features/prototype/components/organisms/GameBoard.tsx
@@ -573,12 +573,6 @@ export default function GameBoard({
     <DebugModeProvider>
       {/* Provide overlay messages for parts (e.g., shuffle text like deck) */}
       <PartOverlayMessageProvider>
-        {canEdit && (
-          <SelectionModeToggleButton
-            isSelectionMode={isSelectionMode}
-            onToggle={toggleMode}
-          />
-        )}
         <GameBoardCanvas
           stageRef={stageRef}
           viewportSize={viewportSize}
@@ -669,13 +663,21 @@ export default function GameBoard({
           />
         )}
 
-        <ZoomToolbar
-          zoomIn={handleZoomIn}
-          zoomOut={handleZoomOut}
-          canZoomIn={canZoomIn}
-          canZoomOut={canZoomOut}
-          zoomLevel={camera.scale}
-        />
+        <div className="fixed bottom-4 right-4 z-overlay flex items-center gap-4">
+          {canEdit && (
+            <SelectionModeToggleButton
+              isSelectionMode={isSelectionMode}
+              onToggle={toggleMode}
+            />
+          )}
+          <ZoomToolbar
+            zoomIn={handleZoomIn}
+            zoomOut={handleZoomOut}
+            canZoomIn={canZoomIn}
+            canZoomOut={canZoomOut}
+            zoomLevel={camera.scale}
+          />
+        </div>
 
         <DebugInfo
           camera={camera}


### PR DESCRIPTION
## Summary
- position SelectionModeToggleButton next to ZoomToolbar
- wrap zoom controls and selection toggle in bottom-right overlay

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c76e5fda9883269cbdf1739869662a