### PR TITLE
fix: lighten inactive KibakoToggle label

### DIFF
--- a/frontend/src/components/atoms/KibakoToggle.tsx
+++ b/frontend/src/components/atoms/KibakoToggle.tsx
@@ -65,7 +65,7 @@ export default function KibakoToggle({
           onClick={() => !disabled && onChange(false)}
           className={twMerge(
             'inline-flex items-center gap-1 rounded px-1 py-0.5 text-xs font-medium focus:outline-none',
-            checked ? 'text-kibako-primary/70' : 'text-kibako-primary',
+            checked ? 'text-kibako-primary/30' : 'text-kibako-primary',
             disabled
               ? 'cursor-not-allowed opacity-60'
               : 'cursor-pointer hover:opacity-80'
@@ -94,7 +94,7 @@ export default function KibakoToggle({
           onClick={() => !disabled && onChange(true)}
           className={twMerge(
             'inline-flex items-center gap-1 rounded px-1 py-0.5 text-xs font-medium focus:outline-none',
-            checked ? 'text-kibako-primary' : 'text-kibako-primary/70',
+            checked ? 'text-kibako-primary' : 'text-kibako-primary/30',
             disabled
               ? 'cursor-not-allowed opacity-60'
               : 'cursor-pointer hover:opacity-80'

--- a/frontend/src/components/atoms/__tests__/KibakoToggle.test.tsx
+++ b/frontend/src/components/atoms/__tests__/KibakoToggle.test.tsx
@@ -27,4 +27,38 @@ describe('KibakoToggle', () => {
     expect(handleChange).toHaveBeenCalledWith(true);
     expect(toggle).toHaveAttribute('aria-checked', 'true');
   });
+
+  it('renders inactive label with reduced opacity', () => {
+    const { rerender } = render(
+      <KibakoToggle
+        checked={false}
+        onChange={() => {}}
+        labelLeft="Left"
+        labelRight="Right"
+      />
+    );
+
+    expect(screen.getByRole('button', { name: 'Right' })).toHaveClass(
+      'text-kibako-primary/30'
+    );
+    expect(screen.getByRole('button', { name: 'Left' })).toHaveClass(
+      'text-kibako-primary'
+    );
+
+    rerender(
+      <KibakoToggle
+        checked
+        onChange={() => {}}
+        labelLeft="Left"
+        labelRight="Right"
+      />
+    );
+
+    expect(screen.getByRole('button', { name: 'Left' })).toHaveClass(
+      'text-kibako-primary/30'
+    );
+    expect(screen.getByRole('button', { name: 'Right' })).toHaveClass(
+      'text-kibako-primary'
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- make non-selected label of `KibakoToggle` more transparent
- test opacity behaviour for toggle labels

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c789001f648326b4242c9e388b5aa8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Adjusted toggle label text opacity to improve visual contrast between selected and unselected states.

* **Bug Fixes**
  * Corrected label opacity so inactive labels appear lighter while the active label retains the primary emphasis.

* **Tests**
  * Added unit tests to verify label opacity in both checked and unchecked states to ensure consistent UI behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->