### PR TITLE
Ensure prototype timestamps use JST

### DIFF
--- a/frontend/src/utils/__tests__/dateFormat.test.ts
+++ b/frontend/src/utils/__tests__/dateFormat.test.ts
@@ -10,6 +10,6 @@ describe('formatDate', () => {
 
   it('formats a Date object with time when withTime=true', () => {
     const result = formatDate(new Date('2021-01-01'), true);
-    expect(result).toBe('2021/01/01 00:00:00');
+    expect(result).toBe('2021/01/01 09:00:00');
   });
 });

--- a/frontend/src/utils/dateFormat.ts
+++ b/frontend/src/utils/dateFormat.ts
@@ -6,7 +6,7 @@
  *
  * @example
  * formatDate('2021-01-01') // '2021/01/01'
- * formatDate(new Date('2021-01-01'), true) // '2021/01/01 00:00:00'
+ * formatDate(new Date('2021-01-01'), true) // '2021/01/01 09:00:00'
  */
 export default function formatDate(
   date: string | Date | null | undefined,
@@ -25,12 +25,12 @@ export default function formatDate(
     return fallback;
   }
 
-  // Use UTC to ensure stable results regardless of execution environment's timezone.
+  // Format using JST so that results stay consistent regardless of the server runtime timezone.
   const options: Intl.DateTimeFormatOptions = {
     year: 'numeric',
     month: '2-digit',
     day: '2-digit',
-    timeZone: 'UTC',
+    timeZone: 'Asia/Tokyo',
     ...(withTime
       ? ({
           hour: '2-digit',


### PR DESCRIPTION
## Summary
- format the shared date formatter with the Asia/Tokyo timezone so generated version and instance names stay in JST
- update the accompanying unit test expectation to reflect the JST timestamp string

## Testing
- npm run test


------
https://chatgpt.com/codex/tasks/task_e_68c8a9d895b88326be672a497adc7d84

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Date and time formatting now uses Japan Standard Time (Asia/Tokyo). Times displayed with dates will reflect JST (e.g., midnight UTC now shows as 09:00:00).
- Documentation
  - Updated references to indicate JST-based formatting.
- Tests
  - Adjusted unit tests to match JST-formatted outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->