### PR TITLE
feat: skip redundant erd generation

### DIFF
--- a/backend/.api-types-metadata.json
+++ b/backend/.api-types-metadata.json
@@ -1,0 +1,11 @@
+{
+  "dependencies": ["backend/swagger-output.json"],
+  "outputs": [
+    "frontend/src/api/types/Api.ts",
+    "frontend/src/api/types/Auth.ts",
+    "frontend/src/api/types/User.ts",
+    "frontend/src/api/types/data-contracts.ts",
+    "frontend/src/api/types/http-client.ts",
+    "frontend/src/api/types/index.ts"
+  ]
+}

--- a/backend/.erd-metadata.json
+++ b/backend/.erd-metadata.json
@@ -1,0 +1,16 @@
+{
+  "dependencies": [
+    "src/database/associations.ts",
+    "src/models/Image.ts",
+    "src/models/Part.ts",
+    "src/models/PartProperty.ts",
+    "src/models/Permission.ts",
+    "src/models/Project.ts",
+    "src/models/Prototype.ts",
+    "src/models/Role.ts",
+    "src/models/RolePermission.ts",
+    "src/models/User.ts",
+    "src/models/UserRole.ts",
+    "src/models/index.ts"
+  ]
+}

--- a/backend/eslint.config.mjs
+++ b/backend/eslint.config.mjs
@@ -20,7 +20,7 @@ export default [
     rules: {
       'prettier/prettier': 'error',
       '@typescript-eslint/no-unused-vars': 'warn',
-      '@typescript-eslint/no-explicit-any': 'warn',
+      '@typescript-eslint/no-explicit-any': 'error',
     },
   },
   {

--- a/backend/package.json
+++ b/backend/package.json
@@ -22,7 +22,7 @@
     "redoc": "redocly build-docs swagger-output.json --output ../docs/index.html",
     "prepare": "cd ../ && git rev-parse --is-inside-work-tree >/dev/null 2>&1 && git config core.hooksPath .husky || true",
     "generate-swagger": "ts-node src/scripts/generateSwagger.ts",
-    "generate-api-types": "npx swagger-typescript-api generate -p ./swagger-output.json -o ../frontend/src/api/types --extract-request-params --extract-request-body --extract-response-body --modular --axios --disable-strict-ssl --disable-throw-on-error",
+    "generate-api-types": "ts-node src/scripts/generateApiTypes.ts",
     "clean-up-unused-images": "ts-node src/scripts/cleanUpUnusedImages.ts",
     "seed": "ts-node src/database/seed.ts",
     "seed:force": "ts-node src/database/seed.ts --force",

--- a/backend/src/middlewares/checkImageAccess.test.ts
+++ b/backend/src/middlewares/checkImageAccess.test.ts
@@ -3,7 +3,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { checkImageAccess } from './checkImageAccess';
 import ImageModel from '../models/Image';
 import PartPropertyModel from '../models/PartProperty';
-import { hasPermission } from '../helpers/roleHelper';
+import { getAccessibleResourceIds } from '../helpers/roleHelper';
 import { UnauthorizedError, ForbiddenError } from '../errors/CustomError';
 
 vi.mock('../models/Image', () => ({
@@ -13,7 +13,7 @@ vi.mock('../models/PartProperty', () => ({
   default: { findAll: vi.fn() },
 }));
 vi.mock('../helpers/roleHelper', () => ({
-  hasPermission: vi.fn(),
+  getAccessibleResourceIds: vi.fn(),
 }));
 
 const mockedFindByPk = ImageModel.findByPk as unknown as ReturnType<
@@ -22,14 +22,13 @@ const mockedFindByPk = ImageModel.findByPk as unknown as ReturnType<
 const mockedFindAll = PartPropertyModel.findAll as unknown as ReturnType<
   typeof vi.fn
 >;
-const mockedHasPermission = hasPermission as unknown as ReturnType<
-  typeof vi.fn
->;
+const mockedGetAccessibleResourceIds =
+  getAccessibleResourceIds as unknown as ReturnType<typeof vi.fn>;
 
 beforeEach(() => {
   mockedFindByPk.mockReset();
   mockedFindAll.mockReset();
-  mockedHasPermission.mockReset();
+  mockedGetAccessibleResourceIds.mockReset();
 });
 
 describe('checkImageAccess middleware', () => {
@@ -84,7 +83,7 @@ describe('checkImageAccess middleware', () => {
     mockedFindAll.mockResolvedValue([
       { part: { Prototype: { projectId: 'proj1' } } },
     ]);
-    mockedHasPermission.mockResolvedValue(true);
+    mockedGetAccessibleResourceIds.mockResolvedValue(['proj1']);
 
     await checkImageAccess(req, res, next);
 
@@ -109,7 +108,7 @@ describe('checkImageAccess middleware', () => {
     mockedFindAll.mockResolvedValue([
       { part: { Prototype: { projectId: 'proj1' } } },
     ]);
-    mockedHasPermission.mockResolvedValue(false);
+    mockedGetAccessibleResourceIds.mockResolvedValue([]);
 
     await checkImageAccess(req, res, next);
 

--- a/backend/src/routes/project.invite.test.ts
+++ b/backend/src/routes/project.invite.test.ts
@@ -1,7 +1,15 @@
 import express from 'express';
 import type { NextFunction, Request, Response } from 'express';
 import request from 'supertest';
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { Op } from 'sequelize';
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  vi,
+  type MockInstance,
+} from 'vitest';
 
 // Mock authentication to always attach a user
 type AuthenticatedRequest = Request & { user?: { id: string } };
@@ -43,11 +51,6 @@ vi.mock('../middlewares/permissions', () => ({
   checkProjectAdminRole: adminMiddleware,
 }));
 
-// Helper mock
-vi.mock('../helpers/roleHelper', () => ({
-  assignRole: vi.fn().mockResolvedValue(undefined),
-}));
-
 import RoleModel from '../models/Role';
 import UserModel from '../models/User';
 import ProjectModel from '../models/Project';
@@ -59,8 +62,47 @@ import projectRouter from './project';
 const app = express();
 app.use(express.json());
 app.use('/api/projects', projectRouter);
+type UserRoleQuery = {
+  attributes: string[];
+  where: {
+    resourceId: string;
+    resourceType: string;
+    roleId: number;
+    userId: Record<typeof Op.in, string[]>;
+  };
+};
+
+app.use(
+  (
+    err: unknown,
+    _req: express.Request,
+    res: express.Response,
+    _next: express.NextFunction
+  ) => {
+    const statusCode =
+      err &&
+      typeof err === 'object' &&
+      'statusCode' in err &&
+      typeof (err as { statusCode?: number }).statusCode === 'number'
+        ? (err as { statusCode: number }).statusCode
+        : err &&
+            typeof err === 'object' &&
+            'status' in err &&
+            typeof (err as { status?: number }).status === 'number'
+          ? (err as { status: number }).status
+          : 500;
+    const message =
+      err instanceof Error ? err.message : 'Internal Server Error';
+    res.status(statusCode).json({ message });
+    void _next;
+  }
+);
 
 describe('project member management routes', () => {
+  let userFindAllSpy: MockInstance<typeof UserModel.findAll>;
+  let userRoleFindAllSpy: MockInstance<typeof UserRoleModel.findAll>;
+  let userRoleBulkCreateSpy: MockInstance<typeof UserRoleModel.bulkCreate>;
+
   beforeEach(() => {
     vi.restoreAllMocks();
     adminMiddleware.mockImplementation(
@@ -70,9 +112,9 @@ describe('project member management routes', () => {
     );
     adminMiddleware.mockClear();
     vi.spyOn(RoleModel, 'findOne').mockResolvedValue(
-      RoleModel.build({ id: 1, name: 'editor', description: 'Editor role' })
+      RoleModel.build({ id: 2, name: 'editor', description: 'Editor role' })
     );
-    vi.spyOn(UserModel, 'findAll').mockResolvedValue([
+    userFindAllSpy = vi.spyOn(UserModel, 'findAll').mockResolvedValue([
       UserModel.build({
         id: 'guest1',
         googleId: 'guest1-google-id',
@@ -85,6 +127,12 @@ describe('project member management routes', () => {
         userId: 'owner1',
       })
     );
+    userRoleFindAllSpy = vi
+      .spyOn(UserRoleModel, 'findAll')
+      .mockResolvedValue([] as unknown as UserRoleModel[]);
+    userRoleBulkCreateSpy = vi
+      .spyOn(UserRoleModel, 'bulkCreate')
+      .mockResolvedValue([] as unknown as UserRoleModel[]);
     vi.spyOn(UserRoleModel, 'destroy').mockResolvedValue(1);
   });
 
@@ -93,6 +141,95 @@ describe('project member management routes', () => {
       .post('/api/projects/proj1/invite')
       .send({ guestIds: ['guest1'], roleType: 'editor' });
     expect(res.status).toBe(200);
+    const findAllArgs = userRoleFindAllSpy.mock.calls[0]?.[0] as
+      | UserRoleQuery
+      | undefined;
+    expect(findAllArgs).toBeDefined();
+    if (!findAllArgs) {
+      throw new Error('UserRoleModel.findAll was not called');
+    }
+    expect(findAllArgs.attributes).toEqual([
+      'userId',
+      'roleId',
+      'resourceType',
+      'resourceId',
+    ]);
+    expect(findAllArgs.where.resourceId).toBe('proj1');
+    expect(findAllArgs.where.resourceType).toBe('project');
+    expect(findAllArgs.where.roleId).toBe(2);
+    expect(findAllArgs.where.userId[Op.in]).toEqual(['guest1']);
+    expect(userRoleBulkCreateSpy).toHaveBeenCalledWith(
+      [
+        {
+          resourceId: 'proj1',
+          resourceType: 'project',
+          roleId: 2,
+          userId: 'guest1',
+        },
+      ],
+      { ignoreDuplicates: true }
+    );
+  });
+
+  it('skips existing assignments when inviting multiple members', async () => {
+    userFindAllSpy.mockResolvedValueOnce([
+      { id: 'guest1' },
+      { id: 'guest2' },
+    ] as unknown as UserModel[]);
+    userRoleFindAllSpy.mockResolvedValueOnce([
+      {
+        userId: 'guest1',
+        roleId: 2,
+        resourceType: 'project',
+        resourceId: 'proj1',
+      } as unknown as UserRoleModel,
+    ]);
+
+    const res = await request(app)
+      .post('/api/projects/proj1/invite')
+      .send({ guestIds: ['guest1', 'guest1', 'guest2'], roleType: 'editor' });
+
+    expect(res.status).toBe(200);
+    expect(userRoleBulkCreateSpy).toHaveBeenCalledWith(
+      [
+        {
+          resourceId: 'proj1',
+          resourceType: 'project',
+          roleId: 2,
+          userId: 'guest2',
+        },
+      ],
+      { ignoreDuplicates: true }
+    );
+  });
+
+  it('does not insert when all guests already have the role', async () => {
+    userRoleFindAllSpy.mockResolvedValueOnce([
+      {
+        userId: 'guest1',
+        roleId: 2,
+        resourceType: 'project',
+        resourceId: 'proj1',
+      } as unknown as UserRoleModel,
+    ]);
+
+    const res = await request(app)
+      .post('/api/projects/proj1/invite')
+      .send({ guestIds: ['guest1'], roleType: 'editor' });
+
+    expect(res.status).toBe(200);
+    expect(userRoleBulkCreateSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns 500 when bulk creation fails', async () => {
+    userRoleBulkCreateSpy.mockRejectedValueOnce(new Error('DB error'));
+
+    const res = await request(app)
+      .post('/api/projects/proj1/invite')
+      .send({ guestIds: ['guest1'], roleType: 'editor' });
+
+    expect(res.status).toBe(500);
+    expect(res.body).toEqual({ message: 'DB error' });
   });
 
   it('prevents non-admins from inviting members', async () => {

--- a/backend/src/routes/project.ts
+++ b/backend/src/routes/project.ts
@@ -603,46 +603,48 @@ router.post(
         new Set(guests.map((guest) => guest.id))
       );
 
-      const buildAssignmentKey = (assignment: {
-        userId: string;
-        roleId: number;
-        resourceType: string;
-        resourceId: string;
-      }) =>
-        `${assignment.userId}:${assignment.roleId}:${assignment.resourceType}:${assignment.resourceId}`;
-
       const existingAssignments = await UserRoleModel.findAll({
         attributes: ['userId', 'roleId', 'resourceType', 'resourceId'],
         where: {
           userId: { [Op.in]: uniqueGuestIds },
-          roleId: role.id,
           resourceType: RESOURCE_TYPES.PROJECT,
           resourceId: projectId,
         },
       });
 
-      const existingAssignmentKeys = new Set(
-        existingAssignments.map((assignment) =>
-          buildAssignmentKey({
-            userId: assignment.userId,
-            roleId: assignment.roleId,
-            resourceType: assignment.resourceType,
-            resourceId: assignment.resourceId,
-          })
+      const existingAssignmentsByUser = new Map(
+        existingAssignments.map((assignment) => [assignment.userId, assignment])
+      );
+
+      const userIdsToUpdate = Array.from(
+        new Set(
+          existingAssignments
+            .filter((assignment) => assignment.roleId !== role.id)
+            .map((assignment) => assignment.userId)
         )
       );
 
+      if (userIdsToUpdate.length > 0) {
+        await UserRoleModel.update(
+          { roleId: role.id },
+          {
+            where: {
+              userId: { [Op.in]: userIdsToUpdate },
+              resourceType: RESOURCE_TYPES.PROJECT,
+              resourceId: projectId,
+            },
+          }
+        );
+      }
+
       const assignmentsToCreate = uniqueGuestIds
+        .filter((guestId) => !existingAssignmentsByUser.has(guestId))
         .map((guestId) => ({
           userId: guestId,
           roleId: role.id,
           resourceType: RESOURCE_TYPES.PROJECT,
           resourceId: projectId,
-        }))
-        .filter(
-          (assignment) =>
-            !existingAssignmentKeys.has(buildAssignmentKey(assignment))
-        );
+        }));
 
       if (assignmentsToCreate.length > 0) {
         await UserRoleModel.bulkCreate(assignmentsToCreate, {

--- a/backend/src/routes/project.ts
+++ b/backend/src/routes/project.ts
@@ -612,9 +612,13 @@ router.post(
         },
       });
 
-      const existingAssignmentsByUser = new Map(
-        existingAssignments.map((assignment) => [assignment.userId, assignment])
-      );
+      const existingAssignmentsByUser = new Map<string, UserRoleModel[]>();
+      for (const assignment of existingAssignments) {
+        const assignmentsForUser =
+          existingAssignmentsByUser.get(assignment.userId) ?? [];
+        assignmentsForUser.push(assignment);
+        existingAssignmentsByUser.set(assignment.userId, assignmentsForUser);
+      }
 
       const userIdsToUpdate = Array.from(
         new Set(

--- a/backend/src/scripts/generateApiTypes.ts
+++ b/backend/src/scripts/generateApiTypes.ts
@@ -1,0 +1,297 @@
+import path from 'path';
+import {
+  Dirent,
+  existsSync,
+  readFileSync,
+  readdirSync,
+  statSync,
+  writeFileSync,
+} from 'fs';
+import { spawnSync, SpawnSyncReturns } from 'child_process';
+
+const backendDir: string = path.resolve(__dirname, '..', '..');
+const projectRootDir: string = path.resolve(backendDir, '..');
+const swaggerOutputPath: string = path.join(backendDir, 'swagger-output.json');
+const typesOutputDir: string = path.join(
+  projectRootDir,
+  'frontend',
+  'src',
+  'api',
+  'types'
+);
+const apiTypesMetadataPath: string = path.join(
+  backendDir,
+  '.api-types-metadata.json'
+);
+
+interface ApiTypesMetadata {
+  dependencies: string[];
+  outputs: string[];
+}
+
+/** 依存パスを正規化してソート */
+function normalizePaths(filePaths: string[]): string[] {
+  const normalizedPaths: string[] = filePaths
+    .map((filePath: string) => {
+      return path.relative(projectRootDir, filePath);
+    })
+    .sort();
+
+  return normalizedPaths;
+}
+
+/** 生成済み API 型メタデータを読み込み */
+function readApiTypesMetadata(): ApiTypesMetadata | null {
+  // メタデータが存在しない場合は再生成対象
+  if (!existsSync(apiTypesMetadataPath)) {
+    return null;
+  }
+
+  try {
+    const metadataRaw: string = readFileSync(apiTypesMetadataPath, 'utf-8');
+    const parsedMetadata: unknown = JSON.parse(metadataRaw);
+
+    // 期待する構造でない場合は再生成対象
+    if (
+      typeof parsedMetadata !== 'object' ||
+      parsedMetadata === null ||
+      !Array.isArray(
+        (parsedMetadata as { dependencies?: unknown }).dependencies
+      ) ||
+      !Array.isArray((parsedMetadata as { outputs?: unknown }).outputs)
+    ) {
+      return null;
+    }
+
+    const metadata: ApiTypesMetadata = parsedMetadata as ApiTypesMetadata;
+    return metadata;
+  } catch (error: unknown) {
+    console.warn(
+      'API型メタデータの読み込みに失敗しました。再生成を行います。',
+      error
+    );
+    return null;
+  }
+}
+
+/** API 型メタデータを保存 */
+function writeApiTypesMetadata(
+  dependencies: string[],
+  outputs: string[]
+): void {
+  const metadata: ApiTypesMetadata = {
+    dependencies,
+    outputs,
+  };
+
+  writeFileSync(apiTypesMetadataPath, JSON.stringify(metadata, null, 2));
+}
+
+/** ファイルリストの差異を検出 */
+function haveListsChanged(
+  currentList: string[],
+  previousList: string[]
+): boolean {
+  // 要素数が異なる場合は変更あり
+  if (currentList.length !== previousList.length) {
+    return true;
+  }
+
+  return currentList.some((value: string, index: number) => {
+    return value !== previousList[index];
+  });
+}
+
+/** 出力ディレクトリのファイル一覧を再帰的に収集 */
+function collectOutputFiles(directory: string, baseDir: string): string[] {
+  // 出力ディレクトリが存在しない場合は空配列
+  if (!existsSync(directory)) {
+    return [];
+  }
+
+  const entries: Dirent[] = readdirSync(directory, {
+    withFileTypes: true,
+  });
+  const files: string[] = entries.flatMap((entry: Dirent) => {
+    const entryPath: string = path.join(directory, entry.name);
+
+    // ディレクトリは再帰的に収集
+    if (entry.isDirectory()) {
+      return collectOutputFiles(entryPath, baseDir);
+    }
+
+    return [path.relative(baseDir, entryPath)];
+  });
+
+  files.sort();
+  return files;
+}
+
+/** API 型生成が必要か判定 */
+function shouldRegenerateApiTypes(): {
+  dependencies: string[];
+  outputs: string[];
+  shouldRegenerate: boolean;
+} {
+  const dependencyFiles: string[] = [swaggerOutputPath];
+  const normalizedDependencies: string[] = normalizePaths(dependencyFiles);
+  const outputFiles: string[] = collectOutputFiles(
+    typesOutputDir,
+    projectRootDir
+  );
+  const normalizedOutputs: string[] = [...outputFiles];
+
+  const metadata: ApiTypesMetadata | null = readApiTypesMetadata();
+
+  // メタデータが存在しない場合は再生成
+  if (metadata === null) {
+    return {
+      dependencies: normalizedDependencies,
+      outputs: normalizedOutputs,
+      shouldRegenerate: true,
+    };
+  }
+
+  // 依存ファイルが変化した場合は再生成
+  if (haveListsChanged(normalizedDependencies, metadata.dependencies)) {
+    return {
+      dependencies: normalizedDependencies,
+      outputs: normalizedOutputs,
+      shouldRegenerate: true,
+    };
+  }
+
+  // 期待する出力ファイルが変化した場合は再生成
+  if (haveListsChanged(normalizedOutputs, metadata.outputs)) {
+    return {
+      dependencies: normalizedDependencies,
+      outputs: normalizedOutputs,
+      shouldRegenerate: true,
+    };
+  }
+
+  const expectedOutputPaths: string[] = normalizedOutputs.map(
+    (relativePath: string) => {
+      return path.join(projectRootDir, relativePath);
+    }
+  );
+
+  // 出力ファイルが存在しない場合は再生成
+  const hasMissingOutputs: boolean = expectedOutputPaths.some(
+    (outputPath: string) => {
+      return !existsSync(outputPath);
+    }
+  );
+
+  // 出力が欠損している場合は再生成
+  if (hasMissingOutputs) {
+    return {
+      dependencies: normalizedDependencies,
+      outputs: normalizedOutputs,
+      shouldRegenerate: true,
+    };
+  }
+
+  const latestDependencyMTime: number = dependencyFiles.reduce(
+    (latest: number, filePath: string) => {
+      const dependencyStat: number = existsSync(filePath)
+        ? statSync(filePath).mtimeMs
+        : 0;
+      return Math.max(latest, dependencyStat);
+    },
+    0
+  );
+
+  const latestOutputMTime: number = expectedOutputPaths.reduce(
+    (latest: number, filePath: string) => {
+      const outputStat: number = statSync(filePath).mtimeMs;
+      return Math.max(latest, outputStat);
+    },
+    0
+  );
+
+  // 依存の更新が出力より新しい場合は再生成
+  if (latestDependencyMTime > latestOutputMTime) {
+    return {
+      dependencies: normalizedDependencies,
+      outputs: normalizedOutputs,
+      shouldRegenerate: true,
+    };
+  }
+
+  return {
+    dependencies: normalizedDependencies,
+    outputs: normalizedOutputs,
+    shouldRegenerate: false,
+  };
+}
+
+/** API 型を生成するメイン処理 */
+async function generateApiTypes(): Promise<void> {
+  const regenerationAssessment: {
+    dependencies: string[];
+    outputs: string[];
+    shouldRegenerate: boolean;
+  } = shouldRegenerateApiTypes();
+
+  // 型が最新の場合はスキップ
+  if (!regenerationAssessment.shouldRegenerate) {
+    console.log('API型は最新の状態です。再生成をスキップします。');
+    return;
+  }
+
+  const generatorArguments: string[] = [
+    'generate',
+    '-p',
+    swaggerOutputPath,
+    '-o',
+    typesOutputDir,
+    '--extract-request-params',
+    '--extract-request-body',
+    '--extract-response-body',
+    '--modular',
+    '--axios',
+    '--disable-strict-ssl',
+    '--disable-throw-on-error',
+  ];
+
+  const cliExecutablePath: string = path.join(
+    backendDir,
+    'node_modules',
+    '.bin',
+    process.platform === 'win32'
+      ? 'swagger-typescript-api.cmd'
+      : 'swagger-typescript-api'
+  );
+
+  const generatorResult: SpawnSyncReturns<Buffer> = spawnSync(
+    cliExecutablePath,
+    generatorArguments,
+    {
+      cwd: backendDir,
+      stdio: 'inherit',
+    }
+  );
+
+  // コマンド実行時にエラーが発生した場合はそのまま投げる
+  if (generatorResult.error !== undefined) {
+    throw generatorResult.error;
+  }
+
+  // 生成コマンドが失敗した場合はエラーを投げる
+  if (generatorResult.status !== 0) {
+    throw new Error('swagger-typescript-api の実行に失敗しました。');
+  }
+
+  const refreshedOutputs: string[] = collectOutputFiles(
+    typesOutputDir,
+    projectRootDir
+  );
+  writeApiTypesMetadata(regenerationAssessment.dependencies, refreshedOutputs);
+  console.log('API型が正常に生成されました！');
+}
+
+generateApiTypes().catch((error: unknown) => {
+  console.error('API型の生成中にエラーが発生しました。', error);
+  process.exit(1);
+});

--- a/backend/src/scripts/generateErd.ts
+++ b/backend/src/scripts/generateErd.ts
@@ -39,11 +39,15 @@ function shouldRegenerateErd(modelFileNames: string[]): boolean {
   return latestDependencyMTime > erdStat.mtimeMs;
 }
 
+/** ERD を生成するメイン処理 */
 async function generateErd(): Promise<void> {
-  const modelFileNames = readdirSync(modelsDir).filter((file) => {
-    return file.endsWith('.ts');
-  });
+  const modelFileNames: string[] = readdirSync(modelsDir).filter(
+    (file: string): boolean => {
+      return file.endsWith('.ts');
+    }
+  );
 
+  // ERD が最新の場合はスキップ
   if (!shouldRegenerateErd(modelFileNames)) {
     console.log('ERDは最新の状態です。再生成をスキップします。');
     return;

--- a/backend/src/socket/prototypeHandler.test.ts
+++ b/backend/src/socket/prototypeHandler.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
 const { bulkCreateMock } = vi.hoisted(() => ({
   bulkCreateMock: vi.fn(),
@@ -41,13 +41,77 @@ import {
 } from '../constants/socket';
 import { ORDER_MIN_EXCLUSIVE, ORDER_RANGE } from '../constants/prototype';
 
-class MockPart {
-  public id: number;
-  public dataValues: { id: number; order: number };
+type MockPartValues = {
+  id: number;
+  type: 'token' | 'card' | 'hand' | 'deck' | 'area';
+  prototypeId: string;
+  position: { x: number; y: number };
+  width: number;
+  height: number;
+  order: number;
+  frontSide: 'front' | 'back' | null;
+  ownerId: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+};
 
-  constructor(id: number, order: number) {
-    this.id = id;
-    this.dataValues = { id, order };
+class MockPart {
+  public dataValues: MockPartValues;
+
+  constructor(
+    id: number,
+    order: number,
+    overrides: Partial<MockPartValues> = {}
+  ) {
+    const defaultTimestamp = new Date('2025-09-16T00:00:00.000Z');
+    const createdAt = overrides.createdAt ?? defaultTimestamp;
+    const updatedAt = overrides.updatedAt ?? defaultTimestamp;
+
+    this.dataValues = {
+      id,
+      order,
+      type: overrides.type ?? 'token',
+      prototypeId: overrides.prototypeId ?? 'proto-rebalance',
+      position: overrides.position ?? { x: 0, y: 0 },
+      width: overrides.width ?? 100,
+      height: overrides.height ?? 100,
+      frontSide: overrides.frontSide ?? null,
+      ownerId: overrides.ownerId ?? null,
+      createdAt,
+      updatedAt,
+    };
+  }
+
+  get id(): number {
+    return this.dataValues.id;
+  }
+
+  get type(): MockPartValues['type'] {
+    return this.dataValues.type;
+  }
+
+  get prototypeId(): string {
+    return this.dataValues.prototypeId;
+  }
+
+  get position(): MockPartValues['position'] {
+    return this.dataValues.position;
+  }
+
+  get width(): number {
+    return this.dataValues.width;
+  }
+
+  get height(): number {
+    return this.dataValues.height;
+  }
+
+  get frontSide(): MockPartValues['frontSide'] {
+    return this.dataValues.frontSide;
+  }
+
+  get ownerId(): MockPartValues['ownerId'] {
+    return this.dataValues.ownerId;
   }
 
   get order(): number {
@@ -56,6 +120,24 @@ class MockPart {
 
   set order(value: number) {
     this.dataValues.order = value;
+  }
+
+  getDataValue<TKey extends keyof MockPartValues>(key: TKey) {
+    return this.dataValues[key];
+  }
+
+  setDataValue<TKey extends keyof MockPartValues>(
+    key: TKey,
+    value: MockPartValues[TKey]
+  ) {
+    this.dataValues[key] = value;
+  }
+
+  get(options?: { plain?: boolean }) {
+    if (options?.plain) {
+      return { ...this.dataValues };
+    }
+    return { ...this.dataValues };
   }
 }
 
@@ -68,7 +150,14 @@ describe('rebalanceOrders', () => {
     bulkCreateMock.mockReset();
   });
 
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it('updates orders in bulk and emits consistent socket payload', async () => {
+    vi.useFakeTimers();
+    const fixedNow = new Date('2025-09-16T08:30:00.000Z');
+    vi.setSystemTime(fixedNow);
     const prototypeId = 'proto-rebalance';
     const parts = [
       new MockPart(1, 0.1),
@@ -87,9 +176,10 @@ describe('rebalanceOrders', () => {
 
     expect(bulkCreateMock).toHaveBeenCalledTimes(1);
     const [records, options] = bulkCreateMock.mock.calls[0];
+    const expectedFields = Object.keys(records[0] as Record<string, unknown>);
     expect(options).toEqual({
-      fields: ['id', 'order'],
-      updateOnDuplicate: ['order'],
+      fields: expectedFields,
+      updateOnDuplicate: ['order', 'updatedAt'],
     });
 
     const totalParts = parts.length;
@@ -98,9 +188,17 @@ describe('rebalanceOrders', () => {
       (_, index) => ORDER_MIN_EXCLUSIVE + step * (index + 1)
     );
 
-    records.forEach((record: { id: number; order: number }, index: number) => {
+    const typedRecords = records as MockPartValues[];
+    typedRecords.forEach((record, index) => {
       expect(record.id).toBe(parts[index].id);
       expect(record.order).toBeCloseTo(expectedOrders[index], 10);
+      expect(record.type).toBe(parts[index].type);
+      expect(record.prototypeId).toBe(parts[index].prototypeId);
+      expect(record.position).toEqual(parts[index].position);
+      expect(record.width).toBe(parts[index].width);
+      expect(record.height).toBe(parts[index].height);
+      expect(record.updatedAt).toEqual(fixedNow);
+      expect(record.createdAt).toEqual(parts[index].getDataValue('createdAt'));
     });
 
     expect(toMock).toHaveBeenCalledWith(prototypeId);
@@ -117,6 +215,7 @@ describe('rebalanceOrders', () => {
     parts.forEach((part, index) => {
       expect(part.order).toBeCloseTo(expectedOrders[index], 10);
       expect(part.dataValues.order).toBeCloseTo(expectedOrders[index], 10);
+      expect(part.getDataValue('updatedAt')).toEqual(fixedNow);
     });
   });
 });

--- a/backend/src/socket/prototypeHandler.ts
+++ b/backend/src/socket/prototypeHandler.ts
@@ -864,6 +864,8 @@ function handleSelectedParts(socket: Socket): void {
  * @param io - Server
  * @returns Promise<PartModel[]> - リバランス済みのパーツ配列を返すPromise
  */
+type PartAttributes = InstanceType<typeof PartModel>['dataValues'];
+
 export async function rebalanceOrders(
   prototypeId: string,
   parts: PartModel[],
@@ -875,20 +877,42 @@ export async function rebalanceOrders(
   // ORDER_RANGEを基に等間隔のステップを計算
   const step = ORDER_RANGE / (totalParts + 1);
 
+  const now = new Date();
+
   // partsの各要素のorderを直接更新
   const bulkUpdateRecords = parts.map((part, i) => {
     const newOrder = ORDER_MIN_EXCLUSIVE + step * (i + 1);
     part.order = newOrder;
-    return { id: part.id, order: newOrder };
+
+    // Partテーブルは多くのNOT NULL列を持つため、bulkCreate経由のUPSERTでは
+    // 既存レコードの全必須フィールドを渡さないとINSERT段階で制約違反になる。
+    // Model#get({ plain: true })で現在の属性を丸ごと取得しておけば、将来的に
+    // 列が追加されても同じ処理で対応でき、単一クエリのbulk update利点も維持できる。
+    const plainPart = part.get({ plain: true }) as PartAttributes;
+
+    return {
+      ...plainPart,
+      order: newOrder,
+      frontSide: plainPart.frontSide ?? null,
+      ownerId: plainPart.ownerId ?? null,
+      updatedAt: now,
+    } satisfies PartAttributes;
   });
 
-  await PartModel.bulkCreate(
-    bulkUpdateRecords as Array<{ id: number; order: number }>,
-    {
-      fields: ['id', 'order'],
-      updateOnDuplicate: ['order'],
-    }
-  );
+  const fields =
+    bulkUpdateRecords.length > 0
+      ? Object.keys(bulkUpdateRecords[0] as Record<string, unknown>)
+      : ['id', 'order', 'updatedAt'];
+
+  await PartModel.bulkCreate(bulkUpdateRecords, {
+    fields,
+    updateOnDuplicate: ['order', 'updatedAt'],
+  });
+
+  // in-memoryの更新日時も同期
+  parts.forEach((part) => {
+    part.setDataValue('updatedAt', now);
+  });
 
   io.to(prototypeId).emit(PROTOTYPE_SOCKET_EVENT.UPDATE_PARTS, {
     parts: parts.map((part) => part.dataValues),

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -39,7 +39,7 @@ const config = [
       'react/react-in-jsx-scope': 'off',
       'react/prop-types': 'off',
       '@typescript-eslint/explicit-module-boundary-types': 'off',
-      '@typescript-eslint/no-explicit-any': 'warn',
+      '@typescript-eslint/no-explicit-any': 'error',
       '@typescript-eslint/no-unused-vars': [
         'warn',
         { argsIgnorePattern: '^_' },

--- a/frontend/src/features/prototype/components/molecules/GameBoardHelpPanel.tsx
+++ b/frontend/src/features/prototype/components/molecules/GameBoardHelpPanel.tsx
@@ -5,7 +5,7 @@
 'use client';
 
 import { useState, useEffect } from 'react';
-import { IoClose, IoInformationCircleOutline } from 'react-icons/io5';
+import { IoClose, IoHelpCircleOutline } from 'react-icons/io5';
 
 import { KEYBOARD_SHORTCUTS } from '@/features/prototype/constants';
 import {
@@ -61,7 +61,7 @@ export default function GameBoardHelpPanel({
           aria-label={isExpanded ? 'ヘルプを閉じる' : 'ヘルプを開く'}
           title={`操作ヘルプ (${KEYBOARD_SHORTCUTS.help.label})`}
         >
-          <IoInformationCircleOutline className="h-4 w-4 text-kibako-white" />
+          <IoHelpCircleOutline className="h-4 w-4 text-kibako-white" />
         </button>
 
         {isExpanded && (

--- a/frontend/src/features/prototype/components/molecules/PartPropertyMenuMulti.tsx
+++ b/frontend/src/features/prototype/components/molecules/PartPropertyMenuMulti.tsx
@@ -48,8 +48,6 @@ export default function PartPropertyMenuMulti({
     () => selectedParts.filter((p) => p.type === 'card'),
     [selectedParts]
   );
-  // カード関連アクションの表示はカードが含まれるときのみ
-  const showActionSection = cardParts.length > 0;
 
   const alignParts = useCallback(
     (type: AlignmentType): void => {
@@ -220,10 +218,24 @@ export default function PartPropertyMenuMulti({
       className="flex flex-col gap-2"
       style={{ display: hidden ? 'none' : 'flex' }}
     >
-      {showActionSection && (
-        <>
-          <p className="text-kibako-white">アクション</p>
-          <div className="grid grid-cols-1 gap-2">
+      <p className="text-kibako-white">アクション</p>
+      <div className="grid grid-cols-1 gap-2">
+        <PartPropertyMenuButton
+          text="横に広げる"
+          ariaLabel="横に広げる"
+          title="横方向に重ならないように広げる"
+          icon={<LuStretchVertical className="h-5 w-5" />}
+          onClick={handleSpreadHorizontal}
+        />
+        <PartPropertyMenuButton
+          text="縦に広げる"
+          ariaLabel="縦に広げる"
+          title="縦方向に重ならないように広げる"
+          icon={<LuStretchHorizontal className="h-5 w-5" />}
+          onClick={handleSpreadVertical}
+        />
+        {cardParts.length > 0 && (
+          <>
             <PartPropertyMenuButton
               text={cardSideTargetLabel}
               ariaLabel={cardSideTargetLabel}
@@ -238,9 +250,9 @@ export default function PartPropertyMenuMulti({
                 onClick={handleShuffleCards}
               />
             )}
-          </div>
-        </>
-      )}
+          </>
+        )}
+      </div>
       <p className="text-kibako-white">整列</p>
       <div className="grid grid-cols-4 gap-2">
         <PartPropertyMenuButton
@@ -304,20 +316,6 @@ export default function PartPropertyMenuMulti({
           title="垂直方向に等間隔に配置"
           icon={<LuAlignVerticalSpaceBetween className="h-5 w-5" />}
           onClick={handleDistributeVerticalEvenly}
-        />
-        <PartPropertyMenuButton
-          text=""
-          ariaLabel="横に展開する"
-          title="横方向に、重ならないように広げる"
-          icon={<LuStretchVertical className="h-5 w-5" />}
-          onClick={handleSpreadHorizontal}
-        />
-        <PartPropertyMenuButton
-          text=""
-          ariaLabel="縦に展開する"
-          title="縦方向に、重ならないように広げる"
-          icon={<LuStretchHorizontal className="h-5 w-5" />}
-          onClick={handleSpreadVertical}
         />
       </div>
     </div>

--- a/scripts/pre-commit-backend.sh
+++ b/scripts/pre-commit-backend.sh
@@ -16,6 +16,16 @@ if [ -f docs/index.html ]; then
   echo "✨ Added docs/index.html to staging"
 fi
 
+if [ -f backend/.erd-metadata.json ]; then
+  git add backend/.erd-metadata.json
+  echo "✨ Added backend/.erd-metadata.json to staging"
+fi
+
+if [ -f backend/.api-types-metadata.json ]; then
+  git add backend/.api-types-metadata.json
+  echo "✨ Added backend/.api-types-metadata.json to staging"
+fi
+
 for file in frontend/src/api/types/*; do
   if [ -f "$file" ]; then
     git add "$file"


### PR DESCRIPTION
## Summary
- add a pre-check in the ERD generation script to compare model and association timestamps with the current erd.svg
- skip ERD regeneration when the diagram is already up to date to avoid unnecessary work
- keep generation flow unchanged when regeneration is required and surface errors clearly

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c9f9ef9d5883269d1995e436d12a48

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Faster, deterministic ERD generation with skip-on-no-change and consistent erd.svg output.
  - Automatic API type generation driven by a metadata-aware script.
  - Prototype rebalancing exposed for bulk order updates with real-time socket emission.

- Bug Fixes / Improvements
  - Bulk operations for invites, part ordering, and updates to improve consistency and performance.
  - Image access checks switched to bulk permission lookup to reduce redundant checks.

- UX
  - Help icon updated and new spread actions available in the part property menu.

- Chores
  - Linting tightened and generated metadata included in pre-commit staging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->