### PR TITLE
Fix selection mode preference reset in production build

### DIFF
--- a/frontend/src/features/prototype/components/organisms/GameBoard.tsx
+++ b/frontend/src/features/prototype/components/organisms/GameBoard.tsx
@@ -133,7 +133,7 @@ export default function GameBoard({
   // 手札の上のカードの表示制御
   const { cardVisibilityMap } = useHandVisibility(parts, gameBoardMode);
   // ロール管理情報を取得
-  const { userRoles } = useRoleManagement(projectId);
+  const { userRoles, rolesReady } = useRoleManagement(projectId);
   // ロールユーザー一覧（接続中→非接続の順で一意化）
   const roleUsers: ConnectedUser[] = useMemo(
     () => deriveRoleUsers(userRoles, connectedUsers),
@@ -192,6 +192,7 @@ export default function GameBoard({
     isSelectionInProgress,
     isJustFinishedSelection,
     consumeJustFinishedSelection,
+    setSelectionMode,
   } = useSelection({
     stageRef,
     parts,
@@ -205,13 +206,12 @@ export default function GameBoard({
   });
 
   // ロール読み込み完了後、閲覧者（編集不可）の場合のみ選択モードを無効化
-  const rolesLoaded: boolean = userRoles !== undefined;
   useEffect(() => {
-    // ロールが揃ってから閲覧者であれば選択モードを解除
-    if (rolesLoaded && !canEdit && isSelectionMode) {
-      toggleMode();
+    if (!rolesReady) return;
+    if (!canEdit && isSelectionMode) {
+      setSelectionMode(false, { persist: false });
     }
-  }, [rolesLoaded, canEdit, isSelectionMode, toggleMode]);
+  }, [rolesReady, canEdit, isSelectionMode, setSelectionMode]);
   // ドラッグ機能
   const { handlePartDragStart, handlePartDragMove, handlePartDragEnd } =
     usePartDragSystem({
@@ -453,7 +453,7 @@ export default function GameBoard({
       // 選択モードの場合のみ、一時的にパンモードに切り替え
       if (isSelectionMode) {
         setNeedToReturnToSelectionMode(true);
-        toggleMode();
+        setSelectionMode(false, { persist: false });
       }
     };
 
@@ -467,7 +467,7 @@ export default function GameBoard({
       // 元々選択モードだった場合、選択モードに復帰
       if (needToReturnToSelectionMode && !isSelectionMode) {
         setNeedToReturnToSelectionMode(false);
-        toggleMode();
+        setSelectionMode(true, { persist: false });
       }
     };
 
@@ -483,7 +483,7 @@ export default function GameBoard({
     spacePressing,
     isSelectionMode,
     needToReturnToSelectionMode,
-    toggleMode,
+    setSelectionMode,
   ]);
 
   useEffect(() => {

--- a/frontend/src/features/role/hooks/__tests__/useRoleManagement.test.ts
+++ b/frontend/src/features/role/hooks/__tests__/useRoleManagement.test.ts
@@ -51,9 +51,14 @@ describe('useRoleManagement', () => {
     const { result } = renderHook(() => useRoleManagement('project-1'));
 
     await waitFor(() => {
-      const check = result.current.canRemoveUserRole('current-user', userRoles);
-      expect(check.reason).not.toBe('ユーザー情報が取得できません');
+      expect(result.current.rolesReady).toBe(true);
     });
+
+    const readyCheck = result.current.canRemoveUserRole(
+      'current-user',
+      userRoles
+    );
+    expect(readyCheck.reason).not.toBe('ユーザー情報が取得できません');
 
     const check = result.current.canRemoveUserRole('current-user', userRoles);
     expect(check.canRemove).toBe(false);

--- a/frontend/src/features/role/hooks/useRoleManagement.ts
+++ b/frontend/src/features/role/hooks/useRoleManagement.ts
@@ -46,6 +46,7 @@ export const useRoleManagement = (projectId: string): UseRoleManagement => {
   );
   const [creator, setCreator] = useState<User | null>(null);
   const [loading, setLoading] = useState<boolean>(false);
+  const [rolesReady, setRolesReady] = useState<boolean>(false);
   const isCurrentUserAdmin = useMemo(() => {
     if (!currentUser) return false;
     const currentUserRole = userRoles.find(
@@ -108,6 +109,7 @@ export const useRoleManagement = (projectId: string): UseRoleManagement => {
       showToast('権限一覧の取得に失敗しました。', 'error');
     } finally {
       setLoading(false);
+      setRolesReady(true);
     }
   }, [getProjectRoles, projectId, showToast]);
 
@@ -337,6 +339,7 @@ export const useRoleManagement = (projectId: string): UseRoleManagement => {
     masterPrototypeName,
     creator,
     loading,
+    rolesReady,
 
     // 基本操作
     addRole,

--- a/frontend/src/features/role/types/index.ts
+++ b/frontend/src/features/role/types/index.ts
@@ -33,6 +33,7 @@ export interface UseRoleManagement {
   masterPrototypeName: string;
   creator: User | null;
   loading: boolean;
+  rolesReady: boolean;
   addRole: (userId: string, roleName: RoleValue) => Promise<void>;
   removeRole: (userId: string) => Promise<void>;
   updateRole: (userId: string, roleName: RoleValue) => Promise<void>;


### PR DESCRIPTION
## Summary
- hydrate the selection mode preference after mount and allow non-persistent toggles so SSR no longer overwrites the stored value
- make `GameBoard` respect a new `rolesReady` flag from `useRoleManagement` and avoid clobbering preferences when access is viewer-only
- expose `rolesReady` from `useRoleManagement` and update the related unit tests to cover the new contract

## Testing
- npm run test -- --run src/utils/__tests__/uiPreferences.test.ts src/features/role/hooks/__tests__/useRoleManagement.test.ts


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Selection mode now remembers your last preference across sessions (defaults to on).
  - Temporarily disable/restore selection mode (e.g., via Space) without changing the saved preference.
  - Selection toggle provides more precise on/off control.

- Bug Fixes
  - Prevents selection-mode changes until role data is ready, reducing flicker and inconsistent states.
  - Improves reliability of role-based actions once loading completes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->