### PR TITLE
fix: update donation CTA wording

### DIFF
--- a/frontend/src/components/molecules/UserMenu.tsx
+++ b/frontend/src/components/molecules/UserMenu.tsx
@@ -123,7 +123,7 @@ const UserMenu: React.FC<UserMenuProps> = ({ pathname }) => {
             href="/donate"
             className="block w-full text-kibako-primary p-2 text-left hover:bg-kibako-secondary/10 transition-colors duration-200"
           >
-            KIBAKOに寄付する
+            KIBAKOに寄付
           </Link>
           <button
             onClick={handleLogout}

--- a/frontend/src/features/donation/components/templates/DonationTemplate.tsx
+++ b/frontend/src/features/donation/components/templates/DonationTemplate.tsx
@@ -84,7 +84,7 @@ const DonationTemplate: React.FC = () => {
               disabled
               className="w-full max-w-xs"
             >
-              KIBAKOに寄付する
+              KIBAKOに寄付
             </KibakoButton>
             <span className="text-xs text-gray-500">近日公開予定</span>
           </div>


### PR DESCRIPTION
## Summary
- replace the donation call-to-action label with "KIBAKOに寄付" in the user menu and donation template

## Testing
- not run (text-only change)


------
https://chatgpt.com/codex/tasks/task_e_68c88364017c83269b72b495c24dff48

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated donation call-to-action wording from “KIBAKOに寄付する” to “KIBAKOに寄付” in the user menu link for clearer, more concise labeling.
  * Aligned the donation button text on the donation page to “KIBAKOに寄付” for consistency with the user menu.
  * Visual copy change only; no functional behavior or interaction affected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->