### PR TITLE
Refactor part updates to use batched persistence

### DIFF
--- a/backend/src/scripts/metadata/swagger-schemas.json
+++ b/backend/src/scripts/metadata/swagger-schemas.json
@@ -13,5 +13,7 @@
     "backend/src/models/index.ts",
     "backend/src/scripts/generateSwagger.ts"
   ],
-  "outputs": ["backend/src/swagger-schemas.ts"]
+  "outputs": [
+    "backend/src/swagger-schemas.ts"
+  ]
 }

--- a/backend/swagger-output.json
+++ b/backend/swagger-output.json
@@ -15,7 +15,9 @@
             "description": "処理成功時のメッセージ"
           }
         },
-        "required": ["message"],
+        "required": [
+          "message"
+        ],
         "example": {
           "message": "正常に処理が完了しました"
         }
@@ -28,7 +30,9 @@
             "description": "エラーメッセージ"
           }
         },
-        "required": ["error"],
+        "required": [
+          "error"
+        ],
         "example": {
           "error": "リクエストが不正です"
         }
@@ -41,7 +45,9 @@
             "description": "エラーメッセージ"
           }
         },
-        "required": ["error"],
+        "required": [
+          "error"
+        ],
         "example": {
           "error": "認証が必要です"
         }
@@ -54,7 +60,9 @@
             "description": "エラーメッセージ"
           }
         },
-        "required": ["error"],
+        "required": [
+          "error"
+        ],
         "example": {
           "error": "リソースが見つかりません"
         }
@@ -67,7 +75,9 @@
             "description": "エラーメッセージ"
           }
         },
-        "required": ["error"],
+        "required": [
+          "error"
+        ],
         "example": {
           "error": "予期せぬエラーが発生しました"
         }
@@ -121,7 +131,13 @@
           },
           "type": {
             "type": "string",
-            "enum": ["token", "card", "hand", "deck", "area"]
+            "enum": [
+              "token",
+              "card",
+              "hand",
+              "deck",
+              "area"
+            ]
           },
           "prototypeId": {
             "type": "string",
@@ -144,7 +160,10 @@
             "oneOf": [
               {
                 "type": "string",
-                "enum": ["front", "back"]
+                "enum": [
+                  "front",
+                  "back"
+                ]
               },
               {
                 "type": "null"
@@ -189,7 +208,10 @@
           },
           "side": {
             "type": "string",
-            "enum": ["front", "back"]
+            "enum": [
+              "front",
+              "back"
+            ]
           },
           "name": {
             "type": "string"
@@ -291,7 +313,12 @@
             "type": "string"
           }
         },
-        "required": ["id", "userId", "createdAt", "updatedAt"]
+        "required": [
+          "id",
+          "userId",
+          "createdAt",
+          "updatedAt"
+        ]
       },
       "Prototype": {
         "type": "object",
@@ -309,7 +336,11 @@
           },
           "type": {
             "type": "string",
-            "enum": ["MASTER", "VERSION", "INSTANCE"]
+            "enum": [
+              "MASTER",
+              "VERSION",
+              "INSTANCE"
+            ]
           },
           "sourceVersionPrototypeId": {
             "oneOf": [
@@ -364,7 +395,12 @@
             "type": "string"
           }
         },
-        "required": ["id", "name", "createdAt", "updatedAt"]
+        "required": [
+          "id",
+          "name",
+          "createdAt",
+          "updatedAt"
+        ]
       },
       "RolePermission": {
         "type": "object",
@@ -376,7 +412,10 @@
             "type": "integer"
           }
         },
-        "required": ["roleId", "permissionId"]
+        "required": [
+          "roleId",
+          "permissionId"
+        ]
       },
       "User": {
         "type": "object",
@@ -395,7 +434,12 @@
             "type": "string"
           }
         },
-        "required": ["id", "username", "createdAt", "updatedAt"]
+        "required": [
+          "id",
+          "username",
+          "createdAt",
+          "updatedAt"
+        ]
       },
       "UserRole": {
         "type": "object",
@@ -438,7 +482,9 @@
   "paths": {
     "/api/users/search": {
       "get": {
-        "tags": ["Users"],
+        "tags": [
+          "Users"
+        ],
         "summary": "ユーザー検索",
         "description": "ユーザー名でユーザーを検索します。",
         "parameters": [
@@ -471,7 +517,9 @@
     },
     "/api/users/{userId}": {
       "put": {
-        "tags": ["Users"],
+        "tags": [
+          "Users"
+        ],
         "summary": "ユーザー情報更新",
         "description": "ユーザー名を更新します。",
         "parameters": [
@@ -491,7 +539,9 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["username"],
+                "required": [
+                  "username"
+                ],
                 "properties": {
                   "username": {
                     "type": "string",
@@ -530,7 +580,9 @@
     },
     "/api/users/{userId}/need-tutorial": {
       "get": {
-        "tags": ["Users"],
+        "tags": [
+          "Users"
+        ],
         "summary": "チュートリアル必要判定",
         "description": "指定されたユーザーがチュートリアルを表示すべきか判定します。",
         "parameters": [
@@ -571,7 +623,9 @@
     },
     "/api/prototypes/{prototypeId}": {
       "get": {
-        "tags": ["Prototypes"],
+        "tags": [
+          "Prototypes"
+        ],
         "summary": "特定のプロトタイプ取得",
         "description": "指定されたIDのプロトタイプを取得します。",
         "parameters": [
@@ -614,7 +668,9 @@
         }
       },
       "put": {
-        "tags": ["Prototypes"],
+        "tags": [
+          "Prototypes"
+        ],
         "summary": "プロトタイプ更新",
         "description": "指定されたIDのプロトタイプを更新します。",
         "parameters": [
@@ -673,7 +729,9 @@
         }
       },
       "delete": {
-        "tags": ["Prototypes"],
+        "tags": [
+          "Prototypes"
+        ],
         "summary": "プロトタイプ削除",
         "description": "指定されたIDのプロトタイプを削除します。",
         "parameters": [
@@ -713,7 +771,9 @@
     },
     "/api/projects": {
       "get": {
-        "tags": ["Projects"],
+        "tags": [
+          "Projects"
+        ],
         "summary": "プロジェクト一覧取得",
         "description": "ユーザーがアクセス可能なプロジェクトの一覧を取得します。",
         "responses": {
@@ -786,7 +846,9 @@
         }
       },
       "post": {
-        "tags": ["Projects"],
+        "tags": [
+          "Projects"
+        ],
         "summary": "プロジェクト作成",
         "description": "新しいプロジェクトを作成します。",
         "requestBody": {
@@ -840,7 +902,9 @@
     },
     "/api/projects/{projectId}/versions": {
       "post": {
-        "tags": ["Projects"],
+        "tags": [
+          "Projects"
+        ],
         "summary": "プロトタイプルーム作成",
         "description": "指定されたプロジェクトのプロトタイプルーム（VERSIONとINSTANCE）を作成します。",
         "parameters": [
@@ -866,7 +930,9 @@
                     "description": "プロトタイプ名"
                   }
                 },
-                "required": ["name"]
+                "required": [
+                  "name"
+                ]
               }
             }
           }
@@ -925,7 +991,9 @@
     },
     "/api/projects/{projectId}/versions/{prototypeId}": {
       "delete": {
-        "tags": ["Projects"],
+        "tags": [
+          "Projects"
+        ],
         "summary": "プロトタイプルーム削除",
         "description": "指定されたプロジェクトのプロトタイプルーム（VERSIONとINSTANCE）を削除します。",
         "parameters": [
@@ -984,7 +1052,9 @@
     },
     "/api/projects/{projectId}": {
       "get": {
-        "tags": ["Projects"],
+        "tags": [
+          "Projects"
+        ],
         "summary": "特定のプロジェクトの詳細とプロトタイプ一覧取得",
         "description": "指定されたIDのプロジェクトの詳細情報と、そのプロジェクトに属するプロトタイプの一覧を取得します。",
         "parameters": [
@@ -1037,7 +1107,9 @@
         }
       },
       "delete": {
-        "tags": ["Projects"],
+        "tags": [
+          "Projects"
+        ],
         "summary": "プロジェクト削除",
         "description": "指定されたIDのプロジェクトを削除します。",
         "parameters": [
@@ -1077,7 +1149,9 @@
     },
     "/api/projects/{projectId}/access-users": {
       "get": {
-        "tags": ["Projects"],
+        "tags": [
+          "Projects"
+        ],
         "summary": "プロジェクトへのアクセス権を取得",
         "description": "指定されたプロジェクトにアクセス可能なユーザーを取得します。",
         "parameters": [
@@ -1110,7 +1184,9 @@
     },
     "/api/projects/{projectId}/invite": {
       "post": {
-        "tags": ["Projects"],
+        "tags": [
+          "Projects"
+        ],
         "summary": "ユーザーにプロジェクトへのアクセス権を付与",
         "description": "指定されたプロジェクトにユーザーを招待します。Adminロール（またはMANAGE権限）を持つユーザーのみが利用できます。",
         "parameters": [
@@ -1140,7 +1216,11 @@
                   },
                   "roleType": {
                     "type": "string",
-                    "enum": ["admin", "editor", "viewer"],
+                    "enum": [
+                      "admin",
+                      "editor",
+                      "viewer"
+                    ],
                     "default": "editor",
                     "description": "付与するロールタイプ（Admin, Editor, Viewer）"
                   }
@@ -1195,7 +1275,9 @@
     },
     "/api/projects/{projectId}/invite/{guestId}": {
       "delete": {
-        "tags": ["Projects"],
+        "tags": [
+          "Projects"
+        ],
         "summary": "ユーザーのアクセス権を削除",
         "description": "指定されたプロジェクトからユーザーのアクセス権を削除します。Adminロール（またはMANAGE権限）を持つユーザーのみが利用できます。",
         "parameters": [
@@ -1264,7 +1346,9 @@
     },
     "/api/projects/{projectId}/duplicate": {
       "post": {
-        "tags": ["Projects"],
+        "tags": [
+          "Projects"
+        ],
         "summary": "プロジェクトの複製",
         "description": "指定されたプロジェクトを複製します。書き込みまたはAdmin権限が必要です。",
         "parameters": [
@@ -1314,7 +1398,9 @@
     },
     "/api/projects/{projectId}/members": {
       "get": {
-        "tags": ["Projects"],
+        "tags": [
+          "Projects"
+        ],
         "summary": "プロジェクトのメンバー一覧取得",
         "description": "プロジェクトのメンバーとそのロールを取得します。",
         "parameters": [
@@ -1366,7 +1452,9 @@
     },
     "/api/projects/{projectId}/roles": {
       "get": {
-        "tags": ["Projects"],
+        "tags": [
+          "Projects"
+        ],
         "summary": "プロジェクトのロール一覧取得",
         "description": "プロジェクトのユーザーロール一覧を取得します。",
         "parameters": [
@@ -1419,7 +1507,9 @@
         }
       },
       "post": {
-        "tags": ["Projects"],
+        "tags": [
+          "Projects"
+        ],
         "summary": "プロジェクトにロールを追加",
         "description": "ユーザーにプロジェクトのロールを割り当てます。",
         "parameters": [
@@ -1445,7 +1535,11 @@
                   },
                   "roleName": {
                     "type": "string",
-                    "enum": ["admin", "editor", "viewer"]
+                    "enum": [
+                      "admin",
+                      "editor",
+                      "viewer"
+                    ]
                   }
                 }
               }
@@ -1470,7 +1564,9 @@
     },
     "/api/projects/{projectId}/roles/{userId}": {
       "delete": {
-        "tags": ["Projects"],
+        "tags": [
+          "Projects"
+        ],
         "summary": "プロジェクトからロールを削除",
         "description": "ユーザーからプロジェクトのロールを削除します。",
         "parameters": [
@@ -1503,7 +1599,9 @@
         }
       },
       "put": {
-        "tags": ["Projects"],
+        "tags": [
+          "Projects"
+        ],
         "summary": "プロジェクトのロールを更新",
         "description": "ユーザーのプロジェクトロールを変更します。",
         "parameters": [
@@ -1535,7 +1633,11 @@
                 "properties": {
                   "roleName": {
                     "type": "string",
-                    "enum": ["admin", "editor", "viewer"]
+                    "enum": [
+                      "admin",
+                      "editor",
+                      "viewer"
+                    ]
                   }
                 }
               }
@@ -1557,7 +1659,9 @@
     },
     "/api/images": {
       "post": {
-        "tags": ["Images"],
+        "tags": [
+          "Images"
+        ],
         "summary": "画像アップロード",
         "description": "S3に画像をアップロードし、画像のメタデータを保存します。",
         "requestBody": {
@@ -1624,7 +1728,9 @@
     },
     "/api/images/{imageId}": {
       "get": {
-        "tags": ["Images"],
+        "tags": [
+          "Images"
+        ],
         "summary": "画像取得",
         "description": "S3から指定された画像を取得し、画像データを直接返します。",
         "parameters": [
@@ -1693,7 +1799,9 @@
         }
       },
       "delete": {
-        "tags": ["Images"],
+        "tags": [
+          "Images"
+        ],
         "summary": "画像削除",
         "description": "S3から指定された画像を削除します。",
         "parameters": [
@@ -1731,7 +1839,10 @@
             "description": "面（front または back）",
             "schema": {
               "type": "string",
-              "enum": ["front", "back"]
+              "enum": [
+                "front",
+                "back"
+              ]
             }
           },
           {
@@ -1741,7 +1852,10 @@
             "description": "更新をemitするかどうか（デフォルトはfalse）",
             "schema": {
               "type": "string",
-              "enum": [true, false],
+              "enum": [
+                true,
+                false
+              ],
               "default": false
             }
           }
@@ -1795,7 +1909,9 @@
     },
     "/auth/google": {
       "get": {
-        "tags": ["Auth"],
+        "tags": [
+          "Auth"
+        ],
         "summary": "Googleログイン",
         "description": "Googleアカウントを使用してログインします。",
         "responses": {
@@ -1816,7 +1932,9 @@
     },
     "/auth/google/callback": {
       "get": {
-        "tags": ["Auth"],
+        "tags": [
+          "Auth"
+        ],
         "summary": "Googleログインコールバック",
         "description": "GoogleログインのコールバックURL。",
         "responses": {
@@ -1837,7 +1955,9 @@
     },
     "/auth/logout": {
       "post": {
-        "tags": ["Auth"],
+        "tags": [
+          "Auth"
+        ],
         "summary": "ログアウト",
         "description": "現在のセッションを終了し、ユーザーをログアウトします。",
         "responses": {
@@ -1866,7 +1986,9 @@
     },
     "/auth/user": {
       "get": {
-        "tags": ["Auth"],
+        "tags": [
+          "Auth"
+        ],
         "summary": "ユーザー情報取得",
         "description": "現在ログインしているユーザーの情報を取得します。",
         "responses": {


### PR DESCRIPTION
## Summary
- reorganize the prototype socket part update handler to batch part and property persistence with grouped bulk operations and refreshed response payloads
- ensure single-part updates share the transactional batching approach for properties and prototype scoping
- expand socket handler tests to cover the new batched behaviour and permission mocks

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c88c37c21083268fe43bd9f726dd18

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Batched, transactional updates for parts and properties to reduce latency and improve consistency.
  * More robust error handling and clearer, accurate real-time update emissions after changes.

* **Tests**
  * Expanded coverage for bulk and single part updates with more granular mocks and shared setup/teardown for reliability.

* **Chores**
  * Reformatted a metadata schema file with no functional impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->