### PR TITLE
fix: preserve selection mode preference until roles load

### DIFF
--- a/frontend/src/features/prototype/components/organisms/GameBoard.tsx
+++ b/frontend/src/features/prototype/components/organisms/GameBoard.tsx
@@ -204,9 +204,10 @@ export default function GameBoard({
     onClearSelection: clearSelection,
   });
 
-  // Viewerは常に選択モードを無効化
-  const rolesLoaded = userRoles.length > 0;
+  // ロール読み込み完了後、閲覧者（編集不可）の場合のみ選択モードを無効化
+  const rolesLoaded: boolean = userRoles !== undefined;
   useEffect(() => {
+    // ロールが揃ってから閲覧者であれば選択モードを解除
     if (rolesLoaded && !canEdit && isSelectionMode) {
       toggleMode();
     }

--- a/frontend/src/features/prototype/components/organisms/GameBoard.tsx
+++ b/frontend/src/features/prototype/components/organisms/GameBoard.tsx
@@ -205,11 +205,12 @@ export default function GameBoard({
   });
 
   // Viewerは常に選択モードを無効化
+  const rolesLoaded = userRoles.length > 0;
   useEffect(() => {
-    if (!canEdit && isSelectionMode) {
+    if (rolesLoaded && !canEdit && isSelectionMode) {
       toggleMode();
     }
-  }, [canEdit, isSelectionMode, toggleMode]);
+  }, [rolesLoaded, canEdit, isSelectionMode, toggleMode]);
   // ドラッグ機能
   const { handlePartDragStart, handlePartDragMove, handlePartDragEnd } =
     usePartDragSystem({

--- a/frontend/src/features/role/components/molecules/UserRoleTable.tsx
+++ b/frontend/src/features/role/components/molecules/UserRoleTable.tsx
@@ -46,7 +46,7 @@ const UserRoleTable: React.FC<UserRoleTableProps> = ({
 }) => {
   const { user: currentUser } = useUser();
   // ユーザー権限が未設定かつロード完了の場合の空状態
-  if (userRoles.length === 0 && !loading) {
+  if ((userRoles ?? []).length === 0 && !loading) {
     return (
       <div className="flex flex-col items-center justify-center py-12 text-kibako-secondary">
         <FaUserShield className="h-12 w-12 text-kibako-secondary/50 mb-4" />

--- a/frontend/src/features/role/components/molecules/UserRoleTable.tsx
+++ b/frontend/src/features/role/components/molecules/UserRoleTable.tsx
@@ -8,8 +8,8 @@ import { useUser } from '@/hooks/useUser';
 
 import UserRoleRow from './UserRoleRow';
 
-// Types moved to UserRoleRow.tsx
-
+// ユーザー権限テーブルのプロパティ型
+// userRoles は useRoleManagement から常に配列（初期値 []）で渡される契約のため非オプショナル
 interface UserRoleTableProps {
   userRoles: UserRole[];
   creator: User | null;
@@ -46,7 +46,7 @@ const UserRoleTable: React.FC<UserRoleTableProps> = ({
 }) => {
   const { user: currentUser } = useUser();
   // ユーザー権限が未設定かつロード完了の場合の空状態
-  if ((userRoles ?? []).length === 0 && !loading) {
+  if (userRoles.length === 0 && !loading) {
     return (
       <div className="flex flex-col items-center justify-center py-12 text-kibako-secondary">
         <FaUserShield className="h-12 w-12 text-kibako-secondary/50 mb-4" />

--- a/frontend/src/features/role/components/organisms/RoleManagement.tsx
+++ b/frontend/src/features/role/components/organisms/RoleManagement.tsx
@@ -105,8 +105,8 @@ const RoleManagement: React.FC = () => {
     setSearchTerm('');
   };
 
-  // ローディング中の表示
-  if (loading && userRoles.length === 0) {
+  // ローディング中の表示（userRoles の長さに依存せず）
+  if (loading) {
     return <Loading />;
   }
 


### PR DESCRIPTION
## Summary
- ensure selection mode preference isn't overridden before roles are loaded

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c7ff3e33308326a11a7938ce781c3e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents selection mode from turning off before role data finishes loading.
  * Ensures selection mode disables only after roles have loaded and the user lacks edit permission.
  * Always shows the loading indicator when loading is true to avoid stale UI during role fetches.

* **Documentation**
  * Clarified interface comments to state the role list is always provided as an array.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->