### PR TITLE
feat: sort user roles by privilege

### DIFF
--- a/frontend/src/constants/roles.ts
+++ b/frontend/src/constants/roles.ts
@@ -22,6 +22,23 @@ export const ROLE_LABELS: Record<RoleType, string> = {
 };
 
 /**
+ * ロールごとの優先順位。数値が小さいほど権限が高い。
+ * creator と未知のロールの比較に使うため `UNKNOWN_ROLE_PRIORITY` を併用する。
+ */
+export const ROLE_PRIORITY = {
+  [ROLE_TYPE.ADMIN]: 0,
+  [ROLE_TYPE.EDITOR]: 1,
+  [ROLE_TYPE.VIEWER]: 2,
+} as const satisfies Record<RoleType, number>;
+
+/**
+ * 未知のロール名が渡された場合のフォールバック優先度。
+ * 既知ロールよりも低い権限として末尾に配置する。
+ */
+export const UNKNOWN_ROLE_PRIORITY =
+  (Math.max(...Object.values(ROLE_PRIORITY)) || 0) + 1;
+
+/**
  * 権限アクションの定義
  * バックエンドの `backend/src/const.ts` の `PERMISSION_ACTIONS` と同期
  */

--- a/frontend/src/features/role/components/molecules/UserRoleTable.tsx
+++ b/frontend/src/features/role/components/molecules/UserRoleTable.tsx
@@ -51,14 +51,18 @@ const UserRoleTable: React.FC<UserRoleTableProps> = ({
   const sortedUserRoles = React.useMemo(() => {
     const fallbackPriority = UNKNOWN_ROLE_PRIORITY;
 
+    const isKnownRoleName = (value: string): value is RoleValue =>
+      Object.prototype.hasOwnProperty.call(ROLE_PRIORITY, value);
+
     const getHighestPrivilege = (roles: UserRole['roles']) => {
       if (!roles || roles.length === 0) {
         return ROLE_PRIORITY.viewer;
       }
 
       return roles.reduce((currentHighest, role) => {
-        const rolePriority =
-          ROLE_PRIORITY[role.name as string] ?? fallbackPriority;
+        const rolePriority = isKnownRoleName(role.name)
+          ? ROLE_PRIORITY[role.name]
+          : fallbackPriority;
         return Math.min(currentHighest, rolePriority);
       }, fallbackPriority);
     };


### PR DESCRIPTION
## Summary
- expose role priority constants from the shared roles constants module for sorting
- derive a memoized UserRoleTable order that prioritizes creator, privilege, name, and id
- verify the ordering with a shuffled input test covering mixed roles and unknown values
- add a Japanese comment explaining the sortedUserRoles ordering criteria

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d2397dfef08326be3e1fe204e6cba9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added role-priority constants and fallback handling to ensure unknown roles rank below known roles.
  * User Role table now sorts consistently: creator first, then by privilege (admin > editor > viewer > unknown), then username (case-insensitive).

* **Tests**
  * Added tests verifying deterministic, stable sorting (including unknown roles) across varied inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->