### PR TITLE
fix: configure neon pooler in production

### DIFF
--- a/backend/src/helpers/databaseUrl.test.ts
+++ b/backend/src/helpers/databaseUrl.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { withNeonTransactionPooler } from './databaseUrl';
+
+const neonHostUrl =
+  'postgres://user:pass@ep-sample-123.ap-northeast-1.aws.neon.tech/neondb';
+
+describe('withNeonTransactionPooler', () => {
+  it('adds poolerMode in production for Neon connections without existing params', () => {
+    const result = withNeonTransactionPooler(neonHostUrl, 'production');
+
+    expect(result).toBe(`${neonHostUrl}?poolerMode=transaction`);
+  });
+
+  it('appends poolerMode when other parameters are present', () => {
+    const url = `${neonHostUrl}?sslmode=require`;
+    const result = withNeonTransactionPooler(url, 'production');
+
+    expect(result).toBe(
+      `${neonHostUrl}?sslmode=require&poolerMode=transaction`
+    );
+  });
+
+  it('overwrites an existing poolerMode parameter', () => {
+    const url = `${neonHostUrl}?poolerMode=session&sslmode=require`;
+    const result = withNeonTransactionPooler(url, 'production');
+
+    expect(result).toBe(
+      `${neonHostUrl}?poolerMode=transaction&sslmode=require`
+    );
+  });
+
+  it('does not modify URLs in non-production environments', () => {
+    const result = withNeonTransactionPooler(neonHostUrl, 'development');
+
+    expect(result).toBe(neonHostUrl);
+  });
+
+  it('does not modify non-Neon hosts', () => {
+    const url = 'postgres://user:pass@localhost:5432/dbname';
+    const result = withNeonTransactionPooler(url, 'production');
+
+    expect(result).toBe(url);
+  });
+
+  it('returns the original string when the URL cannot be parsed', () => {
+    const url = 'not-a-valid-url';
+    const result = withNeonTransactionPooler(url, 'production');
+
+    expect(result).toBe(url);
+  });
+});

--- a/backend/src/helpers/databaseUrl.test.ts
+++ b/backend/src/helpers/databaseUrl.test.ts
@@ -42,6 +42,13 @@ describe('withNeonTransactionPooler', () => {
     expect(result).toBe(url);
   });
 
+  it('does not treat notneon.tech as a Neon host (dot-boundary check)', () => {
+    const url = 'postgres://user:pass@notneon.tech:5432/dbname';
+    const result = withNeonTransactionPooler(url, 'production');
+
+    expect(result).toBe(url);
+  });
+
   it('returns the original string when the URL cannot be parsed', () => {
     const url = 'not-a-valid-url';
     const result = withNeonTransactionPooler(url, 'production');

--- a/backend/src/helpers/databaseUrl.ts
+++ b/backend/src/helpers/databaseUrl.ts
@@ -1,9 +1,17 @@
+// 環境名を表す型（NODE_ENVの候補値）
 type NodeEnv = 'development' | 'test' | 'production';
 
+/**
+ * Neonの本番接続URLに poolerMode=transaction を付加するユーティリティ
+ * @param databaseUrl Neon/PostgreSQLの接続URL
+ * @param nodeEnv 現在のNODE_ENV
+ * @returns poolerModeを必要に応じて付与したURL
+ */
 export function withNeonTransactionPooler(
   databaseUrl: string,
   nodeEnv: NodeEnv
 ): string {
+  // 本番環境以外の場合
   if (nodeEnv !== 'production') {
     return databaseUrl;
   }
@@ -17,12 +25,14 @@ export function withNeonTransactionPooler(
     const isNeonHost =
       hostname === neonDomain || hostname.endsWith(`.${neonDomain}`);
 
+    // Neonホストでない場合
     if (!isNeonHost) {
       return databaseUrl;
     }
 
     const currentPoolerMode = parsedUrl.searchParams.get('poolerMode');
 
+    // 既にtransaction指定がある場合
     if (currentPoolerMode?.toLowerCase() === 'transaction') {
       return parsedUrl.toString();
     }

--- a/backend/src/helpers/databaseUrl.ts
+++ b/backend/src/helpers/databaseUrl.ts
@@ -1,0 +1,31 @@
+type NodeEnv = 'development' | 'test' | 'production';
+
+export function withNeonTransactionPooler(
+  databaseUrl: string,
+  nodeEnv: NodeEnv
+): string {
+  if (nodeEnv !== 'production') {
+    return databaseUrl;
+  }
+
+  try {
+    const parsedUrl = new URL(databaseUrl);
+    const hostname = parsedUrl.hostname.toLowerCase();
+
+    if (!hostname.endsWith('neon.tech')) {
+      return databaseUrl;
+    }
+
+    const currentPoolerMode = parsedUrl.searchParams.get('poolerMode');
+
+    if (currentPoolerMode?.toLowerCase() === 'transaction') {
+      return parsedUrl.toString();
+    }
+
+    parsedUrl.searchParams.set('poolerMode', 'transaction');
+
+    return parsedUrl.toString();
+  } catch {
+    return databaseUrl;
+  }
+}

--- a/backend/src/helpers/databaseUrl.ts
+++ b/backend/src/helpers/databaseUrl.ts
@@ -12,7 +12,12 @@ export function withNeonTransactionPooler(
     const parsedUrl = new URL(databaseUrl);
     const hostname = parsedUrl.hostname.toLowerCase();
 
-    if (!hostname.endsWith('neon.tech')) {
+    const neonDomain = 'neon.tech';
+
+    const isNeonHost =
+      hostname === neonDomain || hostname.endsWith(`.${neonDomain}`);
+
+    if (!isNeonHost) {
       return databaseUrl;
     }
 

--- a/backend/src/helpers/databaseUrl.ts
+++ b/backend/src/helpers/databaseUrl.ts
@@ -22,10 +22,9 @@ export function withNeonTransactionPooler(
 
     const neonDomain = 'neon.tech';
 
-    const isNeonHost =
-      hostname === neonDomain || hostname.endsWith(`.${neonDomain}`);
-
     // Neonホストでない場合
+    const isNeonHost: boolean =
+      hostname === neonDomain || hostname.endsWith(`.${neonDomain}`);
     if (!isNeonHost) {
       return databaseUrl;
     }

--- a/backend/src/models/index.ts
+++ b/backend/src/models/index.ts
@@ -6,8 +6,14 @@ import {
   DB_POOL_ACQUIRE,
   DB_POOL_IDLE,
 } from '../constants/database';
+import { withNeonTransactionPooler } from '../helpers/databaseUrl';
 
-const sequelize = new Sequelize(env.DATABASE_URL, {
+const connectionString = withNeonTransactionPooler(
+  env.DATABASE_URL,
+  env.NODE_ENV
+);
+
+const sequelize = new Sequelize(connectionString, {
   dialect: 'postgres',
   protocol: 'postgres',
   logging: false,


### PR DESCRIPTION
## Summary
- confirm that the development setup continues to rely on the local Postgres configuration without Neon-specific settings
- add a helper that appends `poolerMode=transaction` when a production Neon connection string is detected
- cover the helper with unit tests and use it when instantiating Sequelize

## Testing
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68c9263e8c088326a5ca29a91993bafe

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved production database connection handling to ensure transaction pooling is enabled for applicable hosted databases, with safe fallbacks and unchanged non-production behavior.

* **Tests**
  * Added comprehensive tests covering URL transformation across environments and host scenarios to ensure consistent behavior.

* **Chores**
  * Updated backend initialization to use the normalized connection string.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->