### PR TITLE
refactor: bulk update part order rebalance

### DIFF
--- a/backend/src/socket/prototypeHandler.test.ts
+++ b/backend/src/socket/prototypeHandler.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
 const { bulkCreateMock } = vi.hoisted(() => ({
   bulkCreateMock: vi.fn(),
@@ -41,13 +41,77 @@ import {
 } from '../constants/socket';
 import { ORDER_MIN_EXCLUSIVE, ORDER_RANGE } from '../constants/prototype';
 
-class MockPart {
-  public id: number;
-  public dataValues: { id: number; order: number };
+type MockPartValues = {
+  id: number;
+  type: 'token' | 'card' | 'hand' | 'deck' | 'area';
+  prototypeId: string;
+  position: { x: number; y: number };
+  width: number;
+  height: number;
+  order: number;
+  frontSide: 'front' | 'back' | null;
+  ownerId: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+};
 
-  constructor(id: number, order: number) {
-    this.id = id;
-    this.dataValues = { id, order };
+class MockPart {
+  public dataValues: MockPartValues;
+
+  constructor(
+    id: number,
+    order: number,
+    overrides: Partial<MockPartValues> = {}
+  ) {
+    const defaultTimestamp = new Date('2025-09-16T00:00:00.000Z');
+    const createdAt = overrides.createdAt ?? defaultTimestamp;
+    const updatedAt = overrides.updatedAt ?? defaultTimestamp;
+
+    this.dataValues = {
+      id,
+      order,
+      type: overrides.type ?? 'token',
+      prototypeId: overrides.prototypeId ?? 'proto-rebalance',
+      position: overrides.position ?? { x: 0, y: 0 },
+      width: overrides.width ?? 100,
+      height: overrides.height ?? 100,
+      frontSide: overrides.frontSide ?? null,
+      ownerId: overrides.ownerId ?? null,
+      createdAt,
+      updatedAt,
+    };
+  }
+
+  get id(): number {
+    return this.dataValues.id;
+  }
+
+  get type(): MockPartValues['type'] {
+    return this.dataValues.type;
+  }
+
+  get prototypeId(): string {
+    return this.dataValues.prototypeId;
+  }
+
+  get position(): MockPartValues['position'] {
+    return this.dataValues.position;
+  }
+
+  get width(): number {
+    return this.dataValues.width;
+  }
+
+  get height(): number {
+    return this.dataValues.height;
+  }
+
+  get frontSide(): MockPartValues['frontSide'] {
+    return this.dataValues.frontSide;
+  }
+
+  get ownerId(): MockPartValues['ownerId'] {
+    return this.dataValues.ownerId;
   }
 
   get order(): number {
@@ -56,6 +120,24 @@ class MockPart {
 
   set order(value: number) {
     this.dataValues.order = value;
+  }
+
+  getDataValue<TKey extends keyof MockPartValues>(key: TKey) {
+    return this.dataValues[key];
+  }
+
+  setDataValue<TKey extends keyof MockPartValues>(
+    key: TKey,
+    value: MockPartValues[TKey]
+  ) {
+    this.dataValues[key] = value;
+  }
+
+  get(options?: { plain?: boolean }) {
+    if (options?.plain) {
+      return { ...this.dataValues };
+    }
+    return { ...this.dataValues };
   }
 }
 
@@ -68,7 +150,14 @@ describe('rebalanceOrders', () => {
     bulkCreateMock.mockReset();
   });
 
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it('updates orders in bulk and emits consistent socket payload', async () => {
+    vi.useFakeTimers();
+    const fixedNow = new Date('2025-09-16T08:30:00.000Z');
+    vi.setSystemTime(fixedNow);
     const prototypeId = 'proto-rebalance';
     const parts = [
       new MockPart(1, 0.1),
@@ -87,9 +176,10 @@ describe('rebalanceOrders', () => {
 
     expect(bulkCreateMock).toHaveBeenCalledTimes(1);
     const [records, options] = bulkCreateMock.mock.calls[0];
+    const expectedFields = Object.keys(records[0] as Record<string, unknown>);
     expect(options).toEqual({
-      fields: ['id', 'order'],
-      updateOnDuplicate: ['order'],
+      fields: expectedFields,
+      updateOnDuplicate: ['order', 'updatedAt'],
     });
 
     const totalParts = parts.length;
@@ -98,9 +188,17 @@ describe('rebalanceOrders', () => {
       (_, index) => ORDER_MIN_EXCLUSIVE + step * (index + 1)
     );
 
-    records.forEach((record: { id: number; order: number }, index: number) => {
+    const typedRecords = records as MockPartValues[];
+    typedRecords.forEach((record, index) => {
       expect(record.id).toBe(parts[index].id);
       expect(record.order).toBeCloseTo(expectedOrders[index], 10);
+      expect(record.type).toBe(parts[index].type);
+      expect(record.prototypeId).toBe(parts[index].prototypeId);
+      expect(record.position).toEqual(parts[index].position);
+      expect(record.width).toBe(parts[index].width);
+      expect(record.height).toBe(parts[index].height);
+      expect(record.updatedAt).toEqual(fixedNow);
+      expect(record.createdAt).toEqual(parts[index].getDataValue('createdAt'));
     });
 
     expect(toMock).toHaveBeenCalledWith(prototypeId);
@@ -117,6 +215,7 @@ describe('rebalanceOrders', () => {
     parts.forEach((part, index) => {
       expect(part.order).toBeCloseTo(expectedOrders[index], 10);
       expect(part.dataValues.order).toBeCloseTo(expectedOrders[index], 10);
+      expect(part.getDataValue('updatedAt')).toEqual(fixedNow);
     });
   });
 });

--- a/backend/src/socket/prototypeHandler.ts
+++ b/backend/src/socket/prototypeHandler.ts
@@ -864,6 +864,8 @@ function handleSelectedParts(socket: Socket): void {
  * @param io - Server
  * @returns Promise<PartModel[]> - リバランス済みのパーツ配列を返すPromise
  */
+type PartAttributes = InstanceType<typeof PartModel>['dataValues'];
+
 export async function rebalanceOrders(
   prototypeId: string,
   parts: PartModel[],
@@ -875,20 +877,42 @@ export async function rebalanceOrders(
   // ORDER_RANGEを基に等間隔のステップを計算
   const step = ORDER_RANGE / (totalParts + 1);
 
+  const now = new Date();
+
   // partsの各要素のorderを直接更新
   const bulkUpdateRecords = parts.map((part, i) => {
     const newOrder = ORDER_MIN_EXCLUSIVE + step * (i + 1);
     part.order = newOrder;
-    return { id: part.id, order: newOrder };
+
+    // Partテーブルは多くのNOT NULL列を持つため、bulkCreate経由のUPSERTでは
+    // 既存レコードの全必須フィールドを渡さないとINSERT段階で制約違反になる。
+    // Model#get({ plain: true })で現在の属性を丸ごと取得しておけば、将来的に
+    // 列が追加されても同じ処理で対応でき、単一クエリのbulk update利点も維持できる。
+    const plainPart = part.get({ plain: true }) as PartAttributes;
+
+    return {
+      ...plainPart,
+      order: newOrder,
+      frontSide: plainPart.frontSide ?? null,
+      ownerId: plainPart.ownerId ?? null,
+      updatedAt: now,
+    } satisfies PartAttributes;
   });
 
-  await PartModel.bulkCreate(
-    bulkUpdateRecords as Array<{ id: number; order: number }>,
-    {
-      fields: ['id', 'order'],
-      updateOnDuplicate: ['order'],
-    }
-  );
+  const fields =
+    bulkUpdateRecords.length > 0
+      ? Object.keys(bulkUpdateRecords[0] as Record<string, unknown>)
+      : ['id', 'order', 'updatedAt'];
+
+  await PartModel.bulkCreate(bulkUpdateRecords, {
+    fields,
+    updateOnDuplicate: ['order', 'updatedAt'],
+  });
+
+  // in-memoryの更新日時も同期
+  parts.forEach((part) => {
+    part.setDataValue('updatedAt', now);
+  });
 
   io.to(prototypeId).emit(PROTOTYPE_SOCKET_EVENT.UPDATE_PARTS, {
     parts: parts.map((part) => part.dataValues),


### PR DESCRIPTION
## Summary
- batch update rebalanceOrders by replacing per-row updates with a single bulkCreate call that keeps the socket payload unchanged
- export rebalanceOrders for direct testing and cover it with a new spec that verifies bulk updates and emitted data

## Testing
- npm run test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c88c274c348326b1489bbe121d0385

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Improved part ordering to use a single bulk update for faster, more reliable reordering; end-user behavior unchanged but updates apply more consistently.

- Tests
  - Added extensive tests covering order recalculation, timestamp updates, and real-time update emissions to ensure correct display and synchronization.

- Chores
  - Exposed the rebalancing operation for testing and improved internal APIs to aid maintainability without altering user-facing features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->