### PR TITLE
chore: replace help panel icon

### DIFF
--- a/frontend/src/features/prototype/components/molecules/GameBoardHelpPanel.tsx
+++ b/frontend/src/features/prototype/components/molecules/GameBoardHelpPanel.tsx
@@ -5,7 +5,7 @@
 'use client';
 
 import { useState, useEffect } from 'react';
-import { IoClose, IoInformationCircleOutline } from 'react-icons/io5';
+import { IoClose, IoHelpCircleOutline } from 'react-icons/io5';
 
 import { KEYBOARD_SHORTCUTS } from '@/features/prototype/constants';
 import {
@@ -61,7 +61,7 @@ export default function GameBoardHelpPanel({
           aria-label={isExpanded ? 'ヘルプを閉じる' : 'ヘルプを開く'}
           title={`操作ヘルプ (${KEYBOARD_SHORTCUTS.help.label})`}
         >
-          <IoInformationCircleOutline className="h-4 w-4 text-kibako-white" />
+          <IoHelpCircleOutline className="h-4 w-4 text-kibako-white" />
         </button>
 
         {isExpanded && (


### PR DESCRIPTION
## Summary
- replace the help panel trigger icon with the question-style Ionicon

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c9f8a242d08326af47ecba982c5eb3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the Game Board Help toggle button to use a standard help-circle icon for clearer affordance and visual consistency.
  * No functional changes; behavior, labels, and shortcuts remain the same.
  * Improves discoverability of the help panel for users.
  * Applies across the Game Board help panel wherever the toggle appears.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->